### PR TITLE
Chore: Merge Vite ecosystem updates (PRs #220 and #223)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "stylelint": "^16.21.1",
                 "stylelint-config-standard": "^38.0.0",
                 "tailwindcss": "^4.1.11",
-                "vite": "^6.3.5"
+                "vite": "^7.0.4"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -5115,23 +5115,23 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "6.3.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-            "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.4.tgz",
+            "integrity": "sha512-SkaSguuS7nnmV7mfJ8l81JGBFV7Gvzp8IzgE8A8t23+AxuNX61Q5H1Tpz5efduSN7NHC8nQXD3sKQKZAu5mNEA==",
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
-                "fdir": "^6.4.4",
+                "fdir": "^6.4.6",
                 "picomatch": "^4.0.2",
-                "postcss": "^8.5.3",
-                "rollup": "^4.34.9",
-                "tinyglobby": "^0.2.13"
+                "postcss": "^8.5.6",
+                "rollup": "^4.40.0",
+                "tinyglobby": "^0.2.14"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -5140,14 +5140,14 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@types/node": "^20.19.0 || >=22.12.0",
                 "jiti": ">=1.21.0",
-                "less": "*",
+                "less": "^4.0.0",
                 "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
                 "terser": "^5.16.0",
                 "tsx": "^4.8.1",
                 "yaml": "^2.4.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@tailwindcss/typography": "^0.5.16",
                 "axios": "^1.10.0",
                 "concurrently": "^9.2.0",
-                "laravel-vite-plugin": "^1.3.0",
+                "laravel-vite-plugin": "^2.0.0",
                 "postcss": "^8.5.6",
                 "prettier": "^3.6.2",
                 "stylelint": "^16.21.1",
@@ -3358,9 +3358,9 @@
             "license": "MIT"
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-1.3.0.tgz",
-            "integrity": "sha512-P5qyG56YbYxM8OuYmK2OkhcKe0AksNVJUjq9LUZ5tOekU9fBn9LujYyctI4t9XoLjuMvHJXXpCoPntY1oKltuA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-2.0.0.tgz",
+            "integrity": "sha512-pnaKHInJgiWpG/g+LmaISHl7D/1s5wnOXnrGiBdt4NOs+tYZRw0v/ZANELGX2/dGgHyEzO+iZ6x4idpoK04z/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3371,10 +3371,10 @@
                 "clean-orphaned-assets": "bin/clean.js"
             },
             "engines": {
-                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^5.0.0 || ^6.0.0"
+                "vite": "^7.0.0"
             }
         },
         "node_modules/lightningcss": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "stylelint": "^16.21.1",
         "stylelint-config-standard": "^38.0.0",
         "tailwindcss": "^4.1.11",
-        "vite": "^6.3.5"
+        "vite": "^7.0.4"
     },
     "dependencies": {
         "@tailwindcss/postcss": "^4.1.11",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "@tailwindcss/typography": "^0.5.16",
         "axios": "^1.10.0",
         "concurrently": "^9.2.0",
-        "laravel-vite-plugin": "^1.3.0",
+        "laravel-vite-plugin": "^2.0.0",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
         "stylelint": "^16.21.1",


### PR DESCRIPTION
# Chore: Merge Vite ecosystem updates (PRs #220 and #223)

## Summary
This PR merges two related dependency updates from Dependabot that need to be applied together:
- **PR #220**: Bump laravel-vite-plugin from 1.3.0 to 2.0.0
- **PR #223**: Bump vite from 6.3.5 to 7.0.4

## Changes
- Updated `vite` from `6.3.5` to `7.0.4`
- Updated `laravel-vite-plugin` from `1.3.0` to `2.0.0`
- Updated `package-lock.json` with resolved dependencies

## Testing
✅ All CI checks pass:
- Dependencies installed successfully
- Production build completed without errors
- Security audit passed (0 vulnerabilities)
- Code linting passed (544 files)
- Test suite passed (1329 tests, 5478 assertions)
- Development server running correctly

## Verification
Both updates are compatible and work together correctly. The development and production environments function as expected with the new versions.

## Related PRs
- Closes #220
- Closes #223