### PR TITLE
Enable manual trigger for npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,11 +1,13 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
-name: Node.js Package
+name: Publishing @metanull/inventory-app-api-client
 
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    # Allow manual triggering
 
 jobs:
   build:


### PR DESCRIPTION
# Enable manual trigger for npm publish workflow

This PR updates the GitHub Actions workflow for publishing the npm package `@metanull/inventory-app-api-client`:

- Adds support for manual triggering via `workflow_dispatch`.
- Maintains the release trigger for backward compatibility.
- No changes to package logic or publishing steps.

This allows maintainers to publish the npm package to GitHub Packages without requiring a release event.

**Workflow name:** Publishing @metanull/inventory-app-api-client
**File changed:** .github/workflows/npm-publish-github-packages.yml

See CHANGELOG.md for details.
