### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,5 +1,8 @@
 name: Laravel
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/metanull/inventory-app/security/code-scanning/1](https://github.com/metanull/inventory-app/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the `contents: read` permission is sufficient, as the workflow only reads repository contents and does not perform any write operations.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `laravel-tests` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
