### PR TITLE
Update dependabot.yml to group PRs by dependency type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,16 +12,32 @@ updates:
     labels:
       - "php"
       - "dependencies"
-  - package-ecosystem: "npm" 
+    groups:
+      laravel-dev-dependencies:
+        dependency-type: "development"
+      laravel-prod-dependencies:
+        dependency-type: "production"
+
+  - package-ecosystem: "npm"
     directory: "/" # Look for `package.json` and `lock` files in the `root` directory
     schedule:
       interval: "weekly" # Check the npm registry for updates every week
     labels:
       - "npm"
       - "dependencies"
+    groups:
+      node-dev-dependencies:
+        dependency-type: "development"
+      node-prod-dependencies:
+        dependency-type: "production"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     labels:
       - "dependencies"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - ".*"


### PR DESCRIPTION
# Update dependabot.yml to group PRs by dependency type

This PR updates `.github/dependabot.yml` to enable grouping of Dependabot pull requests for Composer, npm, and GitHub Actions dependencies. The new configuration introduces the following improvements:

- **Composer**: Adds `groups` for `laravel-dev-dependencies` and `laravel-prod-dependencies`, grouping PRs by development and production dependencies.
- **npm**: Adds `groups` for `node-dev-dependencies` and `node-prod-dependencies`, grouping PRs by development and production dependencies.
- **GitHub Actions**: Adds a `github-actions-dependencies` group to combine all workflow dependency updates into a single PR.

**Benefits:**
- Reduces PR noise by consolidating related updates.
- Makes it easier to review and merge dependency updates in logical batches.
- Aligns with best practices for dependency management in multi-ecosystem projects.

No other changes are included in this PR. See the updated `.github/dependabot.yml` for details.
