### PR TITLE
GH Page - fix api-documentation.md is missing

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -44,6 +44,38 @@ jobs:
           if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
             echo "gh-pages branch exists, checking it out..."
             git checkout -b gh-pages origin/gh-pages
+            
+            # Always update documentation files from main branch
+            git checkout main -- docs/_config.yml docs/Gemfile docs/_layouts/ docs/_includes/ docs/index.md docs/archive.md docs/api-documentation.md docs/swagger-ui.html docs/README.md || true
+            
+            # Copy updated files to root
+            if [ -f docs/_config.yml ]; then
+              cp docs/_config.yml _config.yml
+            fi
+            if [ -f docs/Gemfile ]; then
+              cp docs/Gemfile Gemfile
+            fi
+            if [ -d docs/_layouts ]; then
+              cp -r docs/_layouts/* _layouts/
+            fi
+            if [ -d docs/_includes ]; then
+              cp -r docs/_includes/* _includes/
+            fi
+            if [ -f docs/index.md ]; then
+              cp docs/index.md index.md
+            fi
+            if [ -f docs/archive.md ]; then
+              cp docs/archive.md archive.md
+            fi
+            if [ -f docs/api-documentation.md ]; then
+              cp docs/api-documentation.md api-documentation.md
+            fi
+            if [ -f docs/swagger-ui.html ]; then
+              cp docs/swagger-ui.html swagger-ui.html
+            fi
+            if [ -f docs/README.md ]; then
+              cp docs/README.md README.md
+            fi
           else
             echo "Creating new gh-pages branch..."
             gh_pages_exists=0
@@ -51,7 +83,7 @@ jobs:
             git rm -rf . || true
             
             # Copy Jekyll configuration and layouts from main
-            git checkout main -- docs/_config.yml docs/Gemfile docs/_layouts/ docs/index.md docs/archive.md docs/api-documentation.md docs/README.md || true
+            git checkout main -- docs/_config.yml docs/Gemfile docs/_layouts/ docs/_includes/ docs/index.md docs/archive.md docs/api-documentation.md docs/swagger-ui.html docs/README.md || true
             
             # Create basic structure for gh-pages
             mkdir -p _posts _layouts _includes
@@ -72,6 +104,12 @@ jobs:
             fi
             if [ -f docs/archive.md ]; then
               cp docs/archive.md archive.md
+            fi
+            if [ -f docs/api-documentation.md ]; then
+              cp docs/api-documentation.md api-documentation.md
+            fi
+            if [ -f docs/swagger-ui.html ]; then
+              cp docs/swagger-ui.html swagger-ui.html
             fi
             if [ -f docs/README.md ]; then
               cp docs/README.md README.md


### PR DESCRIPTION
# Fix: API Documentation Page Not Accessible on GitHub Pages

## Issue Description
The `api-documentation.md` page was not accessible on the GitHub Pages site and was not visible in the navigation menu because the file was not being properly copied to the gh-pages branch.

## Root Cause
The GitHub Pages workflow had two issues:

1. **Missing file in checkout command**: `docs/swagger-ui.html` was not being checked out from main branch
2. **Missing copy commands**: `docs/api-documentation.md` and `docs/swagger-ui.html` were not being copied to the root of the gh-pages branch
3. **No updates for existing branches**: When the gh-pages branch already existed, documentation files weren't being updated from main

## Files Affected
- `.github/workflows/github-pages.yml` - Updated to properly copy documentation files
- `docs/api-documentation.md` - Existing file that wasn't being deployed
- `docs/swagger-ui.html` - Existing file that wasn't being deployed

## Changes Made

### 1. Updated Git Checkout Command
```yaml
# Before
git checkout main -- docs/_config.yml docs/Gemfile docs/_layouts/ docs/index.md docs/archive.md docs/README.md || true

# After  
git checkout main -- docs/_config.yml docs/Gemfile docs/_layouts/ docs/_includes/ docs/index.md docs/archive.md docs/api-documentation.md docs/swagger-ui.html docs/README.md || true
```

### 2. Added Missing Copy Commands
```yaml
# Added these copy operations
if [ -f docs/api-documentation.md ]; then
  cp docs/api-documentation.md api-documentation.md
fi
if [ -f docs/swagger-ui.html ]; then
  cp docs/swagger-ui.html swagger-ui.html
fi
```

### 3. Added File Updates for Existing gh-pages Branch
When the gh-pages branch already exists, the workflow now:
- Checks out updated documentation files from main branch
- Copies them to the root of gh-pages branch
- Ensures all documentation is always up-to-date

## Expected Results

After this fix:
- ✅ API Documentation page will be accessible at `/api-documentation/`
- ✅ Swagger UI will be accessible at `/swagger-ui.html`
- ✅ Navigation menu will show "API Docs" link
- ✅ All documentation files will be updated on every deployment
- ✅ Both new and existing gh-pages branches will work correctly

## Testing

To verify the fix:
1. Check that `https://metanull.github.io/inventory-app/api-documentation/` loads
2. Verify "API Docs" link appears in navigation menu
3. Confirm Swagger UI loads at `https://metanull.github.io/inventory-app/swagger-ui.html`
4. Test that API JSON loads correctly in Swagger UI

## Technical Details

The fix ensures that:
- All documentation files are consistently copied from main to gh-pages
- The workflow handles both new and existing gh-pages branches
- Jekyll can properly process the documentation files
- File paths and navigation links are correctly resolved


Fixes  #155