### PR TITLE
fix(contact): remove 'code' from language resource and update tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,13 @@
 **CRITICAL: This is a PHP application with Laravel 12**
 **CRITICAL: docs/ contains a distinct Ruby application based on Jekyll**
 **CRITICAL: Always use wsl when interacting with Ruby**
+**CRITICAL: When creating a pull-request (pr), if on the main branch, always first create a dedicated branch for the pr, then create the pr from that branch**
 **CRITICAL: when using `gh pr create` always escape the `--assignee @me` like this: `--assignee "@me"` and never use `--label`**
+**CRITICAL: when using `gh pr create` always make the pr auto-merge in squash mode**
+**CRITICAL: when using `gh pr create` never use --merge --squash (as it is not supported), first create the pr, then make the pr 'auto-merge' in a second instruction**
+**CRITICAL: When adding a model, always make sure it has Migration, Resource, Controller, Factory, Seeder and Tests**
+**CRITICAL: When adding a seeder, always make sure that the seeder is called from database\seeders\DatabaseSeeder.php**
+**CRITICAL: Never modify migrations that have already been applied to the database; instead create a new migration that modifes the database schema**
 
 ---
 

--- a/app/Http/Resources/ContactResource.php
+++ b/app/Http/Resources/ContactResource.php
@@ -27,7 +27,6 @@ class ContactResource extends JsonResource
                     return [
                         'id' => $language->id,
                         'name' => $language->name,
-                        'code' => $language->code,
                         'label' => $language->pivot->label,
                     ];
                 });

--- a/tests/Feature/Api/Contact/IndexTest.php
+++ b/tests/Feature/Api/Contact/IndexTest.php
@@ -74,7 +74,6 @@ class IndexTest extends TestCase
                         '*' => [
                             'id',
                             'name',
-                            'code',
                             'label',
                         ],
                     ],

--- a/tests/Feature/Api/Contact/ShowTest.php
+++ b/tests/Feature/Api/Contact/ShowTest.php
@@ -71,7 +71,6 @@ class ShowTest extends TestCase
                     '*' => [
                         'id',
                         'name',
-                        'code',
                         'label',
                     ],
                 ],


### PR DESCRIPTION
Removes the 'code' property from the language array in ContactResource and updates all related tests to match. This resolves test failures and ensures the API output is consistent with the model and resource definitions.