### PR TITLE
Fix image upload path error in ImageUploadListener

### DIFF
--- a/app/Listeners/ImageUploadListener.php
+++ b/app/Listeners/ImageUploadListener.php
@@ -45,11 +45,8 @@ class ImageUploadListener
 
         // Get disk and directory config for the uploaded images
         $uploadDisk = config('localstorage.uploads.images.disk');
-        $uploadDir = trim(config('localstorage.uploads.images.directory'), '/');
 
-        $path = Storage::disk($uploadDisk)->path(
-            $uploadDir.'/'.$file->name
-        );
+        $path = Storage::disk($uploadDisk)->path($file->path);
 
         $normalizer = new WhitespacePathNormalizer;
         $path = $normalizer->normalizePath($path);
@@ -96,14 +93,13 @@ class ImageUploadListener
             AvailableImageEvent::dispatch($availableImage);
         } else {
             // If the file is not an image, delete it
-            Storage::disk($uploadDisk)->delete($uploadDir.'/'.$file->name);
+            Storage::disk($uploadDisk)->delete($file->path);
 
             // Optionally, you can log an error or throw an exception
             Log::error('Uploaded file was not a valid image.', [
                 'disk' => $uploadDisk,
-                'directory' => $uploadDir,
                 'name' => $file->name,
-                'path' => $path,
+                'path' => $file->path,
             ]);
         }
     }

--- a/database/factories/ImageUploadFactory.php
+++ b/database/factories/ImageUploadFactory.php
@@ -25,7 +25,7 @@ class ImageUploadFactory extends Factory
         $image_directory = dirname($image);
 
         return [
-            'path' => $image_directory,
+            'path' => $image,
             'name' => $image_name,
             'extension' => 'jpg',
             'mime_type' => Storage::disk($disk)->mimeType($image),

--- a/tests/Feature/Event/AvailableImage/AvailableImageTest.php
+++ b/tests/Feature/Event/AvailableImage/AvailableImageTest.php
@@ -47,9 +47,8 @@ class AvailableImageTest extends TestCase
         $imageUpload = ImageUpload::factory()->create();
         $imageUploadEvent = new ImageUploadEvent($imageUpload);
         $imageUploadListener = new ImageUploadListener;
-        $imageUploadRelativePath = $imageUpload->path.'/'.$imageUpload->name;
         $imageUploadListener->handle($imageUploadEvent);
-        $this->assertFileExists(Storage::disk('local')->path($imageUploadRelativePath));
+        $this->assertFileExists(Storage::disk('local')->path($imageUpload->path));
     }
 
     public function test_availableimagelistener_creates_an_image_on_the_public_disk(): void
@@ -59,7 +58,7 @@ class AvailableImageTest extends TestCase
 
         // Dispatch the AvailableImageEvent, using the fake uploaded image's path as source
         $availableImage = AvailableImage::factory()->create([
-            'path' => $imageUpload->path.'/'.$imageUpload->name,
+            'path' => $imageUpload->path,
             'id' => $imageUpload->id,
         ]);
         $availableImageEvent = new AvailableImageEvent($availableImage);
@@ -79,7 +78,7 @@ class AvailableImageTest extends TestCase
 
         // Dispatch the AvailableImageEvent, using the fake uploaded image's path as source
         $availableImage = AvailableImage::factory()->create([
-            'path' => $imageUpload->path.'/'.$imageUpload->name,
+            'path' => $imageUpload->path,
             'id' => $imageUpload->id,
         ]);
         $availableImageEvent = new AvailableImageEvent($availableImage);
@@ -101,7 +100,7 @@ class AvailableImageTest extends TestCase
 
         // Dispatch the AvailableImageEvent, using the fake uploaded image's path as source
         $availableImage = AvailableImage::factory()->create([
-            'path' => $imageUpload->path.'/'.$imageUpload->name,
+            'path' => $imageUpload->path,
             'id' => $imageUpload->id,
         ]);
         $availableImageEvent = new AvailableImageEvent($availableImage);
@@ -111,6 +110,6 @@ class AvailableImageTest extends TestCase
         // The Listener should have created a new image in the public disk, and have updated
         // the path of the AvailableImage model to point to the new image in the public disk.
         $availableImage->refresh();
-        $this->assertFileDoesNotExist(Storage::disk('local')->path($imageUpload->path.'/'.$imageUpload->name));
+        $this->assertFileDoesNotExist(Storage::disk('local')->path($imageUpload->path));
     }
 }

--- a/tests/Unit/ImageUpload/FactoryTest.php
+++ b/tests/Unit/ImageUpload/FactoryTest.php
@@ -50,6 +50,6 @@ class FactoryTest extends TestCase
     {
         $imageUpload = ImageUpload::factory()->create();
 
-        $this->assertFileExists(Storage::disk('local')->path($imageUpload->path.'/'.$imageUpload->name));
+        $this->assertFileExists(Storage::disk('local')->path($imageUpload->path));
     }
 }


### PR DESCRIPTION
## Problem

The ImageUploadController.store method was failing with a 500 Internal Server Error:
`
exif_imagetype(E:/inventory/inventory-app/storage/app/private/image_uploads/Skull.jpg): Failed to open stream: No such file or directory
`

## Root Cause

The issue was in the ImageUploadListener.php where it was incorrectly constructing the file path by using $file->name (original filename) instead of $file->path (actual stored path with hashed filename).

When Laravel stores uploaded files using $file->store(), it:
1. Generates a hashed filename for security
2. Returns the full relative path including the hashed filename
3. Stores this path in the path field of the ImageUpload model

However, the listener was trying to reconstruct the path using the original filename, which doesn't exist on disk.

## Solution

- **ImageUploadListener.php**: Changed to use $file->path directly instead of concatenating directory + original filename
- **ImageUploadFactory.php**: Fixed to store the complete file path in the path field instead of just the directory
- **Updated tests**: Modified all test files to work with the corrected path structure

## Changes

1. **app/Listeners/ImageUploadListener.php**:
   - Use Storage::disk()->path(->path) instead of manually constructing path
   - Fix file deletion to use the correct stored path

2. **database/factories/ImageUploadFactory.php**:
   - Store complete file path in path field instead of just directory

3. **tests/Unit/ImageUpload/FactoryTest.php**:
   - Update test to use $imageUpload->path directly

4. **tests/Feature/Event/AvailableImage/AvailableImageTest.php**:
   - Update all test methods to use correct path structure

## Testing

✅ All 895 tests pass
✅ Code formatting (Pint) passes
✅ No lint errors

## Compliance

This fix follows Laravel 12 best practices:
- Uses proper Laravel Storage facade methods
- Maintains consistency with how file uploads are handled in the controller
- Preserves security by keeping hashed filenames