### PR TITLE
Reorganize Unit tests to follow coding standards structure

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,190 +7,172 @@ description: |
 # Copilot instructions for PHP files
 
 ## Context
-- This repository is a Laravel application.
-- This repository uses PHP 8.2 or higher.
-- This repository uses Laravel 12 or higher.
-- This repository follows the Laravel standard.
-- This repository adheres to the PSR-12 coding standard.
-- This laravel application defines a REST API.
-- This laravel application uses resource controllers.
-- This laravel application uses Eloquent ORM.
-- This laravel application uses migrations for database schema.
-- This laravel application uses factories for testing.
-- This laravel application uses seeders for database seeding.
-- This laravel application uses PHPUnit for testing.
-- This laravel application uses Laravel's built-in validation.
-- This laravel application uses Laravel's built-in authentication.
-- This repository uses GitHub for version control.
-
-## Standards
-- This repository is a Laravel application.
-- This repository uses PHP 8.2 or higher.
-- This repository follows the Laravel standard.
-- This repository adheres to the PSR-12 coding standard.
-- This repository uses the PSR-4 autoloading standard.
-- This repository uses Pint for code formatting and style checking.
+- This is a PHP application
+  - It requires PHP 8.2 or higher.
+  - It uses the Laravel Framework
+    - It requires Laravel 12 or higher.
+    - It uses composer for dependency management.
+    - It uses artisan to generate files and run commands.
+    - It uses phpunit for testing.
+    - It uses Pint for code formatting and style checking.
+    - It uses GitHub for version control.
+    - It uses Blade as the templating engine.
+    - It uses Tailwind CSS for styling.
+  - It provides a Database
+  - It uses Eloquent ORM to define the database schema and interact with the database.
+    - Every table is created via migrations
+    - Every table has a Model
+    - Every Model has factories for testing
+    - Every Model has seeders for database seeding
+    - It uses GUID identifiers
+      - Every table has a single column primary key.
+        - The primary key is a `uuid` column, save for the Language and Country models:
+          - Language uses the `ISO 639-1` code as identifier.
+            - The code is a three-letter code.
+          - Country uses the `ISO 3166-1 alpha-3` code as identifier.
+            - The code is a three-letter code.
+        - The primary key is named `id`.
+      - Every `uuid` primary key is generated automatically through `HasUUID` trait, and the method `public function uniqueIds(): array{return ['id'];}`.
+        - The `HasUUID` trait is provided by the Laravel framework.
+        - The `HasUUID` trait is used in every Model that has a `uuid` primary key.
+    - Every Model has a Factory
+      - The Factory is used to generate test data.
+      - The Factory is used to seed the database.
+      - The Factory is used to create test data for the tests.
+      - The Factory is defined in the `database/factories` directory.
+      - The Factory uses the `Faker` library to generate random data.
+      - The Factory uses the `HasFactory` trait, which is provided by the Laravel framework.
+    - Every Model has a Seeder
+      - The Seeder is used to seed the database with initial data.
+      - The Seeder is defined in the `database/seeders` directory.
+      - The Seeder uses the Factory to generate test data.
+      - The Seeder uses the `HasSeeder` trait, which is provided by the Laravel framework.
+      - The Language and Country models are seeded with the ISO 639-1 and ISO 3166-1 alpha-3 codes, respectively.
+        - These Seeders are already defined in the `database/seeders/LanguageSeeder.php` and `database/seeders/CountrySeeder.php` files.
+  - It provides a REST API
+    - The routes are defined in the `routes/api.php` file.
+    - It exposes methodes to interact with the database.
+    - It uses Resource controllers
+      - Controllers are defined in the `app/Http/Controllers` directory.
+      - Every Controller method that accepts input data uses the `Request` class to validate the input.
+        - The Validation in the controller is aligned with the constraints defined in the Model, Factory and Migration.
+      - Every Controller method that returns data uses the `Resource` class to format the output.
+    - Every Model has a Resource 
+    - Every Model has a Controller
+      - Every Controller uses the Resource
+    - Most Controllers have methods for the following actions:
+      - `index` - to list all records
+      - `show` - to show a single record
+      - `store` - to create a new record
+      - `update` - to update an existing record
+      - `destroy` - to delete a record
+    - Model may have Scopes
+      - Scopes are defined in the Model class.
+      - Scopes are used to filter the results of a query.
+      - Scopes are used to apply common query logic to the Model.
+      - When a Model has Scopes, the Controller exposes extra methods to apply the Scopes.
+        - For example, if the `User` model has a `scopeActive` method, the `UserController` will have an `active` method that applies the scope.
+          The route for this method will be `GET /users/active`. 
+    - Some Models are created through Event Listeners.
+      - Such Controllers do not allow `store`, `update` methods.
+    - All Models, Controllers, Resources, Factories, Seeders, and Tests are kept consistent
+      - Every Controller exposes similar routes and follow similar naming conventions
+      - Every Resource formats the output in a consistent way
+      - Every Factory generates similar data for the Model
+      - Every Test validates the data in a consistent way
+  - It has Unit and Feature tests
+    - The Feature tests are defined in the `tests/Feature` directory.
+    - The Unit tests are defined in the `tests/Unit` directory.
+    - Every Factory has Unit tests
+      - The tests are defined in the `tests/Unit` directory.
+      - The tests use the Factory to generate test data.
+      - The tests use the `assertDatabaseHas` method to validate the data in the database.
+      - The tests asserts that generated data complies with the constraints defined in the Model, Factory and Migration.
+      - When the Model has Scopes, the Factory test has extra tests for each Scope
+    - Every Model has Feature tests
+      - The tests are defined in the `tests/Feature` directory.
+      - The tests for a single Model are organized in a directory named after the Model.
+        - Every Model has the following test files:
+          - `AnonymousTest.php` - Tests for unauthorized access scenarios
+          - `IndexTest.php` - Tests for listing/index operations
+          - `ShowTest.php` - Tests for showing single records
+          - `StoreTest.php` - Tests for creating new records
+            - When the model forbids creation, this file contains one single test that asserts that the `store` method returns a `405 Method Not Allowed` response.
+          - `UpdateTest.php` - Tests for updating existing records
+            - when the model forbids updating, this file contains one single test that asserts that the `update` method returns a `405 Method Not Allowed` response.
+          - `DestroyTest.php` - Tests for deleting records
+            - when the model forbids deletion, this file contains one single test that asserts that the `destroy` method returns a `405 Method Not Allowed` response.
+      - The test class has `setUp()`.
+        - In AnonymousTest.php, the `setUp()` is empty.
+        - In the other test files the class has a `protected ?User $user = null;` property and the `setUp()` method creates and authenticates a user with 
+          ```
+          $this->user = User::factory()->create();
+          $this->actingAs($this->user);
+          ```
+      - The tests use the `RefreshDatabase` trait to reset the database state before each test.
+      - The tests use the `WithFaker` trait to generate random data for tests.
+      - The tests use the Factory to generate test data.
+        - When the test requires data in the database, the test uses the Factory to create and store the data with `->create()`.
+          - When creating a record it is preferred to use the Factory without customizing the data
+        - When the test requires a second set of data to pass to a controller then it uses the Factory to create the data in memory with `->make()->toArray()`.
+        - When the test requires a second set of data with missing fields then it uses the Factory to create the data in memory with `->make()->except()`.
+      - The tests use `assertJsonStructure` method to validate the response structure.
+      - The tests use `assertJsonPath` method to validate the response content.
+      - The tests use `assertOk`, `assertCreated`, `assertNoContent`, `assertNotFound`, and `assertUnprocessable` methods to validate the status code of the response.
+      - To generate url, if the route has a name, always use the `route()` helper with the route's name. Otherwise use the `url()` helper with the route's path.
+        - For example, if the route is named `user.index`, use `route('user.index')` to generate the URL for the index method of the UserController.
+        - If the route is not named, use `url('/users')` to generate the URL for the index method of the UserController.
+  - The structure of the repository is as follows:
+    ```
+    .
+    ├── app
+    │   ├── Http
+    │   │   ├── Controllers
+    │   │   └── Resources
+    │   └── Models
+    ├── database
+    │   ├── factories
+    │   ├── migrations
+    │   └── seeders
+    ├── routes
+    │   └── api.php
+    ├── tests
+    │   ├── Feature
+    │   │   └── Api
+    │   │       ├── ModelName
+    │   │       │   ├── AnonymousTest.php
+    │   │       │   ├── IndexTest.php
+    │   │       │   ├── ShowTest.php
+    │   │       │   ├── StoreTest.php
+    │   │       │   ├── UpdateTest.php
+    │   │       │   └── DestroyTest.php
+    │   │       └── OtherModelName
+    │   │           ├── AnonymousTest.php
+    │   │           ├── IndexTest.php
+    │   │           ├── ShowTest.php
+    │   │           ├── StoreTest.php
+    │   │           ├── UpdateTest.php
+    │   │           └── DestroyTest.php
+    │   └── Unit
+    │       ├── ModelName
+    │       |   └── FactoryTest.php
+    │       └── OtherModelName
+    │           └── FactoryTest.php
+    └── composer.json
+    ```
 
 ## Naming Conventions
-- Always comply with Laravel's naming conventions.
-- Use `snake_case` for database columns and table names.
-- Use `kebab-case` for URLs and routes.
-- Use `snake_case` for configuration files.
-- Use `camelCase` for variable and function names.
-- Use `PascalCase` for class names and methods.
-- Use `UPPER_CASE` for constants.
-
-## Testing the API
-- Use PHPUnit for testing.
-- Use the `tests/Feature` directory for API tests.
-- Use `php artisan make:test` to create new test classes.
-- All tests classes shall contain `use RefreshDatabase, WithFaker;` to insure proper isolation and data generation.
-  - This line is to be placed first inside the class declaration.
-  - For example:
-    ```php
-    use Illuminate\Foundation\Testing\RefreshDatabase;
-    use Illuminate\Foundation\Testing\WithFaker;
-    use Tests\TestCase;
-
-    class MyModelTest extends TestCase
-    {
-        use RefreshDatabase, WithFaker;
-    }
-    ```
-- Use `php artisan test` to run tests.
-- Use `php artisan test --coverage` to generate a code coverage report.
-- Test every route in the `routes/api.php` file.
-- Test names should be descriptive and follow the format:
-  `test_[ControllerMethod]_[Scenario]`.
-- Organize tests into focused test classes by functionality within entity-specific directories.
-  - For each entity (e.g., `User`), create a directory under `tests/Feature/Api/` (e.g., `tests/Feature/Api/User/`).
-  - Within each entity directory, create separate test files for different aspects:
-    - `AnonymousTest.php` - Tests for unauthorized access scenarios
-    - `IndexTest.php` - Tests for listing/index operations
-    - `ShowTest.php` - Tests for showing single records
-    - `StoreTest.php` - Tests for creating new records
-    - `UpdateTest.php` - Tests for updating existing records
-    - `DestroyTest.php` - Tests for deleting records
-  - Each test file should focus only on tests relevant to its specific functionality.
-  - Each test file should include a `protected ?User $user = null;` property and a `setUp()` method that creates and authenticates a user.
-  - For example, for a `User` model, create:
-    - `tests/Feature/Api/User/AnonymousTest.php`
-    - `tests/Feature/Api/User/IndexTest.php`
-    - `tests/Feature/Api/User/ShowTest.php`
-    - `tests/Feature/Api/User/StoreTest.php`
-    - `tests/Feature/Api/User/UpdateTest.php`
-    - `tests/Feature/Api/User/DestroyTest.php`
-- Ensure that tests are concise and focused on a single aspect of the functionality.
-- Use the `assert` methods provided by PHPUnit to validate the expected outcomes.
-- Always use the `route()` helper to generate URLs for testing.
-- When using the `route()` helper, ensure that the route name is used correctly. 
-  - Route names are defined in the `routes/api.php` file.
-  - Route names autogenerated by the Resource controllers comply with Laravel's naming conventions:
-    - the name of the route is the singular form of the model's database table, followed by the action.
-    - For example, for the `UserResource` (based on the `User` model), the name of the database table is `users` and the name of the route is `user`:
-      - `user.index` for the index method
-      - `user.show` for the show method
-      - `user.store` for the store method
-      - `user.update` for the update method
-      - `user.destroy` for the destroy method
-- Categorize tests according to the process they are testing.
-  - Tests related to the Factory are in the category 'Factory'.
-    - For every factory, make a distinct test to assert that the factory creates the expected data
-      - The name of this test should follow the format `test_factory`.
-    - For every factory method, make a distinct test to assert that the factory creates the expected data.
-      - The name of this test should follow the format `test_factory_[FactoryMethod]`.
-      - For example, if the `UserFactory` has a method `withEmail`, then all tests related to the factory must be repeated with the `withEmail` method.
-        - The name of these tests should follow the format `test_factory_withEmail`.
-  - Tests related to the HTTP responses are in the category 'Response'.
-    - For every response make a distinct test to assert the status code of the response.
-      - The name of this test should follow the format `test_[ControllerMethod]_returns_[StatusCode]_on_[Scenario]`.
-    - For every response make a distinct test to assert the structure of the response.
-      - The name of this test should follow the format `test_[ControllerMethod]_returns_the_expected_structure`.
-    - For every response make a distinct test to assert the content of the response.
-      - The name of this test should follow the format `test_[ControllerMethod]_returns_the_expected_data`.
-    - Prefer the Response tests to use the `assertJsonStructure` to validate the response structure.
-    # - Prefer the Response tests to use the `assertJsonPath` methods to validate the response content, when the response has a single item.
-    # - Prefer the Response tests to use the `assertJson` methods to validate the response content, when the response has multiple items.
-    - Prefer the Response tests to use the `assertJsonPath` methods to validate the response content
-    - Prefer the methods `assertOk`, `assertCreated`, `assertNoContent`, `assertNotFound`, and `assertUnprocessable` to validate the status code of the response.
-  - Tests related to the validation of the request data are in the category 'Validation'.
-    - For every `store` and `update` method, make a distinct test to assert that input validation is performed.
-      - The name of this test should follow the format `test_[ControllerMethod]_validates_its_input`.
-  - Tests related to the authentication and authorization are in the category 'Authentication'.
-    - For every route make a distinct test to assert that authenticated access is allowed.
-      - The name of this test should follow the format `test_[ControllerMethod]_allows_authenticated_users`.
-    - For every route make a distinct test to assert that anonymous access is forbidden.
-      - The name of this test should follow the format `test_[ControllerMethod]_forbids_anonymous_access`.
-  - Tests related to the process performed by the controller are in the category 'Process'.
-    - For every `store`, `update` and `destroy` method, make a distinct test to assert that the underlying database record is impacted.
-      - The name of this test should follow the format `test_[ControllerMethod]_[creates|updates|deletes]_a_row`.
-  - When the factory has extra methods, all HTTP Response tests may be repeated with the extra methods.
-    - For example:
-        - `test_[ControllerMethod]_[extra_method]_returns_[StatusCode]_on_[Scenario]` 
-        - `test_[ControllerMethod]_[extra_method]_returns_the_expected_structure`
-        - `test_[ControllerMethod]_[extra_method]_returns_the_expected_data`
-  - For example, the `User` model has a `UserResource`, `UserFactory` and `UserController`.
-    The `UserFactory` has one method: `withEmail`.
-    The `UserController` has five methods: `index`, `show`, `store`, `update`, `destroy`.
-    The test case shall include all of the following tests:
-    - `test_factory`.
-    - `test_factory_withEmail`.
-    - `test_index_allows_authenticated_users`.
-    - `test_index_forbids_anonymous_access`.
-    - `test_show_allows_authenticated_users`.
-    - `test_show_forbids_anonymous_access`.
-    - `test_store_allows_authenticated_users`.
-    - `test_store_forbids_anonymous_access`.
-    - `test_update_allows_authenticated_users`.
-    - `test_update_forbids_anonymous_access`.
-    - `test_destroy_allows_authenticated_users`.
-    - `test_destroy_forbids_anonymous_access`.
-    - `test_index_returns_all_rows`.
-    - `test_show_returns_one_row`.
-    - `test_store_creates_a_row`.
-    - `test_update_updates_a_row`.
-    - `test_destroy_deletes_a_row`.
-    - `test_index_returns_ok_on_success`.
-    - `test_show_returns_ok_on_success`.
-    - `test_show_returns_not_found_when_record_does_not_exist`.
-    - `test_store_returns_created_on_success`.
-    - `test_store_returns_unprocessable_entity_when_input_is_invalid`.
-    - `test_update_returns_ok_on_success`.
-    - `test_update_returns_not_found_when_record_does_not_exist`.
-    - `test_update_returns_unprocessable_entity_when_input_is_invalid`.
-    - `test_destroy_returns_no_content_on_success`.
-    - `test_destroy_returns_not_found_when_record_does_not_exist`.
-    - `test_index_returns_the_expected_structure`.
-    - `test_show_returns_the_expected_structure`.
-    - `test_store_returns_the_expected_structure`.
-    - `test_update_returns_the_expected_structure`.
-    - `test_destroy_returns_the_expected_structure`.
-    - `test_index_returns_the_expected_data`.
-    - `test_show_returns_the_expected_data`.
-    - `test_store_returns_the_expected_data`.
-    - `test_update_returns_the_expected_data`.
-    - `test_destroy_returns_the_expected_data`.
-    - `test_store_validates_its_input`.
-    - `test_update_validates_its_input`.
-- When testing a route that requires authentication, use the `actingAs` method to simulate an authenticated user.
-  - Each test file should include a `protected ?User $user = null;` property and a `setUp()` method that handles user creation and authentication.
-  - For example:
-    ```php
-    protected ?User $user = null;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->user = User::factory()->create();
-        $this->actingAs($this->user);
-    }
-    ```
-  - For testing anonymous access, use `withHeaders(['Authorization' => ''])` to simulate unauthenticated requests.
-  - For example:
-    ```php
-    $response = $this->withHeaders(['Authorization' => ''])
-        ->getJson(route('user.index'));
-    ```
+- The repository complies with Laravel's naming conventions.
+  - It adheres to the PSR-12 coding standard.
+  - Is uses the PSR-4 autoloading standard.
+  - It uses Pint for code formatting and style checking.
+- It uses `snake_case` for database columns and table names.
+- It uses `kebab-case` for URLs and routes.
+- It uses `snake_case` for configuration files.
+- It uses `camelCase` for variable and function names.
+- It uses `PascalCase` for class names and methods.
+- It uses `UPPER_CASE` for constants.
+- It uses `snake_case` for file names.
 
 ## Error Handling
 - Use try-catch blocks for asynchronous operations.

--- a/ANALYSIS_REPORT.md
+++ b/ANALYSIS_REPORT.md
@@ -61,8 +61,9 @@ Based on the models found in `app/Models/` (excluding User):
 - **Status**: ✅ ALIGNED
 
 #### Tests Analysis Status
-- **Test Files Present**: ✅ AnonymousTest, DestroyTest, IndexTest, ShowTest, StoreTest, UpdateTest
-- **Validation Tests**: ✅ Present
+- **Feature Test Files Present**: ✅ All test files exist (AnonymousTest, DestroyTest, IndexTest, ShowTest, StoreTest, UpdateTest)
+- **Unit Test Files Present**: 🔴 **MISSING** - No `tests/Unit/Context/FactoryTest.php` (currently `tests/Unit/ContextTest.php`)
+- **Test Organization**: ✅ Follows new structure with individual test files per functionality
 - **All Fields Tested**: ✅ VERIFIED
 
 ---
@@ -140,7 +141,18 @@ Based on the models found in `app/Models/` (excluding User):
 - **Status**: ❌ MISALIGNED
 
 #### Tests Analysis Status
-- **Test Files Present**: 🔴 **MISSING COMPLETELY**
+- **Feature Test Files Present**: ✅ All test files exist (AnonymousTest, DestroyTest, IndexTest, ShowTest, StoreTest, UpdateTest) 
+- **Unit Test Files Present**: 🔴 **MISSING** - No `tests/Unit/Project/FactoryTest.php`
+- **Test Organization**: ✅ Follows new structure with individual test files per functionality
+
+#### Migration vs Model Analysis
+- **Migration Fields**: `id` (uuid), `internal_name` (string), `backward_compatibility` (nullable string), `copyright_text` (nullable string), `copyright_url` (nullable string), `path` (nullable string), `upload_name` (nullable string), `upload_extension` (nullable string), `upload_mime_type` (nullable string), `upload_size` (nullable bigint), `timestamps`
+- **Status**: ✅ ALIGNED
+
+#### Controller Validation vs Migration
+- **Store Validation**: ✅ Well implemented with file upload handling
+- **Update Validation**: 🔴 **MISSING COMPLETELY**
+- **Status**: ❌ INCOMPLETE IMPLEMENTATION
 
 ---
 
@@ -156,7 +168,9 @@ Based on the models found in `app/Models/` (excluding User):
 - **Status**: ❌ INCOMPLETE IMPLEMENTATION
 
 #### Tests Analysis Status
-- **Test Files Present**: 🔴 **MISSING COMPLETELY**
+- **Feature Test Files Present**: ✅ All test files exist (AnonymousTest, DestroyTest, IndexTest, ShowTest, StoreTest, UpdateTest)
+- **Unit Test Files Present**: 🔴 **MISSING** - No `tests/Unit/Picture/FactoryTest.php`
+- **Test Organization**: ✅ Follows new structure with individual test files per functionality
 
 ---
 

--- a/tests/Feature/Api/Picture/AnonymousTest.php
+++ b/tests/Feature/Api/Picture/AnonymousTest.php
@@ -12,58 +12,45 @@ class AnonymousTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 
-    /**
-     * Authentication: index forbids anonymous access.
-     */
-    public function test_index_forbids_anonymous_access()
+    protected ?User $user = null;
+
+    protected function setUp(): void
     {
-        $response = $this->withHeaders(['Authorization' => ''])
-            ->getJson(route('picture.index'));
+        parent::setUp();
+    }
+
+    public function test_index_forbids_anonymous_access(): void
+    {
+        $response = $this->getJson(route('picture.index'));
         $response->assertUnauthorized();
     }
 
-    /**
-     * Authentication: show forbids anonymous access.
-     */
-    public function test_show_forbids_anonymous_access()
+    public function test_show_forbids_anonymous_access(): void
     {
         $picture = Picture::factory()->create();
-        $response = $this->withHeaders(['Authorization' => ''])
-            ->getJson(route('picture.show', $picture));
+        $response = $this->getJson(route('picture.show', $picture));
         $response->assertUnauthorized();
     }
 
-    /**
-     * Authentication: store forbids anonymous access.
-     */
-    public function test_store_forbids_anonymous_access()
+    public function test_store_forbids_anonymous_access(): void
     {
         $data = Picture::factory()->make()->except(['id', 'path', 'upload_name', 'upload_extension', 'upload_mime_type', 'upload_size']);
-        $response = $this->withHeaders(['Authorization' => ''])
-            ->postJson(route('picture.store'), $data);
+        $response = $this->postJson(route('picture.store'), $data);
         $response->assertUnauthorized();
     }
 
-    /**
-     * Authentication: update forbids anonymous access.
-     */
-    public function test_update_forbids_anonymous_access()
+    public function test_update_forbids_anonymous_access(): void
     {
         $picture = Picture::factory()->create();
         $data = ['internal_name' => 'Updated Name'];
-        $response = $this->withHeaders(['Authorization' => ''])
-            ->putJson(route('picture.update', $picture), $data);
+        $response = $this->putJson(route('picture.update', $picture), $data);
         $response->assertUnauthorized();
     }
 
-    /**
-     * Authentication: destroy forbids anonymous access.
-     */
-    public function test_destroy_forbids_anonymous_access()
+    public function test_destroy_forbids_anonymous_access(): void
     {
         $picture = Picture::factory()->create();
-        $response = $this->withHeaders(['Authorization' => ''])
-            ->deleteJson(route('picture.destroy', $picture));
+        $response = $this->deleteJson(route('picture.destroy', $picture));
         $response->assertUnauthorized();
     }
 }

--- a/tests/Feature/Api/Picture/DestroyTest.php
+++ b/tests/Feature/Api/Picture/DestroyTest.php
@@ -1,7 +1,68 @@
 <?php
 
-test('example', function () {
-    $response = $this->get('/');
+namespace Tests\Feature\Api\Picture;
 
-    $response->assertStatus(200);
-});
+use App\Models\Picture;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class DestroyTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected ?User $user = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function test_destroy_allows_authenticated_users(): void
+    {
+        $picture = Picture::factory()->create();
+        $response = $this->deleteJson(route('picture.destroy', $picture));
+        $response->assertNoContent();
+    }
+
+    public function test_destroy_deletes_a_row(): void
+    {
+        $picture = Picture::factory()->create();
+        $response = $this->deleteJson(route('picture.destroy', $picture));
+        $response->assertNoContent();
+        $this->assertDatabaseMissing('pictures', ['id' => $picture->id]);
+    }
+
+    public function test_destroy_returns_no_content_on_success(): void
+    {
+        $picture = Picture::factory()->create();
+        $response = $this->deleteJson(route('picture.destroy', $picture));
+        $response->assertNoContent();
+    }
+
+    public function test_destroy_returns_not_found_when_record_does_not_exist(): void
+    {
+        $response = $this->deleteJson(route('picture.destroy', 'non-existent-id'));
+        $response->assertNotFound();
+    }
+
+    public function test_destroy_returns_the_expected_structure(): void
+    {
+        $picture = Picture::factory()->create();
+        $response = $this->deleteJson(route('picture.destroy', $picture));
+        $response->assertNoContent();
+        $this->assertEmpty($response->getContent());
+    }
+
+    public function test_destroy_returns_the_expected_data(): void
+    {
+        $picture = Picture::factory()->create();
+        $response = $this->deleteJson(route('picture.destroy', $picture));
+        $response->assertNoContent();
+        $this->assertEmpty($response->getContent());
+        $this->assertDatabaseMissing('pictures', ['id' => $picture->id]);
+    }
+}

--- a/tests/Feature/Api/Picture/IndexTest.php
+++ b/tests/Feature/Api/Picture/IndexTest.php
@@ -21,28 +21,19 @@ class IndexTest extends TestCase
         $this->actingAs($this->user);
     }
 
-    /**
-     * Authentication: index allows authenticated users.
-     */
-    public function test_index_allows_authenticated_users()
+    public function test_index_allows_authenticated_users(): void
     {
         $response = $this->getJson(route('picture.index'));
         $response->assertOk();
     }
 
-    /**
-     * Response: index returns ok on success.
-     */
-    public function test_index_returns_ok_on_success()
+    public function test_index_returns_ok_on_success(): void
     {
         $response = $this->getJson(route('picture.index'));
         $response->assertOk();
     }
 
-    /**
-     * Response: index returns the expected structure.
-     */
-    public function test_index_returns_the_expected_structure()
+    public function test_index_returns_the_expected_structure(): void
     {
         Picture::factory()->create();
         $response = $this->getJson(route('picture.index'));
@@ -67,10 +58,7 @@ class IndexTest extends TestCase
         ]);
     }
 
-    /**
-     * Response: index returns the expected data.
-     */
-    public function test_index_returns_the_expected_data()
+    public function test_index_returns_the_expected_data(): void
     {
         $picture = Picture::factory()->create();
         $response = $this->getJson(route('picture.index'));

--- a/tests/Feature/Api/Picture/ShowTest.php
+++ b/tests/Feature/Api/Picture/ShowTest.php
@@ -1,7 +1,75 @@
 <?php
 
-test('example', function () {
-    $response = $this->get('/');
+namespace Tests\Feature\Api\Picture;
 
-    $response->assertStatus(200);
-});
+use App\Models\Picture;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected ?User $user = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function test_show_allows_authenticated_users(): void
+    {
+        $picture = Picture::factory()->create();
+        $response = $this->getJson(route('picture.show', $picture));
+        $response->assertOk();
+    }
+
+    public function test_show_returns_ok_on_success(): void
+    {
+        $picture = Picture::factory()->create();
+        $response = $this->getJson(route('picture.show', $picture));
+        $response->assertOk();
+    }
+
+    public function test_show_returns_not_found_when_record_does_not_exist(): void
+    {
+        $response = $this->getJson(route('picture.show', 'non-existent-id'));
+        $response->assertNotFound();
+    }
+
+    public function test_show_returns_the_expected_structure(): void
+    {
+        $picture = Picture::factory()->create();
+        $response = $this->getJson(route('picture.show', $picture));
+        $response->assertJsonStructure([
+            'data' => [
+                'id',
+                'internal_name',
+                'backward_compatibility',
+                'copyright_text',
+                'copyright_url',
+                'path',
+                'upload_name',
+                'upload_extension',
+                'upload_mime_type',
+                'upload_size',
+                'created_at',
+                'updated_at',
+            ]
+        ]);
+    }
+
+    public function test_show_returns_the_expected_data(): void
+    {
+        $picture = Picture::factory()->create();
+        $response = $this->getJson(route('picture.show', $picture));
+        $response->assertOk();
+        $response->assertJsonPath('data.id', $picture->id);
+        $response->assertJsonPath('data.internal_name', $picture->internal_name);
+        $response->assertJsonPath('data.backward_compatibility', $picture->backward_compatibility);
+    }
+}

--- a/tests/Feature/Api/Picture/StoreTest.php
+++ b/tests/Feature/Api/Picture/StoreTest.php
@@ -24,20 +24,7 @@ class StoreTest extends TestCase
         Storage::fake('local');
     }
 
-    /**
-     * Factory: test factory.
-     */
-    public function test_factory()
-    {
-        $picture = Picture::factory()->create();
-        $this->assertInstanceOf(Picture::class, $picture);
-        $this->assertDatabaseHas('pictures', ['id' => $picture->id]);
-    }
-
-    /**
-     * Authentication: store allows authenticated users.
-     */
-    public function test_store_allows_authenticated_users()
+    public function test_store_allows_authenticated_users(): void
     {
         $file = UploadedFile::fake()->image('test.jpg');
         $data = Picture::factory()->make()->except(['id', 'path', 'upload_name', 'upload_extension', 'upload_mime_type', 'upload_size']);
@@ -47,10 +34,7 @@ class StoreTest extends TestCase
         $response->assertCreated();
     }
 
-    /**
-     * Process: store creates a row.
-     */
-    public function test_store_creates_a_row()
+    public function test_store_creates_a_row(): void
     {
         $file = UploadedFile::fake()->image('test.jpg');
         $data = Picture::factory()->make()->except(['id', 'path', 'upload_name', 'upload_extension', 'upload_mime_type', 'upload_size']);
@@ -66,10 +50,7 @@ class StoreTest extends TestCase
         ]);
     }
 
-    /**
-     * Response: store returns created on success.
-     */
-    public function test_store_returns_created_on_success()
+    public function test_store_returns_created_on_success(): void
     {
         $file = UploadedFile::fake()->image('test.jpg');
         $data = Picture::factory()->make()->except(['id', 'path', 'upload_name', 'upload_extension', 'upload_mime_type', 'upload_size']);
@@ -79,10 +60,7 @@ class StoreTest extends TestCase
         $response->assertCreated();
     }
 
-    /**
-     * Response: store returns unprocessable entity when input is invalid.
-     */
-    public function test_store_returns_unprocessable_entity_when_input_is_invalid()
+    public function test_store_returns_unprocessable_entity_when_input_is_invalid(): void
     {
         $data = Picture::factory()->make()->except(['internal_name', 'file']); // missing required fields
 
@@ -90,10 +68,7 @@ class StoreTest extends TestCase
         $response->assertUnprocessable();
     }
 
-    /**
-     * Response: store returns the expected structure.
-     */
-    public function test_store_returns_the_expected_structure()
+    public function test_store_returns_the_expected_structure(): void
     {
         $file = UploadedFile::fake()->image('test.jpg');
         $data = Picture::factory()->make()->except(['id', 'path', 'upload_name', 'upload_extension', 'upload_mime_type', 'upload_size']);
@@ -119,10 +94,7 @@ class StoreTest extends TestCase
         ]);
     }
 
-    /**
-     * Response: store returns the expected data.
-     */
-    public function test_store_returns_the_expected_data()
+    public function test_store_returns_the_expected_data(): void
     {
         $file = UploadedFile::fake()->image('test.jpg');
         $data = Picture::factory()->make()->except(['id', 'path', 'upload_name', 'upload_extension', 'upload_mime_type', 'upload_size']);
@@ -136,10 +108,7 @@ class StoreTest extends TestCase
         $response->assertJsonPath('data.copyright_url', $data['copyright_url']);
     }
 
-    /**
-     * Validation: store validates its input.
-     */
-    public function test_store_validates_its_input()
+    public function test_store_validates_its_input(): void
     {
         $data = Picture::factory()->make()->except(['internal_name', 'file']); // missing required fields
 

--- a/tests/Feature/Api/Picture/UpdateTest.php
+++ b/tests/Feature/Api/Picture/UpdateTest.php
@@ -1,7 +1,31 @@
 <?php
 
-test('example', function () {
-    $response = $this->get('/');
+namespace Tests\Feature\Api\Picture;
 
-    $response->assertStatus(200);
-});
+use App\Models\Picture;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class UpdateTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected ?User $user = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function test_update_returns_method_not_allowed(): void
+    {
+        $picture = Picture::factory()->create();
+        $data = ['internal_name' => 'Updated Name'];
+        $response = $this->putJson(route('picture.update', $picture), $data);
+        $response->assertMethodNotAllowed();
+    }
+}

--- a/tests/Feature/Api/Project/AnonymousTest.php
+++ b/tests/Feature/Api/Project/AnonymousTest.php
@@ -1,7 +1,56 @@
 <?php
 
-test('example', function () {
-    $response = $this->get('/');
+namespace Tests\Feature\Api\Project;
 
-    $response->assertStatus(200);
-});
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class AnonymousTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected ?User $user = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function test_index_forbids_anonymous_access(): void
+    {
+        $response = $this->getJson(route('project.index'));
+        $response->assertUnauthorized();
+    }
+
+    public function test_show_forbids_anonymous_access(): void
+    {
+        $project = Project::factory()->create();
+        $response = $this->getJson(route('project.show', $project));
+        $response->assertUnauthorized();
+    }
+
+    public function test_store_forbids_anonymous_access(): void
+    {
+        $data = Project::factory()->make()->toArray();
+        $response = $this->postJson(route('project.store'), $data);
+        $response->assertUnauthorized();
+    }
+
+    public function test_update_forbids_anonymous_access(): void
+    {
+        $project = Project::factory()->create();
+        $data = ['internal_name' => 'Updated Name'];
+        $response = $this->putJson(route('project.update', $project), $data);
+        $response->assertUnauthorized();
+    }
+
+    public function test_destroy_forbids_anonymous_access(): void
+    {
+        $project = Project::factory()->create();
+        $response = $this->deleteJson(route('project.destroy', $project));
+        $response->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Api/Project/DestroyTest.php
+++ b/tests/Feature/Api/Project/DestroyTest.php
@@ -1,7 +1,68 @@
 <?php
 
-test('example', function () {
-    $response = $this->get('/');
+namespace Tests\Feature\Api\Project;
 
-    $response->assertStatus(200);
-});
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class DestroyTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected ?User $user = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function test_destroy_allows_authenticated_users(): void
+    {
+        $project = Project::factory()->create();
+        $response = $this->deleteJson(route('project.destroy', $project));
+        $response->assertNoContent();
+    }
+
+    public function test_destroy_deletes_a_row(): void
+    {
+        $project = Project::factory()->create();
+        $response = $this->deleteJson(route('project.destroy', $project));
+        $response->assertNoContent();
+        $this->assertDatabaseMissing('projects', ['id' => $project->id]);
+    }
+
+    public function test_destroy_returns_no_content_on_success(): void
+    {
+        $project = Project::factory()->create();
+        $response = $this->deleteJson(route('project.destroy', $project));
+        $response->assertNoContent();
+    }
+
+    public function test_destroy_returns_not_found_when_record_does_not_exist(): void
+    {
+        $response = $this->deleteJson(route('project.destroy', 'non-existent-id'));
+        $response->assertNotFound();
+    }
+
+    public function test_destroy_returns_the_expected_structure(): void
+    {
+        $project = Project::factory()->create();
+        $response = $this->deleteJson(route('project.destroy', $project));
+        $response->assertNoContent();
+        $this->assertEmpty($response->getContent());
+    }
+
+    public function test_destroy_returns_the_expected_data(): void
+    {
+        $project = Project::factory()->create();
+        $response = $this->deleteJson(route('project.destroy', $project));
+        $response->assertNoContent();
+        $this->assertEmpty($response->getContent());
+        $this->assertDatabaseMissing('projects', ['id' => $project->id]);
+    }
+}

--- a/tests/Feature/Api/Project/IndexTest.php
+++ b/tests/Feature/Api/Project/IndexTest.php
@@ -1,7 +1,67 @@
 <?php
 
-test('example', function () {
-    $response = $this->get('/');
+namespace Tests\Feature\Api\Project;
 
-    $response->assertStatus(200);
-});
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class IndexTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected ?User $user = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function test_index_allows_authenticated_users(): void
+    {
+        $response = $this->getJson(route('project.index'));
+        $response->assertOk();
+    }
+
+    public function test_index_returns_ok_on_success(): void
+    {
+        $response = $this->getJson(route('project.index'));
+        $response->assertOk();
+    }
+
+    public function test_index_returns_the_expected_structure(): void
+    {
+        Project::factory()->create();
+        $response = $this->getJson(route('project.index'));
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'internal_name',
+                    'backward_compatibility',
+                    'launch_date',
+                    'is_launched',
+                    'is_enabled',
+                    'context_id',
+                    'language_id',
+                    'created_at',
+                    'updated_at',
+                ]
+            ]
+        ]);
+    }
+
+    public function test_index_returns_the_expected_data(): void
+    {
+        $project = Project::factory()->create();
+        $response = $this->getJson(route('project.index'));
+        $response->assertOk();
+        $response->assertJsonPath('data.0.id', $project->id);
+        $response->assertJsonPath('data.0.internal_name', $project->internal_name);
+    }
+}

--- a/tests/Feature/Api/Project/ShowTest.php
+++ b/tests/Feature/Api/Project/ShowTest.php
@@ -1,7 +1,73 @@
 <?php
 
-test('example', function () {
-    $response = $this->get('/');
+namespace Tests\Feature\Api\Project;
 
-    $response->assertStatus(200);
-});
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class ShowTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected ?User $user = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function test_show_allows_authenticated_users(): void
+    {
+        $project = Project::factory()->create();
+        $response = $this->getJson(route('project.show', $project));
+        $response->assertOk();
+    }
+
+    public function test_show_returns_ok_on_success(): void
+    {
+        $project = Project::factory()->create();
+        $response = $this->getJson(route('project.show', $project));
+        $response->assertOk();
+    }
+
+    public function test_show_returns_not_found_when_record_does_not_exist(): void
+    {
+        $response = $this->getJson(route('project.show', 'non-existent-id'));
+        $response->assertNotFound();
+    }
+
+    public function test_show_returns_the_expected_structure(): void
+    {
+        $project = Project::factory()->create();
+        $response = $this->getJson(route('project.show', $project));
+        $response->assertJsonStructure([
+            'data' => [
+                'id',
+                'internal_name',
+                'backward_compatibility',
+                'launch_date',
+                'is_launched',
+                'is_enabled',
+                'context_id',
+                'language_id',
+                'created_at',
+                'updated_at',
+            ]
+        ]);
+    }
+
+    public function test_show_returns_the_expected_data(): void
+    {
+        $project = Project::factory()->create();
+        $response = $this->getJson(route('project.show', $project));
+        $response->assertOk();
+        $response->assertJsonPath('data.id', $project->id);
+        $response->assertJsonPath('data.internal_name', $project->internal_name);
+        $response->assertJsonPath('data.backward_compatibility', $project->backward_compatibility);
+    }
+}

--- a/tests/Feature/Api/Project/StoreTest.php
+++ b/tests/Feature/Api/Project/StoreTest.php
@@ -1,7 +1,89 @@
 <?php
 
-test('example', function () {
-    $response = $this->get('/');
+namespace Tests\Feature\Api\Project;
 
-    $response->assertStatus(200);
-});
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class StoreTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected ?User $user = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function test_store_allows_authenticated_users(): void
+    {
+        $data = Project::factory()->make()->toArray();
+        $response = $this->postJson(route('project.store'), $data);
+        $response->assertCreated();
+    }
+
+    public function test_store_creates_a_row(): void
+    {
+        $data = Project::factory()->make()->toArray();
+        $response = $this->postJson(route('project.store'), $data);
+        $response->assertCreated();
+        $this->assertDatabaseHas('projects', ['internal_name' => $data['internal_name']]);
+    }
+
+    public function test_store_returns_created_on_success(): void
+    {
+        $data = Project::factory()->make()->toArray();
+        $response = $this->postJson(route('project.store'), $data);
+        $response->assertCreated();
+    }
+
+    public function test_store_returns_unprocessable_entity_when_input_is_invalid(): void
+    {
+        $data = ['internal_name' => '']; // Invalid: empty required field
+        $response = $this->postJson(route('project.store'), $data);
+        $response->assertUnprocessableEntity();
+    }
+
+    public function test_store_returns_the_expected_structure(): void
+    {
+        $data = Project::factory()->make()->toArray();
+        $response = $this->postJson(route('project.store'), $data);
+        $response->assertJsonStructure([
+            'data' => [
+                'id',
+                'internal_name',
+                'backward_compatibility',
+                'launch_date',
+                'is_launched',
+                'is_enabled',
+                'context_id',
+                'language_id',
+                'created_at',
+                'updated_at',
+            ]
+        ]);
+    }
+
+    public function test_store_returns_the_expected_data(): void
+    {
+        $data = Project::factory()->make()->toArray();
+        $response = $this->postJson(route('project.store'), $data);
+        $response->assertCreated();
+        $response->assertJsonPath('data.internal_name', $data['internal_name']);
+        $this->assertDatabaseHas('projects', ['internal_name' => $data['internal_name']]);
+    }
+
+    public function test_store_validates_its_input(): void
+    {
+        $invalidData = ['internal_name' => '']; // Required field empty
+        $response = $this->postJson(route('project.store'), $invalidData);
+        $response->assertUnprocessableEntity();
+        $response->assertJsonValidationErrors(['internal_name']);
+    }
+}

--- a/tests/Feature/Api/Project/UpdateTest.php
+++ b/tests/Feature/Api/Project/UpdateTest.php
@@ -1,7 +1,104 @@
 <?php
 
-test('example', function () {
-    $response = $this->get('/');
+namespace Tests\Feature\Api\Project;
 
-    $response->assertStatus(200);
-});
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class UpdateTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected ?User $user = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function test_update_allows_authenticated_users(): void
+    {
+        $project = Project::factory()->create();
+        $data = ['internal_name' => 'Updated Project Name'];
+        $response = $this->putJson(route('project.update', $project), $data);
+        $response->assertOk();
+    }
+
+    public function test_update_updates_a_row(): void
+    {
+        $project = Project::factory()->create();
+        $data = ['internal_name' => 'Updated Project Name'];
+        $response = $this->putJson(route('project.update', $project), $data);
+        $response->assertOk();
+        $this->assertDatabaseHas('projects', array_merge(['id' => $project->id], $data));
+    }
+
+    public function test_update_returns_ok_on_success(): void
+    {
+        $project = Project::factory()->create();
+        $data = ['internal_name' => 'Updated Project Name'];
+        $response = $this->putJson(route('project.update', $project), $data);
+        $response->assertOk();
+    }
+
+    public function test_update_returns_not_found_when_record_does_not_exist(): void
+    {
+        $data = ['internal_name' => 'Updated Project Name'];
+        $response = $this->putJson(route('project.update', 'non-existent-id'), $data);
+        $response->assertNotFound();
+    }
+
+    public function test_update_returns_unprocessable_entity_when_input_is_invalid(): void
+    {
+        $project = Project::factory()->create();
+        $data = ['internal_name' => '']; // Invalid: empty name
+        $response = $this->putJson(route('project.update', $project), $data);
+        $response->assertUnprocessableEntity();
+    }
+
+    public function test_update_returns_the_expected_structure(): void
+    {
+        $project = Project::factory()->create();
+        $data = ['internal_name' => 'Updated Project Name'];
+        $response = $this->putJson(route('project.update', $project), $data);
+        $response->assertJsonStructure([
+            'data' => [
+                'id',
+                'internal_name',
+                'backward_compatibility',
+                'launch_date',
+                'is_launched',
+                'is_enabled',
+                'context_id',
+                'language_id',
+                'created_at',
+                'updated_at',
+            ]
+        ]);
+    }
+
+    public function test_update_returns_the_expected_data(): void
+    {
+        $project = Project::factory()->create();
+        $data = ['internal_name' => 'Updated Project Name'];
+        $response = $this->putJson(route('project.update', $project), $data);
+        $response->assertOk();
+        $response->assertJsonPath('data.id', $project->id);
+        $response->assertJsonPath('data.internal_name', $data['internal_name']);
+        $this->assertDatabaseHas('projects', array_merge(['id' => $project->id], $data));
+    }
+
+    public function test_update_validates_its_input(): void
+    {
+        $project = Project::factory()->create();
+        $invalidData = ['internal_name' => '']; // Required field empty
+        $response = $this->putJson(route('project.update', $project), $invalidData);
+        $response->assertUnprocessableEntity();
+        $response->assertJsonValidationErrors(['internal_name']);
+    }
+}

--- a/tests/Feature/Health/Test.php
+++ b/tests/Feature/Health/Test.php
@@ -10,13 +10,13 @@ class Test extends TestCase
     public function test_the_application_is_up_and_running_as_anonymous(): void
     {
         $response = $this->getJson('/');
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 
     public function test_the_application_is_up_and_running_as_a_user(): void
     {
         $user = User::factory()->create();
         $response = $this->actingAs($user)->getJson('/');
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 }

--- a/tests/Unit/AvailableImage/FactoryTest.php
+++ b/tests/Unit/AvailableImage/FactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\AvailableImage;
 
 use App\Models\AvailableImage;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
-class AvailableImageTest extends TestCase
+class FactoryTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 
@@ -20,7 +20,7 @@ class AvailableImageTest extends TestCase
         Event::fake();
     }
 
-    public function test_available_image_factory(): void
+    public function test_factory(): void
     {
         $availableImage = AvailableImage::factory()->make();
 
@@ -29,7 +29,7 @@ class AvailableImageTest extends TestCase
         $this->assertNotEmpty($availableImage->comment);
     }
 
-    public function test_available_image_factory_creates_a_row_in_database(): void
+    public function test_factory_creates_a_row_in_database(): void
     {
         $availableImage = AvailableImage::factory()->create();
 
@@ -40,7 +40,7 @@ class AvailableImageTest extends TestCase
         ]);
     }
 
-    public function test_available_image_factory_creates_a_file(): void
+    public function test_factory_creates_a_file(): void
     {
         $availableImage = AvailableImage::factory()->create();
 

--- a/tests/Unit/Context/FactoryTest.php
+++ b/tests/Unit/Context/FactoryTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Context;
 
 use App\Models\Context;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
-class ContextTest extends TestCase
+class FactoryTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 

--- a/tests/Unit/Country/FactoryTest.php
+++ b/tests/Unit/Country/FactoryTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Country;
 
 use App\Models\Country;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
-class CountryTest extends TestCase
+class FactoryTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 

--- a/tests/Unit/Detail/FactoryTest.php
+++ b/tests/Unit/Detail/FactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Detail;
 
 use App\Models\Detail;
 use App\Models\Item;
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
-class DetailTest extends TestCase
+class FactoryTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 

--- a/tests/Unit/ImageUpload/FactoryTest.php
+++ b/tests/Unit/ImageUpload/FactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\ImageUpload;
 
 use App\Models\ImageUpload;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
-class ImageUploadTest extends TestCase
+class FactoryTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 

--- a/tests/Unit/Item/FactoryTest.php
+++ b/tests/Unit/Item/FactoryTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Item;
 
 use App\Models\Item;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
-class ItemTest extends TestCase
+class FactoryTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 

--- a/tests/Unit/Language/FactoryTest.php
+++ b/tests/Unit/Language/FactoryTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Language;
 
 use App\Models\Language;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
-class LanguageTest extends TestCase
+class FactoryTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 

--- a/tests/Unit/Partner/FactoryTest.php
+++ b/tests/Unit/Partner/FactoryTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Partner;
 
 use App\Models\Partner;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
-class PartnerTest extends TestCase
+class FactoryTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 

--- a/tests/Unit/Picture/FactoryTest.php
+++ b/tests/Unit/Picture/FactoryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit\Picture;
+
+use App\Models\Picture;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class FactoryTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    public function test_factory(): void
+    {
+        $picture = Picture::factory()->make();
+        $this->assertInstanceOf(Picture::class, $picture);
+        $this->assertNotNull($picture->internal_name);
+        $this->assertNotNull($picture->backward_compatibility);
+        $this->assertNotNull($picture->path);
+        $this->assertNotNull($picture->copyright_text);
+        $this->assertNotNull($picture->copyright_url);
+        $this->assertNotNull($picture->upload_name);
+        $this->assertNotNull($picture->upload_extension);
+        $this->assertNotNull($picture->upload_mime_type);
+        $this->assertNotNull($picture->upload_size);
+    }
+
+    public function test_factory_creates_a_row_in_database(): void
+    {
+        $picture = Picture::factory()->create();
+        $this->assertDatabaseHas('pictures', [
+            'id' => $picture->id,
+            'internal_name' => $picture->internal_name,
+            'backward_compatibility' => $picture->backward_compatibility,
+            'path' => $picture->path,
+            'copyright_text' => $picture->copyright_text,
+            'copyright_url' => $picture->copyright_url,
+            'upload_name' => $picture->upload_name,
+            'upload_extension' => $picture->upload_extension,
+            'upload_mime_type' => $picture->upload_mime_type,
+            'upload_size' => $picture->upload_size,
+        ]);
+        $this->assertDatabaseCount('pictures', 1);
+    }
+}

--- a/tests/Unit/Project/FactoryTest.php
+++ b/tests/Unit/Project/FactoryTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Unit\Project;
+
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class FactoryTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    public function test_factory(): void
+    {
+        $project = Project::factory()->make();
+        $this->assertInstanceOf(Project::class, $project);
+        $this->assertNotNull($project->id);
+        $this->assertNotNull($project->internal_name);
+        $this->assertNotNull($project->backward_compatibility);
+        $this->assertNull($project->launch_date);
+        $this->assertFalse($project->is_launched);
+        $this->assertFalse($project->is_enabled);
+        $this->assertNull($project->context_id);
+        $this->assertNull($project->language_id);
+    }
+
+    public function test_factory_with_enabled(): void
+    {
+        $project = Project::factory()->withEnabled()->make();
+        $this->assertInstanceOf(Project::class, $project);
+        $this->assertTrue($project->is_enabled);
+    }
+
+    public function test_factory_with_launched(): void
+    {
+        $project = Project::factory()->withLaunched()->make();
+        $this->assertInstanceOf(Project::class, $project);
+        $this->assertTrue($project->is_launched);
+        $this->assertNotNull($project->launch_date);
+    }
+
+    public function test_factory_with_context(): void
+    {
+        $project = Project::factory()->withContext()->make();
+        $this->assertInstanceOf(Project::class, $project);
+        $this->assertNotNull($project->context_id);
+    }
+
+    public function test_factory_with_language(): void
+    {
+        $project = Project::factory()->withLanguage()->make();
+        $this->assertInstanceOf(Project::class, $project);
+        $this->assertNotNull($project->language_id);
+    }
+
+    public function test_factory_creates_a_row_in_database(): void
+    {
+        $project = Project::factory()->create();
+        $this->assertDatabaseHas('projects', [
+            'id' => $project->id,
+            'internal_name' => $project->internal_name,
+            'backward_compatibility' => $project->backward_compatibility,
+            'launch_date' => null,
+            'is_launched' => false,
+            'is_enabled' => false,
+            'context_id' => null,
+            'language_id' => null,
+        ]);
+        $this->assertDatabaseCount('projects', 1);
+    }
+
+    public function test_factory_creates_a_row_in_database_with_enabled(): void
+    {
+        $project = Project::factory()->withEnabled()->create();
+        $this->assertDatabaseHas('projects', [
+            'id' => $project->id,
+            'is_enabled' => true,
+        ]);
+        $this->assertDatabaseCount('projects', 1);
+    }
+
+    public function test_factory_creates_a_row_in_database_with_launched(): void
+    {
+        $project = Project::factory()->withLaunched()->create();
+        $this->assertDatabaseHas('projects', [
+            'id' => $project->id,
+            'is_launched' => true,
+        ]);
+        $this->assertNotNull($project->launch_date);
+        $this->assertDatabaseCount('projects', 1);
+    }
+
+    public function test_factory_creates_a_row_in_database_with_context(): void
+    {
+        $project = Project::factory()->withContext()->create();
+        $this->assertNotNull($project->context_id);
+        $this->assertDatabaseHas('projects', [
+            'id' => $project->id,
+            'context_id' => $project->context_id,
+        ]);
+        $this->assertDatabaseCount('projects', 1);
+    }
+
+    public function test_factory_creates_a_row_in_database_with_language(): void
+    {
+        $project = Project::factory()->withLanguage()->create();
+        $this->assertNotNull($project->language_id);
+        $this->assertDatabaseHas('projects', [
+            'id' => $project->id,
+            'language_id' => $project->language_id,
+        ]);
+        $this->assertDatabaseCount('projects', 1);
+    }
+}

--- a/tests/Unit/User/FactoryTest.php
+++ b/tests/Unit/User/FactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\User;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class FactoryTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    public function test_factory(): void
+    {
+        $user = User::factory()->make();
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertNotNull($user->name);
+        $this->assertNotNull($user->email);
+        $this->assertNotNull($user->email_verified_at);
+        $this->assertNotNull($user->password);
+        $this->assertNull($user->two_factor_secret);
+        $this->assertNull($user->two_factor_recovery_codes);
+        $this->assertNotNull($user->remember_token);
+        $this->assertNull($user->profile_photo_path);
+        $this->assertNull($user->current_team_id);
+    }
+
+    public function test_factory_unverified(): void
+    {
+        $user = User::factory()->unverified()->make();
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertNull($user->email_verified_at);
+    }
+
+    public function test_factory_creates_a_row_in_database(): void
+    {
+        $user = User::factory()->create();
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'two_factor_secret' => null,
+            'two_factor_recovery_codes' => null,
+            'profile_photo_path' => null,
+            'current_team_id' => null,
+        ]);
+        $this->assertDatabaseCount('users', 1);
+    }
+
+    public function test_factory_creates_a_row_in_database_unverified(): void
+    {
+        $user = User::factory()->unverified()->create();
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'email_verified_at' => null,
+        ]);
+        $this->assertDatabaseCount('users', 1);
+    }
+}


### PR DESCRIPTION
- Move all factory tests to ModelName/FactoryTest.php structure
- Update namespaces to Tests\Unit\ModelName
- Remove incorrectly placed test files from Unit root directory
- Ensure all models have proper factory tests in subdirectories