### PR TITLE
Fix Vite manifest paths in CI environment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,8 @@ import vue from '@vitejs/plugin-vue';
 import { fileURLToPath, URL } from 'node:url';
 
 export default defineConfig({
+    root: './', // Explicitly set root to current directory
+    base: './', // Ensure relative paths for assets
     plugins: [
         vue(),
         laravel({
@@ -30,16 +32,16 @@ export default defineConfig({
         },
     },
     build: {
-            target: 'esnext',
-            sourcemap: true,
-            outDir: 'public/build', // Ensures assets and manifest are placed correctly
-            manifest: 'manifest.json', // Place manifest directly in build dir, not .vite subdir
-            rollupOptions: {
-                input: [
-                    'resources/js/app.ts',
-                    'resources/css/app.css',
-                ],
-            },
-            assetsInlineLimit: 0,
+        target: 'esnext',
+        sourcemap: true,
+        outDir: 'public/build', // Ensures assets and manifest are placed correctly
+        manifest: 'manifest.json', // Place manifest directly in build dir, not .vite subdir
+        rollupOptions: {
+            input: [
+                'resources/js/app.ts',
+                'resources/css/app.css',
+            ],
         },
+        assetsInlineLimit: 0,
+    },
 });


### PR DESCRIPTION
# Fix Vite manifest paths in CI environment

## Problem
The Vite manifest.json generated during GitHub Actions builds contains absolute paths instead of relative paths, causing issues with asset resolution. 

**CI Environment (broken):**
```json
{
  "../../../../actions-runner-win-x64-2.328.0/_work/inventory-app/inventory-app/resources/css/app.css": {
    "file": "assets/app-YzGMk8if.css",
    "src": "../../../../actions-runner-win-x64-2.328.0/_work/inventory-app/inventory-app/resources/css/app.css",
    ...
  }
}
```

**Local Environment (working):**
```json
{
  "resources/css/app.css": {
    "file": "assets/app-YzGMk8if.css", 
    "src": "resources/css/app.css",
    ...
  }
}
```

## Solution
Added explicit Vite configuration options to ensure consistent path resolution:
- `root: './'` - Explicitly set the root directory 
- `base: './'` - Force relative paths for assets

## Testing
- ✅ Local build continues to generate correct relative paths
- ✅ All tests pass
- ⏳ CI environment will be tested via this PR

This fix ensures the manifest.json contains consistent relative paths regardless of the build environment.
