### PR TITLE
Feature/replace faker image by fakerphp picsum

### DIFF
--- a/app/Faker/LoremPicsumImageProvider.php
+++ b/app/Faker/LoremPicsumImageProvider.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Faker;
+
+use Faker\Provider\Base;
+use Illuminate\Support\Facades\Storage;
+use League\Flysystem\WhitespacePathNormalizer;
+
+/**
+ * Class LoremPicsumImageProvider
+ * Provides methods to generate and manipulate image URLs using the Lorem Picsum service.
+ * 
+ * The purpose of this class is to replace the functionality of the original FakerPhp's image 
+ * formatter, as it was deprecated (see: https://fakerphp.org/formatters/image).
+ *  
+ * It is intended to be used in Laravel applications where Faker is used for seeding databases with
+ * test data, particularly for generating image URLs and downloading images for testing purposes.
+ * 
+ * This class extends the Faker Base provider to add functionality for generating random image URLs
+ * and downloading images from Lorem Picsum. It supports generating images with specific dimensions,
+ * optional IDs, and seeds for randomization. It also provides methods to download images and store
+ * them on a specified storage disk, handling the necessary path normalization and error handling.
+ *
+ * Warm thanks to accreditly.io and in particular to the author of the following article:
+ * https://accreditly.io/articles/how-to-replace-laravels-faker-default-image-provider for the
+ * detailed explanations on how to replace the default Faker image provider.
+ * 
+ * Warm thanks to David Marby and Nijiko Yonskai, authors of Lorem Picsum for providing a free image
+ * service that allows us to generate random images.
+ *
+ * @see https://accreditly.io/articles/how-to-replace-laravels-faker-default-image-provider for the tutorial on replacing the default Faker image provider.
+ * @see https://picsum.photos/ for more information on the Picsum image service.
+ * @see https://fakerphp.org/formatters/image/ for the original implementation.
+ */
+class LoremPicsumImageProvider extends Base
+{
+    /**
+     * Generate a random image URL from Lorem Picsum.
+     * @param int $width Width of the image
+     * @param int $height Height of the image
+     * @param int|null $id Optional image ID to fetch a specific image
+     * @param string|null $seed Optional seed for random image generation
+     * @param array $options Additional query parameters to append to the URL. See https://picsum.photos/ for available options.
+     * @return string The generated image URL
+     */
+    public function imageUrl(int $width = 640, int $height = 480, ?int $id = null, ?string $seed = null, ?array $options = []): string
+    {
+        if( $id !== null) {
+            $url = "https://picsum.photos/id/{$id}/{$width}/{$height}.jpg";
+        } elseif ($seed !== null) {
+            $url = "https://picsum.photos/seed/{$seed}/{$width}/{$height}.jpg";
+        } else {
+            $url = "https://picsum.photos/{$width}/{$height}.jpg";
+        }
+        $queryParams = array_merge(['random' => rand()], $options);
+        if (!empty($queryParams)) {
+            $url .= '?' . http_build_query($queryParams);
+        }
+        return $url;
+    }
+
+    /**
+     * Download a remote image from Lorem Picsum and store it on the specified Storage disk.
+     * @param int $width Width of the image
+     * @param int $height Height of the image
+     * @param string $disk Storage disk to save the image
+     * @param string|null $directory Directory to save the image in
+     * @param int|null $id Optional image ID to fetch a specific image
+     * @param string|null $seed Optional seed for random image generation
+     * @param array $options Additional query parameters to append to the URL. See https://picsum.photos/ for available options.
+     * @return string The path where the image is stored (relative to the disk root)
+     * @throws \RuntimeException If the image download fails or the storage operation fails
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException If the paths cannot be resolved
+     */
+    public function image(int $width = 640, int $height = 480, string $disk = 'local', ?string $directory = null, ?int $id = null, ?string $seed = null, ?array $options = []): string
+    {
+        $url = $this->imageUrl($width, $height, $id, $seed, $options);
+        $imageContents = $this->getImageContent($url);
+        return $this->storeImageContent($imageContents, $disk, $directory);
+    }
+
+    /**
+     * Download a remote image and return its contents.
+     * 
+     * This method uses `file_get_contents` to fetch the image data.
+     * It will throw an exception if the download fails or if the image is empty.
+     * 
+     * @param string $url The URL of the image to download
+     * @return string The image contents
+     * @throws \RuntimeException If the image download fails or the contents are empty or allow_url_fopen is disabled.
+     */
+    protected function getImageContent(string $url): string
+    {
+        $imageContents = @file_get_contents($url);
+        if ($imageContents === false || empty($imageContents)) {
+            throw new \RuntimeException("Failed to download image from {$url}");
+        }
+        return $imageContents;
+    }
+
+    /**
+     * Store the image contents to the specified disk and directory.
+     * 
+     * This method normalizes the path and ensures the directory exists before saving.
+     * It will throw an exception if the storage operation fails.
+     * 
+     * @param string $imageContents The raw image data to store
+     * @param string $disk The storage disk to use (default: 'local')
+     * @param string|null $directory The directory to store the image in (optional)
+     * @param string|null $filename The name of the file to save (optional, generates a unique name if not provided)
+     * @return string The normalized relative path of the stored image
+     * @throws \RuntimeException If the storage operation fails
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException If the paths cannot be resolved
+     */
+    protected function storeImageContent(string $imageContents, string $disk = 'local', ?string $directory = null, ?string $filename = null): string {
+        $normalizer = new WhitespacePathNormalizer;
+        if ($filename === null) {
+            $filename = uniqid('picsum_', true) . '.jpg';
+        } else {
+            $filename = $normalizer->normalizePath($filename);
+        }
+        $storagePath = $filename;
+
+        if ($directory !== null) {
+            $directory = $normalizer->normalizePath($directory);
+
+            if (!Storage::disk($disk)->exists($directory)) {
+                Storage::disk($disk)->makeDirectory($directory);
+            }
+
+            $storagePath = "{$directory}/{$filename}";
+        }
+
+        if (false === Storage::disk($disk)->put($storagePath, $imageContents)) {
+            throw new \RuntimeException("Failed to save image to {$storagePath} on disk {$disk}");
+        }
+        return $this->normalizeRelativePath($disk, $storagePath);
+    }
+
+    /**
+     * Normalize the relative path of the stored image.
+     * 
+     * This method resolves the real paths of the base and storage paths,
+     * and normalizes the relative path to ensure it is clean and consistent.
+     * 
+     * @param string $disk The storage disk to use
+     * @param string $storage_path The storage path of the image
+     * @return string The normalized relative path
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException If the paths cannot be resolved
+     */
+    protected function normalizeRelativePath(string $disk, string $storage_path): string
+    {
+        $normalizer = new WhitespacePathNormalizer;
+        $real_base_path = realpath(Storage::disk($disk)->path(''));
+        $real_storage_path = realpath(Storage::disk($disk)->path($storage_path));
+
+        if ($real_base_path === false || $real_storage_path === false) {
+            throw new \Illuminate\Contracts\Filesystem\FileNotFoundException("Failed to resolve paths");
+        }
+
+        return $normalizer->normalizePath(substr($real_storage_path, strlen($real_base_path) + 1));
+    }
+}

--- a/app/Faker/LoremPicsumImageProvider.php
+++ b/app/Faker/LoremPicsumImageProvider.php
@@ -3,6 +3,7 @@
 namespace App\Faker;
 
 use Faker\Provider\Base;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use League\Flysystem\WhitespacePathNormalizer;
 
@@ -73,7 +74,7 @@ class LoremPicsumImageProvider extends Base
      * @param  array  $options  Additional query parameters to append to the URL. See https://picsum.photos/ for available options.
      * @return string The path where the image is stored (relative to the disk root)
      *
-     * @throws \RuntimeException If the image download fails or the storage operation fails
+     * @throws \Illuminate\Http\Client\RequestException If the HTTP request to fetch the image fails
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException If the paths cannot be resolved
      */
     public function image(int $width = 640, int $height = 480, string $disk = 'local', ?string $directory = null, ?int $id = null, ?string $seed = null, ?array $options = []): string
@@ -87,22 +88,17 @@ class LoremPicsumImageProvider extends Base
     /**
      * Download a remote image and return its contents.
      *
-     * This method uses `file_get_contents` to fetch the image data.
-     * It will throw an exception if the download fails or if the image is empty.
-     *
      * @param  string  $url  The URL of the image to download
      * @return string The image contents
      *
-     * @throws \RuntimeException If the image download fails or the contents are empty or allow_url_fopen is disabled.
+     * @throws \Illuminate\Http\Client\RequestException If the HTTP request fails
      */
     protected function getImageContent(string $url): string
     {
-        $imageContents = @file_get_contents($url);
-        if ($imageContents === false || empty($imageContents)) {
-            throw new \RuntimeException("Failed to download image from {$url}");
-        }
+        $response = Http::get($url);
+        $response->throw();
 
-        return $imageContents;
+        return $response->body();
     }
 
     /**

--- a/app/Faker/LoremPicsumImageProvider.php
+++ b/app/Faker/LoremPicsumImageProvider.php
@@ -9,13 +9,13 @@ use League\Flysystem\WhitespacePathNormalizer;
 /**
  * Class LoremPicsumImageProvider
  * Provides methods to generate and manipulate image URLs using the Lorem Picsum service.
- * 
- * The purpose of this class is to replace the functionality of the original FakerPhp's image 
+ *
+ * The purpose of this class is to replace the functionality of the original FakerPhp's image
  * formatter, as it was deprecated (see: https://fakerphp.org/formatters/image).
- *  
+ *
  * It is intended to be used in Laravel applications where Faker is used for seeding databases with
  * test data, particularly for generating image URLs and downloading images for testing purposes.
- * 
+ *
  * This class extends the Faker Base provider to add functionality for generating random image URLs
  * and downloading images from Lorem Picsum. It supports generating images with specific dimensions,
  * optional IDs, and seeds for randomization. It also provides methods to download images and store
@@ -24,7 +24,7 @@ use League\Flysystem\WhitespacePathNormalizer;
  * Warm thanks to accreditly.io and in particular to the author of the following article:
  * https://accreditly.io/articles/how-to-replace-laravels-faker-default-image-provider for the
  * detailed explanations on how to replace the default Faker image provider.
- * 
+ *
  * Warm thanks to David Marby and Nijiko Yonskai, authors of Lorem Picsum for providing a free image
  * service that allows us to generate random images.
  *
@@ -36,16 +36,17 @@ class LoremPicsumImageProvider extends Base
 {
     /**
      * Generate a random image URL from Lorem Picsum.
-     * @param int $width Width of the image
-     * @param int $height Height of the image
-     * @param int|null $id Optional image ID to fetch a specific image
-     * @param string|null $seed Optional seed for random image generation
-     * @param array $options Additional query parameters to append to the URL. See https://picsum.photos/ for available options.
+     *
+     * @param  int  $width  Width of the image
+     * @param  int  $height  Height of the image
+     * @param  int|null  $id  Optional image ID to fetch a specific image
+     * @param  string|null  $seed  Optional seed for random image generation
+     * @param  array  $options  Additional query parameters to append to the URL. See https://picsum.photos/ for available options.
      * @return string The generated image URL
      */
     public function imageUrl(int $width = 640, int $height = 480, ?int $id = null, ?string $seed = null, ?array $options = []): string
     {
-        if( $id !== null) {
+        if ($id !== null) {
             $url = "https://picsum.photos/id/{$id}/{$width}/{$height}.jpg";
         } elseif ($seed !== null) {
             $url = "https://picsum.photos/seed/{$seed}/{$width}/{$height}.jpg";
@@ -53,22 +54,25 @@ class LoremPicsumImageProvider extends Base
             $url = "https://picsum.photos/{$width}/{$height}.jpg";
         }
         $queryParams = array_merge(['random' => rand()], $options);
-        if (!empty($queryParams)) {
-            $url .= '?' . http_build_query($queryParams);
+        if (! empty($queryParams)) {
+            $url .= '?'.http_build_query($queryParams);
         }
+
         return $url;
     }
 
     /**
      * Download a remote image from Lorem Picsum and store it on the specified Storage disk.
-     * @param int $width Width of the image
-     * @param int $height Height of the image
-     * @param string $disk Storage disk to save the image
-     * @param string|null $directory Directory to save the image in
-     * @param int|null $id Optional image ID to fetch a specific image
-     * @param string|null $seed Optional seed for random image generation
-     * @param array $options Additional query parameters to append to the URL. See https://picsum.photos/ for available options.
+     *
+     * @param  int  $width  Width of the image
+     * @param  int  $height  Height of the image
+     * @param  string  $disk  Storage disk to save the image
+     * @param  string|null  $directory  Directory to save the image in
+     * @param  int|null  $id  Optional image ID to fetch a specific image
+     * @param  string|null  $seed  Optional seed for random image generation
+     * @param  array  $options  Additional query parameters to append to the URL. See https://picsum.photos/ for available options.
      * @return string The path where the image is stored (relative to the disk root)
+     *
      * @throws \RuntimeException If the image download fails or the storage operation fails
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException If the paths cannot be resolved
      */
@@ -76,17 +80,19 @@ class LoremPicsumImageProvider extends Base
     {
         $url = $this->imageUrl($width, $height, $id, $seed, $options);
         $imageContents = $this->getImageContent($url);
+
         return $this->storeImageContent($imageContents, $disk, $directory);
     }
 
     /**
      * Download a remote image and return its contents.
-     * 
+     *
      * This method uses `file_get_contents` to fetch the image data.
      * It will throw an exception if the download fails or if the image is empty.
-     * 
-     * @param string $url The URL of the image to download
+     *
+     * @param  string  $url  The URL of the image to download
      * @return string The image contents
+     *
      * @throws \RuntimeException If the image download fails or the contents are empty or allow_url_fopen is disabled.
      */
     protected function getImageContent(string $url): string
@@ -95,27 +101,30 @@ class LoremPicsumImageProvider extends Base
         if ($imageContents === false || empty($imageContents)) {
             throw new \RuntimeException("Failed to download image from {$url}");
         }
+
         return $imageContents;
     }
 
     /**
      * Store the image contents to the specified disk and directory.
-     * 
+     *
      * This method normalizes the path and ensures the directory exists before saving.
      * It will throw an exception if the storage operation fails.
-     * 
-     * @param string $imageContents The raw image data to store
-     * @param string $disk The storage disk to use (default: 'local')
-     * @param string|null $directory The directory to store the image in (optional)
-     * @param string|null $filename The name of the file to save (optional, generates a unique name if not provided)
+     *
+     * @param  string  $imageContents  The raw image data to store
+     * @param  string  $disk  The storage disk to use (default: 'local')
+     * @param  string|null  $directory  The directory to store the image in (optional)
+     * @param  string|null  $filename  The name of the file to save (optional, generates a unique name if not provided)
      * @return string The normalized relative path of the stored image
+     *
      * @throws \RuntimeException If the storage operation fails
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException If the paths cannot be resolved
      */
-    protected function storeImageContent(string $imageContents, string $disk = 'local', ?string $directory = null, ?string $filename = null): string {
+    protected function storeImageContent(string $imageContents, string $disk = 'local', ?string $directory = null, ?string $filename = null): string
+    {
         $normalizer = new WhitespacePathNormalizer;
         if ($filename === null) {
-            $filename = uniqid('picsum_', true) . '.jpg';
+            $filename = uniqid('picsum_', true).'.jpg';
         } else {
             $filename = $normalizer->normalizePath($filename);
         }
@@ -124,28 +133,30 @@ class LoremPicsumImageProvider extends Base
         if ($directory !== null) {
             $directory = $normalizer->normalizePath($directory);
 
-            if (!Storage::disk($disk)->exists($directory)) {
+            if (! Storage::disk($disk)->exists($directory)) {
                 Storage::disk($disk)->makeDirectory($directory);
             }
 
             $storagePath = "{$directory}/{$filename}";
         }
 
-        if (false === Storage::disk($disk)->put($storagePath, $imageContents)) {
+        if (Storage::disk($disk)->put($storagePath, $imageContents) === false) {
             throw new \RuntimeException("Failed to save image to {$storagePath} on disk {$disk}");
         }
+
         return $this->normalizeRelativePath($disk, $storagePath);
     }
 
     /**
      * Normalize the relative path of the stored image.
-     * 
+     *
      * This method resolves the real paths of the base and storage paths,
      * and normalizes the relative path to ensure it is clean and consistent.
-     * 
-     * @param string $disk The storage disk to use
-     * @param string $storage_path The storage path of the image
+     *
+     * @param  string  $disk  The storage disk to use
+     * @param  string  $storage_path  The storage path of the image
      * @return string The normalized relative path
+     *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException If the paths cannot be resolved
      */
     protected function normalizeRelativePath(string $disk, string $storage_path): string
@@ -155,7 +166,7 @@ class LoremPicsumImageProvider extends Base
         $real_storage_path = realpath(Storage::disk($disk)->path($storage_path));
 
         if ($real_base_path === false || $real_storage_path === false) {
-            throw new \Illuminate\Contracts\Filesystem\FileNotFoundException("Failed to resolve paths");
+            throw new \Illuminate\Contracts\Filesystem\FileNotFoundException('Failed to resolve paths');
         }
 
         return $normalizer->normalizePath(substr($real_storage_path, strlen($real_base_path) + 1));

--- a/app/Providers/LoremPicsumFakerServiceProvider.php
+++ b/app/Providers/LoremPicsumFakerServiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Providers;
+
+use Faker\Factory as FakerFactory;
+use Faker\Generator as FakerGenerator;
+use Illuminate\Database\Eloquent\Factory as EloquentFactory;
+use Illuminate\Support\ServiceProvider;
+use App\Faker\LoremPicsumImageProvider;
+
+class LoremPicsumFakerServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+   public function register() : void
+    {
+        $this->app->singleton(FakerGenerator::class, function () {
+            $faker = FakerFactory::create();
+            $faker->addProvider(new LoremPicsumImageProvider($faker));
+            return $faker;
+        });
+
+        $this->app->singleton(EloquentFactory::class, function ($app) {
+            return EloquentFactory::construct(
+                $app->make(FakerGenerator::class), $this->app->databasePath('factories')
+            );
+        });
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+
+}

--- a/app/Providers/LoremPicsumFakerServiceProvider.php
+++ b/app/Providers/LoremPicsumFakerServiceProvider.php
@@ -2,22 +2,23 @@
 
 namespace App\Providers;
 
+use App\Faker\LoremPicsumImageProvider;
 use Faker\Factory as FakerFactory;
 use Faker\Generator as FakerGenerator;
 use Illuminate\Database\Eloquent\Factory as EloquentFactory;
 use Illuminate\Support\ServiceProvider;
-use App\Faker\LoremPicsumImageProvider;
 
 class LoremPicsumFakerServiceProvider extends ServiceProvider
 {
     /**
      * Register services.
      */
-   public function register() : void
+    public function register(): void
     {
         $this->app->singleton(FakerGenerator::class, function () {
             $faker = FakerFactory::create();
             $faker->addProvider(new LoremPicsumImageProvider($faker));
+
             return $faker;
         });
 
@@ -35,5 +36,4 @@ class LoremPicsumFakerServiceProvider extends ServiceProvider
     {
         //
     }
-
 }

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,6 +2,7 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\LoremPicsumFakerServiceProvider::class,
     App\Providers\FortifyServiceProvider::class,
     App\Providers\JetstreamServiceProvider::class,
     Intervention\Image\ImageServiceProvider::class,

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9",
         "livewire/livewire": "^3.0",
+        "symfony/filesystem": "^7.3",
         "symfony/process": "^7.3"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ae3b3f3c1c24aaea4a546c17ee7d466",
+    "content-hash": "5b7f7c180c79c991fa3aaec216886fbe",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -4805,6 +4805,72 @@
                 }
             ],
             "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
+                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-10-25T15:15:23+00:00"
         },
         {
             "name": "symfony/finder",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b7f7c180c79c991fa3aaec216886fbe",
+    "content-hash": "8ae3b3f3c1c24aaea4a546c17ee7d466",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -241,16 +241,16 @@
         },
         {
             "name": "dedoc/scramble",
-            "version": "v0.12.22",
+            "version": "v0.12.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dedoc/scramble.git",
-                "reference": "3c06a756d4fc20a281638e8ba9941f6463000d78"
+                "reference": "5b650167c81c59138e844c2ae550c14dc1a249d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dedoc/scramble/zipball/3c06a756d4fc20a281638e8ba9941f6463000d78",
-                "reference": "3c06a756d4fc20a281638e8ba9941f6463000d78",
+                "url": "https://api.github.com/repos/dedoc/scramble/zipball/5b650167c81c59138e844c2ae550c14dc1a249d0",
+                "reference": "5b650167c81c59138e844c2ae550c14dc1a249d0",
                 "shasum": ""
             },
             "require": {
@@ -309,7 +309,7 @@
             ],
             "support": {
                 "issues": "https://github.com/dedoc/scramble/issues",
-                "source": "https://github.com/dedoc/scramble/tree/v0.12.22"
+                "source": "https://github.com/dedoc/scramble/tree/v0.12.23"
             },
             "funding": [
                 {
@@ -317,7 +317,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-06-03T07:50:53+00:00"
+            "time": "2025-06-15T09:04:49+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -1384,16 +1384,16 @@
         },
         {
             "name": "laravel/fortify",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/fortify.git",
-                "reference": "2b3f76ba2fef31713d80bdfee66d0d36e6fc5d04"
+                "reference": "0fb2ec99dfee77ed66884668fc06683acca91ebd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/fortify/zipball/2b3f76ba2fef31713d80bdfee66d0d36e6fc5d04",
-                "reference": "2b3f76ba2fef31713d80bdfee66d0d36e6fc5d04",
+                "url": "https://api.github.com/repos/laravel/fortify/zipball/0fb2ec99dfee77ed66884668fc06683acca91ebd",
+                "reference": "0fb2ec99dfee77ed66884668fc06683acca91ebd",
                 "shasum": ""
             },
             "require": {
@@ -1445,20 +1445,20 @@
                 "issues": "https://github.com/laravel/fortify/issues",
                 "source": "https://github.com/laravel/fortify"
             },
-            "time": "2025-06-05T16:18:11+00:00"
+            "time": "2025-06-11T14:30:52+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v12.18.0",
+            "version": "v12.19.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "7d264a0dad2bfc5c154240b38e8ce9b2c4cdd14d"
+                "reference": "4e6ec689ef704bb4bd282f29d9dd658dfb4fb262"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/7d264a0dad2bfc5c154240b38e8ce9b2c4cdd14d",
-                "reference": "7d264a0dad2bfc5c154240b38e8ce9b2c4cdd14d",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/4e6ec689ef704bb4bd282f29d9dd658dfb4fb262",
+                "reference": "4e6ec689ef704bb4bd282f29d9dd658dfb4fb262",
                 "shasum": ""
             },
             "require": {
@@ -1660,20 +1660,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-06-10T14:48:34+00:00"
+            "time": "2025-06-18T12:56:23+00:00"
         },
         {
             "name": "laravel/jetstream",
-            "version": "v5.3.6",
+            "version": "v5.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/jetstream.git",
-                "reference": "cb4371c07f533b61cdc42a85b582ada68ed77e43"
+                "reference": "b606c21daeaa38547f853789212e3802b0f6ff08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/jetstream/zipball/cb4371c07f533b61cdc42a85b582ada68ed77e43",
-                "reference": "cb4371c07f533b61cdc42a85b582ada68ed77e43",
+                "url": "https://api.github.com/repos/laravel/jetstream/zipball/b606c21daeaa38547f853789212e3802b0f6ff08",
+                "reference": "b606c21daeaa38547f853789212e3802b0f6ff08",
                 "shasum": ""
             },
             "require": {
@@ -1727,7 +1727,7 @@
                 "issues": "https://github.com/laravel/jetstream/issues",
                 "source": "https://github.com/laravel/jetstream"
             },
-            "time": "2025-03-24T16:58:34+00:00"
+            "time": "2025-06-16T13:27:00+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -2836,16 +2836,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.10.0",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "c1397390dd0a7e0f11660f0ae20f753d88c1f3d9"
+                "reference": "1fd1935b2d90aef2f093c5e35f7ae1257c448d00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/c1397390dd0a7e0f11660f0ae20f753d88c1f3d9",
-                "reference": "c1397390dd0a7e0f11660f0ae20f753d88c1f3d9",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/1fd1935b2d90aef2f093c5e35f7ae1257c448d00",
+                "reference": "1fd1935b2d90aef2f093c5e35f7ae1257c448d00",
                 "shasum": ""
             },
             "require": {
@@ -2937,7 +2937,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-12T10:24:28+00:00"
+            "time": "2025-06-21T15:19:35+00:00"
         },
         {
             "name": "nette/schema",
@@ -3936,16 +3936,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.8",
+            "version": "v0.12.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "85057ceedee50c49d4f6ecaff73ee96adb3b3625"
+                "reference": "1b801844becfe648985372cb4b12ad6840245ace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/85057ceedee50c49d4f6ecaff73ee96adb3b3625",
-                "reference": "85057ceedee50c49d4f6ecaff73ee96adb3b3625",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/1b801844becfe648985372cb4b12ad6840245ace",
+                "reference": "1b801844becfe648985372cb4b12ad6840245ace",
                 "shasum": ""
             },
             "require": {
@@ -4009,9 +4009,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.8"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.9"
             },
-            "time": "2025-03-16T03:05:19+00:00"
+            "time": "2025-06-23T02:35:06+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -4805,72 +4805,6 @@
                 }
             ],
             "time": "2024-09-25T14:21:43+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v7.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
-                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "require-dev": {
-                "symfony/process": "^6.4|^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-10-25T15:15:23+00:00"
         },
         {
             "name": "symfony/finder",
@@ -7114,16 +7048,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.18.2",
+            "version": "2.18.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "89dabca1490bc77dbcab41c2b20968c7e44bf7c3"
+                "reference": "59a123a3d459c5a23055802237cb317f609867e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/89dabca1490bc77dbcab41c2b20968c7e44bf7c3",
-                "reference": "89dabca1490bc77dbcab41c2b20968c7e44bf7c3",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/59a123a3d459c5a23055802237cb317f609867e5",
+                "reference": "59a123a3d459c5a23055802237cb317f609867e5",
                 "shasum": ""
             },
             "require": {
@@ -7173,7 +7107,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.18.2"
+                "source": "https://github.com/filp/whoops/tree/2.18.3"
             },
             "funding": [
                 {
@@ -7181,7 +7115,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-06-11T20:42:19+00:00"
+            "time": "2025-06-16T00:02:10+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -8377,16 +8311,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "11.0.9",
+            "version": "11.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "14d63fbcca18457e49c6f8bebaa91a87e8e188d7"
+                "reference": "1a800a7446add2d79cc6b3c01c45381810367d76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/14d63fbcca18457e49c6f8bebaa91a87e8e188d7",
-                "reference": "14d63fbcca18457e49c6f8bebaa91a87e8e188d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/1a800a7446add2d79cc6b3c01c45381810367d76",
+                "reference": "1a800a7446add2d79cc6b3c01c45381810367d76",
                 "shasum": ""
             },
             "require": {
@@ -8443,15 +8377,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.9"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/show"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-25T13:26:39+00:00"
+            "time": "2025-06-18T08:56:18+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",

--- a/database/factories/AvailableImageFactory.php
+++ b/database/factories/AvailableImageFactory.php
@@ -17,7 +17,7 @@ class AvailableImageFactory extends Factory
     public function definition(): array
     {
         return [
-            'path' => $this->faker->imageUrl(640, 480, 'nature', true, 'Faker', true),
+            'path' => $this->faker->imageUrl(width: 640, height: 480),
             'comment' => $this->faker->sentence(10),
         ];
     }

--- a/database/factories/ImageUploadFactory.php
+++ b/database/factories/ImageUploadFactory.php
@@ -2,7 +2,10 @@
 
 namespace Database\Factories;
 
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Database\Eloquent\Factories\Factory;
+
+use function Pest\Laravel\options;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ImageUpload>
@@ -16,12 +19,15 @@ class ImageUploadFactory extends Factory
      */
     public function definition(): array
     {
+        $image = $this->faker->image(disk: 'local', directory: 'uploads/images', options: ['grayscale' => true]);
+        $image_name = basename($image);
+        $image_directory = dirname($image);
         return [
-            'path' => $this->faker->imageUrl(640, 480, 'nature', true, 'Faker', true),
-            'name' => $this->faker->word().'.jpg',
+            'path' => $image_directory,
+            'name' => $image_name,
             'extension' => 'jpg',
-            'mime_type' => 'image/jpeg',
-            'size' => $this->faker->numberBetween(1000, 5000000),
+            'mime_type' => Storage::disk('local')->mimeType($image),
+            'size' => Storage::disk('local')->size($image),
         ];
     }
 }

--- a/database/factories/ImageUploadFactory.php
+++ b/database/factories/ImageUploadFactory.php
@@ -2,10 +2,8 @@
 
 namespace Database\Factories;
 
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Database\Eloquent\Factories\Factory;
-
-use function Pest\Laravel\options;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ImageUpload>
@@ -22,6 +20,7 @@ class ImageUploadFactory extends Factory
         $image = $this->faker->image(disk: 'local', directory: 'uploads/images', options: ['grayscale' => true]);
         $image_name = basename($image);
         $image_directory = dirname($image);
+
         return [
             'path' => $image_directory,
             'name' => $image_name,

--- a/database/factories/PictureFactory.php
+++ b/database/factories/PictureFactory.php
@@ -17,7 +17,7 @@ class PictureFactory extends Factory
     public function definition(): array
     {
         return [
-            'path' => $this->faker->imageUrl(640, 480, 'nature', true, 'Faker', true),
+            'path' => $this->faker->imageUrl(width: 640, height: 480),
             'internal_name' => $this->faker->unique()->words(3, true),
             'backward_compatibility' => $this->faker->bothify('???/???/???/##'),
             'copyright_text' => $this->faker->words(4, true),


### PR DESCRIPTION
See #113 

FakerPHP / Faker announced that the service Placeholder.com that they rely on for image and imageurl has shut down. 
As a result the Image formatter in FakerPHP no longer function.


This pull request replaces the default Image formater of FakerPHP by a custom one, LoremPicsumServiceProvider.

Special thanks to https://accreditly.io/articles/how-to-replace-laravels-faker-default-image-provider for the very nice article on how this can be achieved.