### PR TITLE
Fix Vite build output directory for Laravel

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -32,5 +32,6 @@ export default defineConfig({
     build: {
         target: 'esnext',
         sourcemap: true,
+        outDir: 'public/build', // Ensures assets and manifest are placed correctly
     },
 });


### PR DESCRIPTION
## Fix Vite build output directory for Laravel

- Set `outDir: 'public/build'` in `vite.config.js` to ensure manifest and assets are generated in the correct location for Laravel production.
- Resolves issue with manifest paths referencing CI workspace instead of project-relative paths.

---

Auto-merge requested by admin for this hotfix.
