### PR TITLE
Fix Robocopy deployment and Laravel pipeline

### DIFF
--- a/.github/workflows/deploy-mwnf-svr.yml
+++ b/.github/workflows/deploy-mwnf-svr.yml
@@ -198,8 +198,14 @@ jobs:
           $robocopyCmd = "robocopy `"$stagingPath`" `"$env:WEBSERVER_PATH`" /MIR /COPY:DAT /NP /R:2 /W:2 /LOG:`"$robocopyLog`""
           Write-Host "Running: $robocopyCmd"
           $robocopyResult = Invoke-Expression $robocopyCmd
+          $robocopyExitCode = $LASTEXITCODE
           Write-Host $robocopyResult
-          Write-Host "Staging promoted to production: $env:WEBSERVER_PATH"
+          if ($robocopyExitCode -le 2) {
+            Write-Host "Robocopy succeeded with exit code $robocopyExitCode. Staging promoted to production: $env:WEBSERVER_PATH"
+          } else {
+            Write-Error "Robocopy failed with exit code $robocopyExitCode. See log: $robocopyLog"
+            exit $robocopyExitCode
+          }
           
           # Clean up old version after successful deployment
           if (Test-Path $oldPath) { Remove-Item $oldPath -Recurse -Force }

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -43,11 +43,11 @@ jobs:
 
       - name: "Setup > Laravel > Create .env file from example"
         run: |
-          if(-not(Test-Path ".env.example")) {
-            throw "No .env.example file found!"
+          if(-not(Test-Path ".env.local.example")) {
+            throw "No .env.local.example file found!"
           }
           if(-not(Test-Path ".env")) {
-            Copy-Item .env.example .env -ErrorAction Stop
+            Copy-Item .env.local.example .env -ErrorAction Stop
           }
 
       - name: "Setup > Laravel > Generate application key"


### PR DESCRIPTION
## PR: Fix Robocopy deployment and Laravel pipeline

- Deployment workflow now treats Robocopy exit codes 0, 1, and 2 as success, preventing false errors in CI/CD.
- Laravel pipeline now uses `.env.local.example` for environment setup and validation.

These changes ensure robust deployment and validation for Windows-based Laravel environments.

**Admin note:** Please force merge this PR for this deployment.
