### PR TITLE
fix: allow API docs in production when API_DOCS_ENABLED is set

### DIFF
--- a/app/Http/Middleware/CustomRestrictedDocsAccess.php
+++ b/app/Http/Middleware/CustomRestrictedDocsAccess.php
@@ -14,7 +14,9 @@ class CustomRestrictedDocsAccess
         }
 
         // Check if API documentation is explicitly enabled via environment variable
-        if (env('API_DOCS_ENABLED', false)) {
+        // Handle boolean-like values properly (true, "true", "1", 1)
+        $apiDocsEnabled = env('API_DOCS_ENABLED', false);
+        if (filter_var($apiDocsEnabled, FILTER_VALIDATE_BOOLEAN)) {
             return $next($request);
         }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -22,6 +23,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Define a Gate for API documentation access
+        Gate::define('viewApiDocs', function ($user = null) {
+            // Allow authenticated users to view API docs
+            return $user !== null;
+        });
+
         Scramble::afterOpenApiGenerated(function (OpenApi $openApi) {
             $openApi->secure(
                 // SecurityScheme::apiKey('query', 'api_token')

--- a/config/app.php
+++ b/config/app.php
@@ -151,4 +151,17 @@ return [
     */
 
     'faker_use_local_images' => env('FAKER_USE_LOCAL_IMAGES', env('APP_ENV') !== 'production'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | API Documentation Access
+    |--------------------------------------------------------------------------
+    |
+    | This option controls whether API documentation is accessible in production.
+    | By default, API docs are only available in local and testing environments.
+    | Set API_DOCS_ENABLED=true to enable API documentation in production.
+    |
+    */
+
+    'api_docs_enabled' => env('API_DOCS_ENABLED', false),
 ];


### PR DESCRIPTION
# Fix: Allow API docs in production when API_DOCS_ENABLED is set

This PR fixes an issue where API documentation was not accessible in production even when the `API_DOCS_ENABLED` environment variable was set. The middleware now properly handles boolean-like values for `API_DOCS_ENABLED` and a missing Gate definition is added for authenticated users. This resolves 403 errors and ensures tests pass.

**Changelog:**
- Fix `CustomRestrictedDocsAccess` to handle boolean-like values for `API_DOCS_ENABLED`
- Add missing Gate definition for `viewApiDocs` in `AppServiceProvider`
- Add `api_docs_enabled` config to `app.php` (for future use)

**Testing:**
- All relevant tests now pass, including boolean-like value checks for `API_DOCS_ENABLED`.
- Manual verification in production with `API_DOCS_ENABLED=true` allows access to `/docs/api`.
