### PR TITLE
Fix PowerShell environment variable reference in deploy-mwnf-svr workflow

### DIFF
--- a/.github/workflows/deploy-mwnf-svr.yml
+++ b/.github/workflows/deploy-mwnf-svr.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check required environment variables
         run: |
           $required = @('PHP_PATH','COMPOSER_PATH','NODE_PATH','NPM_PATH','MARIADB_PATH','ENV_PATH')
-          $missing = $required | Where-Object { -not $env:$_ }
+          $missing = $required | Where-Object { -not ${env:$_} }
           if ($missing.Count -gt 0) {
             Write-Error "Missing required environment variables: $($missing -join ', ')"
             exit 1


### PR DESCRIPTION
## Fix PowerShell environment variable reference in deploy-mwnf-svr workflow

- Updated `.github/workflows/deploy-mwnf-svr.yml` to use `${env:$_}` for required environment variable check.
- Ensures compatibility and error-free deployment automation on Windows self-hosted runners.
- No changes to application code or configuration files.
- This update only affects the deployment workflow for the `mwnf-svr` environment.

---

**Why:**
- Fixes workflow execution errors due to incorrect PowerShell environment variable reference.
- Aligns with PowerShell and GitHub Actions best practices.

**Impact:**
- Deployment workflow for `mwnf-svr` is now robust and reliable.
- No impact on production or other environments.
- No breaking changes.

---

Closes # (if applicable)
