### PR TITLE
Fix Vite manifest path normalization in CI/CD pipeline

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -24,12 +24,35 @@ export default defineConfig({
                     
                     for (const [key, value] of Object.entries(manifest)) {
                         // Normalize the key to be relative to project root
-                        const normalizedKey = key.replace(/^.*[\\\/]resources[\\\/]/, 'resources/');
-                        // Normalize the src path as well
-                        if (value.src) {
-                            value.src = value.src.replace(/^.*[\\\/]resources[\\\/]/, 'resources/');
+                        // Handle both Windows and Unix paths, and extract everything from 'resources/' onwards
+                        let normalizedKey = key;
+                        const resourcesIndex = key.lastIndexOf('resources/');
+                        if (resourcesIndex !== -1) {
+                            normalizedKey = key.substring(resourcesIndex);
+                        } else {
+                            // Fallback for Windows paths with backslashes
+                            const resourcesIndexWin = key.lastIndexOf('resources\\');
+                            if (resourcesIndexWin !== -1) {
+                                normalizedKey = key.substring(resourcesIndexWin).replace(/\\/g, '/');
+                            }
                         }
-                        normalizedManifest[normalizedKey] = value;
+                        
+                        // Normalize the src path as well
+                        const normalizedValue = { ...value };
+                        if (normalizedValue.src) {
+                            const srcResourcesIndex = normalizedValue.src.lastIndexOf('resources/');
+                            if (srcResourcesIndex !== -1) {
+                                normalizedValue.src = normalizedValue.src.substring(srcResourcesIndex);
+                            } else {
+                                // Fallback for Windows paths with backslashes
+                                const srcResourcesIndexWin = normalizedValue.src.lastIndexOf('resources\\');
+                                if (srcResourcesIndexWin !== -1) {
+                                    normalizedValue.src = normalizedValue.src.substring(srcResourcesIndexWin).replace(/\\/g, '/');
+                                }
+                            }
+                        }
+                        
+                        normalizedManifest[normalizedKey] = normalizedValue;
                     }
                     
                     bundle[manifestKey].source = JSON.stringify(normalizedManifest, null, 2);


### PR DESCRIPTION
# Fix Vite manifest path normalization in CI/CD pipeline

## Problem
The Vite manifest.json file was generating absolute paths in the GitHub Actions pipeline instead of relative paths, causing issues with asset loading. The generated manifest contained paths like:
```json
{
  "../../../../actions-runner-win-x64-2.328.0/_work/inventory-app/inventory-app/resources/css/app.css": {
    "file": "assets/app-YzGMk8if.css",
    "src": "../../../../actions-runner-win-x64-2.328.0/_work/inventory-app/inventory-app/resources/css/app.css",
    "isEntry": true
  }
}
```

## Solution
Enhanced the `normalize-manifest-paths` plugin in `vite.config.js` to properly handle absolute paths from CI/CD environments:

### Key improvements:
- **Better path detection**: Uses `lastIndexOf('resources/')` to find the last occurrence of the resources directory
- **Cross-platform support**: Handles both Unix forward slashes and Windows backslashes
- **Robust extraction**: Uses `substring()` to extract everything from 'resources/' onwards
- **Complete normalization**: Normalizes both manifest keys and `src` properties
- **Path consistency**: Converts Windows backslashes to forward slashes

## Result
Manifest paths are now properly normalized to:
```json
{
  "resources/css/app.css": {
    "file": "assets/app-YzGMk8if.css",
    "src": "resources/css/app.css",
    "isEntry": true
  },
  "resources/js/app.ts": {
    "file": "assets/app-9efYBimQ.js",
    "src": "resources/js/app.ts",
    "isEntry": true
  }
}
```

This ensures consistent asset loading across local development and CI/CD environments.

## Testing
- ✅ Local build generates correct manifest paths
- ✅ Enhanced plugin handles various path formats
- ✅ Cross-platform compatibility maintained
