### PR TITLE
Fix Jekyll documentation navigation structure and nav_order conflicts

### DIFF
--- a/.github/instructions/vue.instructions.md
+++ b/.github/instructions/vue.instructions.md
@@ -1,9 +1,398 @@
 ---
 applyTo: "\**\*.vue"
 ---
-# Project development practices for Vue.js
 
-- Strictly comply with vue.js coding standard.
-- Strictly comply with node.js coding standard.
-- Organize code in a logical and consistent directory structure.
-- Keep code simple and focused on a single behavior.
+# Vue.js Code Generation and Review Standards
+
+## General Principles
+- Strictly comply with Vue.js and Node.js coding standards.
+- Organize code in a logical, consistent directory structure.
+- Keep code simple, focused, and single-responsibility.
+- All code must pass ESLint and Prettier checks; no unused variables or imports.
+
+## Component Structure
+- Always use `<script setup lang="ts">` for all Vue Single File Components (SFCs).
+- Use `<template>` for markup, `<style scoped>` for styles.
+- Prefer the Composition API (`ref`, `computed`, `watch`, etc.) for all logic.
+- Type all props, emits, and state; never use the `any` type.
+
+## Component Reuse
+- Extract repeated UI patterns into shared components.
+- Use slots and props for flexibility and composability.
+- Reference and document all shared components in `docs/frontend/components/`.
+
+### Layout Components
+- **ListView**: Standard list/table layout (`resources/js/components/layout/list/ListView.vue`)
+- **DetailView**: Standard detail/form layout (`resources/js/components/layout/detail/DetailView.vue`)
+- **AppHeader**: Application navigation (`resources/js/components/layout/app/AppHeader.vue`)
+- **AppFooter**: Application footer (`resources/js/components/layout/app/AppFooter.vue`)
+
+### Card Components (Home/Dashboard)
+- **Card**: Base card component (`resources/js/components/format/card/Card.vue`)
+- **NavigationCard**: Navigation with call-to-action button
+- **StatusCard**: Interactive status toggle with indicators
+- **InformationCard**: Static information display with pill badges
+
+### Form Components
+- **FormInput**: Styled input with validation support
+- **GenericDropdown**: Configurable dropdown with search, priority sorting, default options
+- **Toggle**: Boolean toggle switch (regular and compact variants)
+
+### Display Components
+- **DisplayText**: Consistent text display with size variants
+- **InternalName**: Resource name with icon and legacy ID support (regular and small variants)
+- **DateDisplay**: Formatted date/time display
+- **Title**: Flexible heading component with variants (page, section, card, system, empty)
+- **Uuid**: Formatted UUID display with copy functionality
+
+### Table Components
+- **TableElement**: Base table wrapper
+- **TableHeader**: Sortable column headers
+- **TableRow**: Table row wrapper
+- **TableCell**: Table cell with variant support
+
+### Description List Components (Detail Pages)
+- **DescriptionList**: Container for structured data
+- **DescriptionRow**: Individual data row with alternating colors
+- **DescriptionTerm**: Field labels
+- **DescriptionDetail**: Field values
+
+## Page Patterns
+
+### Dashboard/Home Page Pattern (`Home.vue`)
+- Use `<Title variant="page">` for the main page title with description
+- Organize content in themed sections that **MIRROR the navigation menu structure exactly**
+- Use grid layouts: `grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6`
+- Use section headers with borders: `text-xl font-semibold text-gray-900 mb-4 border-b border-gray-200 pb-2`
+
+#### Section Structure (MUST match AppHeader.vue navigation)
+**1. Inventory Section:** Items, Partners
+**2. Reference Data Section:** Languages, Countries, Contexts, Projects  
+**3. Tools Section:** System Status, Additional Features
+
+#### Navigation Tiles
+- Use `<NavigationCard>` for each entity with:
+  - `title`: Entity name (e.g., "Items", "Contexts")
+  - `description`: Clear description of the entity's purpose
+  - `main-color`: **Entity-specific color** (see Color Standards below)
+  - `button-text`: "Manage [EntityName]"
+  - `button-route`: Route to entity list page
+  - Icon slot with entity's Heroicon
+
+#### Home.vue ↔ Navigation Menu Consistency
+- Each entity that has a tile in Home.vue **MUST** have a corresponding menu item in AppHeader.vue
+- Both must use the **same icon** and **same color**
+- Section groupings in Home.vue must match dropdown groupings in navigation menu
+- Order of items within sections should be consistent between both
+
+### List Page Pattern (`Items.vue`, `Countries.vue`, `Contexts.vue`, etc.)
+- Use `<ListView>` component as the main wrapper
+- Required props: `title`, `description`, `isEmpty`, `emptyTitle`, `emptyMessage`
+- Optional props: `addButtonRoute`, `addButtonLabel`, `color`
+- Use slots for: `icon`, `filters`, `search`, `headers`, `rows`, `modals`
+
+#### Required Features for List Pages
+**1. Filtering System:**
+```typescript
+const filterMode = ref<'all' | 'specific_filter'>('all')
+const filteredResources = computed(() => {
+  let filtered = resources.value
+  // Apply filter mode logic
+  if (filterMode.value === 'specific_filter') {
+    filtered = filtered.filter(resource => resource.some_property)
+  }
+  // Apply search and sorting
+  return filtered
+})
+```
+
+**2. Sorting System:**
+```typescript
+const sortKey = ref<string>('internal_name')
+const sortDirection = ref<'asc' | 'desc'>('asc')
+
+const handleSort = (key: string) => {
+  if (sortKey.value === key) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortDirection.value = 'asc'
+  }
+}
+```
+
+**3. Search System:**
+```typescript
+const searchQuery = ref('')
+// Apply search in computed filteredResources
+if (searchQuery.value.trim()) {
+  const query = searchQuery.value.toLowerCase()
+  filtered = filtered.filter(resource =>
+    resource.internal_name.toLowerCase().includes(query) ||
+    (resource.backward_compatibility && resource.backward_compatibility.toLowerCase().includes(query))
+  )
+}
+```
+
+**4. Action Buttons (MANDATORY in every row):**
+- `<ViewButton @click="router.push(\`/resources/\${resource.id}\`)" />`
+- `<EditButton @click="router.push(\`/resources/\${resource.id}?edit=true\`)" />`
+- `<DeleteButton @click="handleDeleteResource(resource)" />`
+- Wrap action buttons in `<div class="flex space-x-2" @click.stop>`
+
+**5. Status Toggles (where applicable):**
+- Use `<Toggle small>` component for inline status changes
+- Common patterns: enabled/disabled, launched/not launched, default/not default
+- Wrap in `<div @click.stop>` to prevent row click navigation
+- Example: `@toggle="updateResourceStatus(resource, 'is_enabled', !resource.is_enabled)"`
+
+**6. Row Click Navigation:**
+- Table rows should be clickable: `class="cursor-pointer hover:bg-[color]-50 transition"`
+- Use `@click="openResourceDetail(resource.id)"` for navigation
+- Prevent event bubbling on action buttons and toggles with `@click.stop`
+
+**7. Filter Buttons:**
+- Use `<FilterButton>` with consistent labeling and count display
+- Common patterns: All, Enabled, Disabled, Default, etc.
+- Show counts: `:count="enabledResources.length"`
+- Use appropriate variants: `variant="primary"`, `variant="info"`, etc.
+
+**8. Store Integration:**
+- Fetch resources in `onMounted` with cache-first approach
+- Handle delete with confirmation dialogs
+- Use loading and error stores for consistent UX
+
+### Detail Page Pattern (`ItemDetail.vue`, `CountryDetail.vue`, `ContextDetail.vue`)
+- Use `<DetailView>` component as the main wrapper
+- Required props: `storeLoading`, `resource`, `mode`, `backLink`, `informationTitle`
+- Optional props: `saveDisabled`, `hasUnsavedChanges`, `statusCards`, `createTitle`, `informationDescription`
+- Use slots for: `resource-icon`, `information`
+- Information section uses `<DescriptionList>`, `<DescriptionRow>`, `<DescriptionTerm>`, `<DescriptionDetail>`
+- Alternate row variants: `variant="gray"` and `variant="white"`
+- Form fields use: `<FormInput>`, `<GenericDropdown>` for editing; `<DisplayText>`, `<DateDisplay>` for viewing
+
+#### Mode Handling (CRITICAL - Must be consistent across ALL detail pages)
+**Three Modes: `view`, `edit`, `create`**
+
+**1. Mode State Management:**
+```typescript
+type Mode = 'view' | 'edit' | 'create'
+const mode = ref<Mode>('view') // Single source of truth
+```
+
+**2. Mode Functions (Required in every detail page):**
+```typescript
+const enterCreateMode = () => {
+  mode.value = 'create'
+  editForm.value = getDefaultFormValues()
+}
+
+const enterEditMode = () => {
+  if (!resource.value) return
+  mode.value = 'edit'
+  editForm.value = getFormValuesFromResource()
+}
+
+const enterViewMode = () => {
+  mode.value = 'view'
+  editForm.value = getDefaultFormValues() // Clear form data
+}
+```
+
+**3. Mode-Based Information Description:**
+```typescript
+const informationDescription = computed(() => {
+  switch (mode.value) {
+    case 'create': return 'Create a new [resource] in your inventory system.'
+    case 'edit': return 'Edit detailed information about this [resource].'
+    default: return 'Detailed information about this [resource].'
+  }
+})
+```
+
+**4. Unsaved Changes Detection:**
+- Must compare form values with original/default values based on mode
+- Must watch for changes and sync with `useCancelChangesConfirmationStore`
+- Must handle navigation guards with `onBeforeRouteLeave`
+
+**5. Component Initialization:**
+```typescript
+const initializeComponent = async () => {
+  const resourceId = route.params.id as string
+  const isCreateRoute = route.name === '[resource]-new' || route.path === '/[resources]/new'
+
+  if (isCreateRoute) {
+    store.clearCurrentResource()
+    enterCreateMode()
+  } else if (resourceId) {
+    await fetchResource()
+    if (route.query.edit === 'true' && resource.value) {
+      enterEditMode()
+    } else {
+      enterViewMode()
+    }
+  }
+}
+```
+
+#### Required Features for Detail Pages
+**1. Pinia Store Integration:**
+- Import and use appropriate store (e.g., `useItemStore`, `useContextStore`)
+- Import related stores for dropdown options (e.g., `usePartnerStore`, `useProjectStore`)
+- Use `store.loading` for loading states
+- Use `store.currentResource` for current resource data
+
+**2. Dropdown Options with Computed Properties:**
+```typescript
+const relatedOptions = computed(() =>
+  (relatedStore.items || []).map(item => ({
+    id: item.id,
+    internal_name: item.internal_name,
+    is_default: false,
+  }))
+)
+```
+
+**3. Status Cards Configuration (where applicable):**
+- Use `computed` property for dynamic status card configuration
+- Handle status toggles with async functions
+- Common patterns: enabled/disabled, launched/not launched, default/not default
+
+**4. Form Data Management:**
+- Define TypeScript interface for form data
+- Implement `getDefaultFormValues()` and `getFormValuesFromResource()` functions
+- Use reactive `editForm` ref with proper typing
+
+**5. Error Handling and Loading States:**
+- Use `useLoadingOverlayStore` for loading states
+- Use `useErrorDisplayStore` for success/error messages
+- Use `useDeleteConfirmationStore` for delete confirmations
+- Use `useCancelChangesConfirmationStore` for unsaved changes
+
+**6. Navigation and Route Handling:**
+- Proper back link configuration with icon and color
+- Handle query parameters (e.g., `?edit=true`)
+- Navigation guards for unsaved changes protection
+
+## TypeScript
+- All components must use TypeScript.
+- No use of `any` type; always provide explicit types for props, emits, and state.
+
+## Testing
+- All components and pages must have unit tests in `components/__tests__/` or the appropriate test directory.
+- Follow the documented testing guidelines in `docs/frontend/guidelines/testing.md`.
+
+## Linting & Formatting
+- Code must pass ESLint and Prettier checks before commit.
+- No unused variables, imports, or code.
+
+## Documentation
+- Every new or changed component/page must be documented in `docs/frontend/components/` or `docs/frontend/guidelines/`.
+- Documentation must include usage examples, prop tables, and clear explanations of component purpose and patterns.
+
+## State Management and Reactivity
+- Use Vue 3 Composition API: `ref`, `computed`, `watch`, `onMounted`, etc.
+- Import composables from `@/composables/` for shared logic (e.g., `useApiStatus`)
+- Store management: Import and use Pinia stores for data persistence
+- Route management: Use `useRoute()` and `useRouter()` from Vue Router
+
+## Styling and Theme Consistency
+- Use Tailwind CSS classes for all styling
+- Responsive design: Use Tailwind responsive prefixes (`sm:`, `md:`, `lg:`, `xl:`)
+- Spacing: Use Tailwind spacing classes for consistent margins and padding
+
+### Entity Color Standards (CRITICAL - Must be consistent across all components)
+Each entity has a **unique color** that must be used consistently in:
+- Home.vue navigation cards (`main-color` prop)
+- AppHeader.vue navigation menu (icon color classes)
+- List pages (`color` prop and icon colors)
+- Detail pages (icon colors)
+- All related components
+
+**Entity Color Mapping:**
+- **Items**: `teal` / `text-teal-600` / `bg-teal-*` / `hover:bg-teal-50`
+- **Partners**: `yellow` / `text-yellow-600` / `bg-yellow-*` / `hover:bg-yellow-50`  
+- **Languages**: `purple` / `text-purple-600` / `bg-purple-*` / `hover:bg-purple-50`
+- **Countries**: `blue` / `text-blue-600` / `bg-blue-*` / `hover:bg-blue-50`
+- **Contexts**: `green` / `text-green-600` / `bg-green-*` / `hover:bg-green-50`
+- **Projects**: `orange` / `text-orange-600` / `bg-orange-*` / `hover:bg-orange-50`
+
+### Icon Usage (CRITICAL - NO exceptions)
+**FORBIDDEN:**
+- ❌ Inline SVG code in components
+- ❌ Creating separate components just for SVG icons
+- ❌ Custom SVG files or icon libraries
+
+**REQUIRED:**
+- ✅ **ONLY use Heroicons**: Import from `@heroicons/vue/24/solid` or `@heroicons/vue/24/outline`
+- ✅ Import icons directly in the component where they're used
+- ✅ Use icon aliases for semantic naming: `import { CogIcon as ContextIcon } from '@heroicons/vue/24/solid'`
+
+**Entity Icon Mapping (MUST be consistent):**
+- **Items**: `ArchiveBoxIcon` (from 24/solid)
+- **Partners**: `UserGroupIcon` (from 24/solid)
+- **Languages**: `LanguageIcon` (from 24/outline)
+- **Countries**: `GlobeAltIcon` (from 24/outline) 
+- **Contexts**: `CogIcon` (from 24/outline or 24/solid)
+- **Projects**: `FolderIcon` (from 24/outline or 24/solid)
+
+**Icon Size Standards:**
+- Navigation menu: `w-4 h-4`
+- List page icons: `h-5 w-5` 
+- Detail page resource icons: `h-6 w-6`
+- Home page card icons: Handled by Card component (responsive sizing)
+
+## Event Handling and Navigation
+- Use `@click.stop` to prevent event bubbling in nested clickable elements
+- Router navigation: Use `router.push()` for programmatic navigation
+- Event emits: Define emits with TypeScript interfaces when needed
+- Form handling: Use `v-model` for two-way binding with form inputs
+
+## Navigation and Menu Integration
+When adding a new entity, you **MUST** update both:
+
+### 1. Home.vue Dashboard Tile
+```vue
+<!-- In appropriate section (Inventory/Reference Data) -->
+<NavigationCard
+  title="EntityName"
+  description="Clear description of entity purpose"
+  main-color="entity-color"
+  button-text="Manage EntityName"
+  button-route="/entities"
+>
+  <template #icon>
+    <EntityIcon />
+  </template>
+</NavigationCard>
+```
+
+### 2. AppHeader.vue Navigation Menu
+```vue
+<!-- In appropriate dropdown section -->
+<RouterLink
+  to="/entities"
+  class="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2"
+  @click="closeDropdown"
+>
+  <EntityIcon class="w-4 h-4 text-entity-600" />
+  EntityName
+</RouterLink>
+```
+
+## Review Checklist for Copilot Agents
+- [ ] Component structure matches project standards (`<template>`, `<script setup lang="ts">`, `<style scoped>`)
+- [ ] Uses appropriate layout component (ListView for lists, DetailView for details, Cards for dashboard)
+- [ ] Reuse of shared components is maximized (no duplicate UI patterns)
+- [ ] Page layout and detail patterns are consistent with existing pages
+- [ ] **Entity colors are consistent** across Home.vue, AppHeader.vue, list pages, and detail pages
+- [ ] **Icons are Heroicons only** - no inline SVG or custom icon components
+- [ ] **Navigation consistency**: Home.vue tiles match AppHeader.vue menu structure exactly
+- [ ] **List page features**: Filtering, sorting, search, action buttons, status toggles implemented
+- [ ] **Detail page mode handling**: Three modes (view/edit/create) with proper state management
+- [ ] TypeScript is used everywhere, with no `any` types
+- [ ] Proper imports from `@/components/`, `@/composables/`, etc.
+- [ ] Event handling follows established patterns (`@click.stop` for nested clickables)
+- [ ] All code passes linting and formatting (ESLint + Prettier)
+- [ ] Unit tests exist and follow guidelines in `__tests__/` directories
+- [ ] Documentation is present and comprehensive in `docs/frontend/`

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -2,7 +2,7 @@
 layout: default
 title: Configuration
 parent: Deployment Guide
-nav_order: 3
+nav_order: 6
 ---
 
 # Configuration Guide

--- a/docs/frontend/application-architecture.md
+++ b/docs/frontend/application-architecture.md
@@ -2,7 +2,7 @@
 layout: default
 title: Application Architecture
 parent: Frontend Documentation
-nav_order: 1
+nav_order: 2
 ---
 
 # Application Architecture
@@ -99,16 +99,36 @@ src/
 
 ## Navigation System
 
-### Main Navigation
+### Main Navigation Structure
 
-- **Home/Dashboard**: Application overview and quick access
-- **Inventory**:
-  - 🛠️ _(under development)_
-- **Reference Data**:
-  - Projects: Museum and cultural institutions' projects
-  - Contexts: Project categorization contexts
-  - Countries: Geographic reference data
-  - Languages: Multi-language support
+The application uses a **two-tier navigation system** that must be kept in sync:
+
+#### 1. AppHeader.vue Navigation Menu
+Dropdown-based navigation with grouped sections:
+- **Inventory**: Items, Partners  
+- **Reference Data**: Languages, Countries, Contexts, Projects
+- **Tools**: Cache management and system utilities
+
+#### 2. Home.vue Dashboard Tiles  
+Landing page with navigation cards organized identically to the header menu:
+- **Inventory Section**: Items, Partners
+- **Reference Data Section**: Languages, Countries, Contexts, Projects  
+- **Tools Section**: System Status, Additional Features
+
+**CRITICAL**: These two navigation systems must mirror each other exactly. Each entity with a dashboard tile must have a corresponding menu item using the same icon and color.
+
+### Entity Standards
+
+Each entity has standardized presentation across all components:
+
+| Entity | Color | Icon | Route |
+|--------|-------|------|-------|
+| Items | teal | ArchiveBoxIcon | `/items` |
+| Partners | yellow | UserGroupIcon | `/partners` |
+| Languages | purple | LanguageIcon | `/languages` |
+| Countries | blue | GlobeAltIcon | `/countries` |
+| Contexts | green | CogIcon | `/contexts` |
+| Projects | orange | FolderIcon | `/projects` |
 
 ### Routing Configuration
 

--- a/docs/frontend/components/Actions.md
+++ b/docs/frontend/components/Actions.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: Action Components
+parent: Components
+nav_order: 2
+---
+
 # Action Components
 
 Button and interactive components for user actions throughout the application.

--- a/docs/frontend/components/Format.md
+++ b/docs/frontend/components/Format.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: Format Components
+parent: Components
+nav_order: 3
+---
+
 # Format Components
 
 Components for displaying and formatting data, handling user input, and presenting information in structured ways.

--- a/docs/frontend/components/Icons.md
+++ b/docs/frontend/components/Icons.md
@@ -1,34 +1,103 @@
-# Icon Components
+---
+layout: default
+title: Icon Standards
+parent: Components
+nav_order: 4
+---
 
-SVG icon components used throughout the application. All icons are implemented as Vue components with consistent sizing and styling.
+# Icon Standards
 
-## Application Icons
+## CRITICAL REQUIREMENTS
 
-### ProjectIcon
+**ONLY Heroicons are allowed** - No exceptions.
 
-Icon representing projects and project-related functionality.
+### FORBIDDEN ❌
+- Inline SVG code in components
+- Creating separate components just for SVG icons  
+- Custom SVG files or other icon libraries
+- Any custom icon components
 
-**Usage:**
+### REQUIRED ✅
+- **ONLY use Heroicons**: Import from `@heroicons/vue/24/solid` or `@heroicons/vue/24/outline`
+- Import icons directly in the component where they're used
+- Use semantic aliases for clarity: `import { CogIcon as ContextIcon }`
+
+## Entity Icon Standards
+
+Each entity has a standardized icon that must be used consistently:
+
+| Entity | Icon | Import Path | Usage Context |
+|--------|------|-------------|---------------|
+| Items | `ArchiveBoxIcon` | `@heroicons/vue/24/solid` | All Items-related components |
+| Partners | `UserGroupIcon` | `@heroicons/vue/24/solid` | All Partners-related components |
+| Languages | `LanguageIcon` | `@heroicons/vue/24/outline` | All Languages-related components |
+| Countries | `GlobeAltIcon` | `@heroicons/vue/24/outline` | All Countries-related components |
+| Contexts | `CogIcon` | `@heroicons/vue/24/outline` | All Contexts-related components |
+| Projects | `FolderIcon` | `@heroicons/vue/24/outline` | All Projects-related components |
+
+## Icon Size Standards
+
+| Context | Size Class | Example Usage |
+|---------|------------|---------------|
+| Navigation Menu | `w-4 h-4` | AppHeader.vue menu items |
+| List Pages | `h-5 w-5` | Table row icons, InternalName icons |
+| Detail Pages | `h-6 w-6` | Resource icons in DetailView |
+| Dashboard Cards | Auto-sized | NavigationCard component handles sizing |
+
+## Implementation Examples
+
+### ✅ CORRECT Usage
 
 ```vue
-<ProjectIcon />
+<script setup lang="ts">
+// Import Heroicons directly
+import { CogIcon as ContextIcon, CheckCircleIcon } from '@heroicons/vue/24/solid'
+import { ArrowLeftIcon, PencilIcon } from '@heroicons/vue/24/outline'
+</script>
+
+<template>
+  <!-- Use icons directly in template with proper classes -->
+  <ContextIcon class="h-6 w-6 text-green-600" />
+  <CheckCircleIcon class="h-4 w-4 text-green-600" />
+  
+  <!-- Navigation menu usage -->
+  <ContextIcon class="w-4 h-4 text-green-600" />
+  
+  <!-- List page usage -->  
+  <ContextIcon class="h-5 w-5 text-green-600" />
+</template>
 ```
 
-### ContextIcon
+### ❌ FORBIDDEN Usage
 
-Icon for context-related features.
+```vue
+<!-- NEVER do these -->
+<template>
+  <!-- Inline SVG - FORBIDDEN -->
+  <svg viewBox="0 0 24 24">
+    <path d="..."/>
+  </svg>
+  
+  <!-- Custom icon components - FORBIDDEN -->
+  <CustomContextIcon />
+  <ProjectIcon />  <!-- Custom component -->
+</template>
+```
 
-### CountryIcon
+## Color Consistency
 
-Icon representing countries and geographical features.
+Icons must use entity-specific colors:
 
-### LanguageIcon
+```vue
+<!-- Contexts always use green -->
+<CogIcon class="text-green-600" />
 
-Icon for language and localization features.
+<!-- Items always use teal -->  
+<ArchiveBoxIcon class="text-teal-600" />
 
-### FeaturesIcon
-
-Icon for feature toggles and feature-related functionality.
+<!-- Countries always use blue -->
+<GlobeAltIcon class="text-blue-600" />
+```
 
 ## Status Icons
 

--- a/docs/frontend/components/Layout.md
+++ b/docs/frontend/components/Layout.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: Layout Components
+parent: Components
+nav_order: 5
+---
+
 # Layout Components
 
 High-level layout components for structuring pages, sections, and application-wide elements.
@@ -58,56 +65,117 @@ A comprehensive list view component that provides a standardized layout for disp
 
 - `retry` - Emitted when user clicks retry in error state
 
-**Usage Example (Projects.vue):**
+**Complete Usage Example (Contexts.vue):**
 
 ```vue
 <ListView
-  title="Projects"
-  description="Manage projects in your inventory system. Projects can be enabled/disabled and launched/not launched."
-  add-button-route="/projects/new"
-  add-button-label="Add Project"
-  color="orange"
-  :is-empty="filteredProjects.length === 0"
-  empty-title="No projects found"
-  :empty-message="
-    filterMode === 'all'
-      ? 'Get started by creating a new project.'
-      : filterMode === 'visible'
-        ? 'No visible projects found. Projects are visible when they are enabled, launched, and the launch date has passed.'
-        : `No ${filterMode} projects found.`
-  "
-  :show-empty-add-button="filterMode === 'all'"
-  empty-add-button-label="New Project"
-  @retry="fetchProjects"
+  title="Contexts"
+  description="Manage contexts in your inventory system. Contexts can be set as default for the entire database."
+  add-button-route="/contexts/new"
+  add-button-label="Add Context"
+  color="green"
+  :is-empty="filteredContexts.length === 0"
+  empty-title="No contexts found"
+  empty-message="Get started by creating a new context."
+  @retry="fetchContexts"
 >
   <template #icon>
-    <ProjectIcon />
+    <ContextIcon />
   </template>
   
   <template #filters>
     <FilterButton
-      label="All Projects"
+      label="All Contexts"
       :is-active="filterMode === 'all'"
-      :count="projects.length"
+      :count="contexts.length"
       variant="primary"
       @click="filterMode = 'all'"
     />
     <FilterButton
-      label="Enabled"
-      :is-active="filterMode === 'enabled'"
-      :count="enabledProjects.length"
-      variant="info"
-      @click="filterMode = 'enabled'"
+      label="Default"
+      :is-active="filterMode === 'default'"
+      :count="defaultContexts.length"
+      variant="success"
+      @click="filterMode = 'default'"
     />
-    <!-- More filter buttons... -->
+  </template>
+
+  <template #search>
+    <SearchControl v-model="searchQuery" placeholder="Search contexts..." />
   </template>
   
-  <!-- Table content goes in default slot -->
-  <DataTable>
-    <!-- Table headers and rows -->
-  </DataTable>
+  <template #headers>
+    <TableRow>
+      <TableHeader
+        sortable
+        :sort-direction="sortKey === 'internal_name' ? sortDirection : null"
+        @sort="handleSort('internal_name')"
+      >
+        Context
+      </TableHeader>
+      <TableHeader class="hidden md:table-cell">Default</TableHeader>
+      <TableHeader class="hidden lg:table-cell">Created</TableHeader>
+      <TableHeader class="hidden sm:table-cell" variant="actions">
+        <span class="sr-only">Actions</span>
+      </TableHeader>
+    </TableRow>
+  </template>
+
+  <template #rows>
+    <TableRow
+      v-for="context in filteredContexts"
+      :key="context.id"
+      class="cursor-pointer hover:bg-green-50 transition"
+      @click="openContextDetail(context.id)"
+    >
+      <TableCell>
+        <InternalName
+          small
+          :internal-name="context.internal_name"
+          :backward-compatibility="context.backward_compatibility"
+        >
+          <template #icon>
+            <ContextIcon class="h-5 w-5 text-green-600" />
+          </template>
+        </InternalName>
+      </TableCell>
+      <TableCell class="hidden md:table-cell">
+        <div @click.stop>
+          <Toggle
+            small
+            title="Default"
+            :status-text="context.is_default ? 'Default' : 'Not default'"
+            :is-active="context.is_default"
+            @toggle="updateContextStatus(context, 'is_default', !context.is_default)"
+          />
+        </div>
+      </TableCell>
+      <TableCell class="hidden lg:table-cell">
+        <DateDisplay :date="context.created_at" format="short" variant="small-dark" />
+      </TableCell>
+      <TableCell class="hidden sm:table-cell">
+        <div class="flex space-x-2" @click.stop>
+          <ViewButton @click="router.push(`/contexts/${context.id}`)" />
+          <EditButton @click="router.push(`/contexts/${context.id}?edit=true`)" />
+          <DeleteButton @click="handleDeleteContext(context)" />
+        </div>
+      </TableCell>
+    </TableRow>
+  </template>
 </ListView>
 ```
+
+**Required List Page Features:**
+
+All list pages must implement:
+
+1. **Filtering System**: Filter buttons with counts and active states
+2. **Sorting System**: Sortable table headers with direction indicators  
+3. **Search System**: SearchControl component for text-based filtering
+4. **Action Buttons**: ViewButton, EditButton, DeleteButton in every row
+5. **Status Toggles**: Toggle components for inline status changes (where applicable)
+6. **Row Click Navigation**: Clickable rows with hover effects and @click.stop for actions
+7. **Entity Colors**: Consistent color usage (e.g., green for contexts, teal for items)
 
 ### DetailView
 

--- a/docs/frontend/components/index.md
+++ b/docs/frontend/components/index.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Components
-nav_order: 4
+parent: Frontend Documentation
+nav_order: 5
 has_children: true
 ---
 

--- a/docs/frontend/guidelines/api-integration.md
+++ b/docs/frontend/guidelines/api-integration.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: API Integration
-nav_order: 1
-parent: Guidelines
+nav_order: 4
+parent: Frontend Guidelines
 ---
 
 # API Integration

--- a/docs/frontend/guidelines/coding-guidelines.md
+++ b/docs/frontend/guidelines/coding-guidelines.md
@@ -2,7 +2,7 @@
 layout: default
 title: Coding Guidelines
 nav_order: 2
-parent: Guidelines
+parent: Frontend Guidelines
 ---
 
 # Coding Guidelines
@@ -34,6 +34,65 @@ This document outlines the coding standards and best practices for the Inventory
 - **TypeScript strict mode** - all code must be properly typed
 - **Composition API** over Options API for new components
 - **Single File Components** with proper separation of concerns
+
+### Icon Usage (STRICT REQUIREMENTS)
+
+**FORBIDDEN:**
+- ❌ Inline SVG code in components
+- ❌ Creating separate components just for SVG icons
+- ❌ Custom SVG files or other icon libraries
+
+**REQUIRED:**
+- ✅ **ONLY use Heroicons**: Import from `@heroicons/vue/24/solid` or `@heroicons/vue/24/outline`
+- ✅ Import icons directly in the component where they're used
+- ✅ Use semantic aliases: `import { CogIcon as ContextIcon } from '@heroicons/vue/24/solid'`
+
+```vue
+<!-- ✅ Good: Proper Heroicons usage -->
+<script setup lang="ts">
+import { CogIcon as ContextIcon, CheckCircleIcon } from '@heroicons/vue/24/solid'
+import { ArrowLeftIcon } from '@heroicons/vue/24/outline'
+</script>
+
+<template>
+  <!-- Use directly in template -->
+  <ContextIcon class="h-6 w-6 text-green-600" />
+</template>
+```
+
+```vue
+<!-- ❌ Bad: Inline SVG or custom components -->
+<template>
+  <svg>...</svg>  <!-- FORBIDDEN -->
+  <CustomIcon />  <!-- FORBIDDEN -->
+</template>
+```
+
+### Entity Color Standards (CRITICAL)
+
+Each entity must use its assigned color consistently across ALL components:
+
+| Entity | Color | Text Class | Background Classes |
+|--------|-------|------------|-------------------|
+| Items | teal | `text-teal-600` | `bg-teal-*`, `hover:bg-teal-50` |
+| Partners | yellow | `text-yellow-600` | `bg-yellow-*`, `hover:bg-yellow-50` |
+| Languages | purple | `text-purple-600` | `bg-purple-*`, `hover:bg-purple-50` |
+| Countries | blue | `text-blue-600` | `bg-blue-*`, `hover:bg-blue-50` |
+| Contexts | green | `text-green-600` | `bg-green-*`, `hover:bg-green-50` |
+| Projects | orange | `text-orange-600` | `bg-orange-*`, `hover:bg-orange-50` |
+
+```vue
+<!-- ✅ Good: Consistent entity colors -->
+<template>
+  <!-- Contexts always use green -->
+  <ContextIcon class="h-5 w-5 text-green-600" />
+  <div class="hover:bg-green-50">...</div>
+  
+  <!-- Items always use teal -->
+  <ItemIcon class="h-5 w-5 text-teal-600" />
+  <div class="hover:bg-teal-50">...</div>
+</template>
+```
 
 ```vue
 <!-- ✅ Good: Proper SFC structure -->

--- a/docs/frontend/guidelines/generate-commit-docs.md
+++ b/docs/frontend/guidelines/generate-commit-docs.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Development Archive Documentation Generator
-nav_order: 4
-parent: Guidelines
+nav_order: 3
+parent: Frontend Guidelines
 ---
 
 # Development Archive Documentation Generator

--- a/docs/frontend/guidelines/index.md
+++ b/docs/frontend/guidelines/index.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: Guidelines
-nav_order: 3
+title: Frontend Guidelines
+parent: Frontend Documentation
+nav_order: 4
 has_children: true
 ---
 

--- a/docs/frontend/guidelines/integration-testing.md
+++ b/docs/frontend/guidelines/integration-testing.md
@@ -3,7 +3,7 @@ layout: default
 title: Integration Testing
 nav_order: 1
 parent: Testing
-grand_parent: Guidelines
+grand_parent: Frontend Guidelines
 ---
 
 # Integration Testing Guide

--- a/docs/frontend/guidelines/testing.md
+++ b/docs/frontend/guidelines/testing.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Testing
-nav_order: 3
-parent: Guidelines
+nav_order: 1
+parent: Frontend Guidelines
 has_children: true
 ---
 

--- a/docs/frontend/index.md
+++ b/docs/frontend/index.md
@@ -59,7 +59,8 @@ The Vue.js application is integrated into Laravel as a Single Page Application (
 
 ## Documentation Sections
 
-- [Application Architecture](application-architecture.md)
-- [Component Guidelines](guidelines/coding-guidelines.md)
-- [Testing Guidelines](guidelines/testing.md)
-- [Component Reference](components/)
+- [Quick Reference](quick-reference.md) - Developer cheat sheet and quick start guide
+- [Application Architecture](application-architecture.md) - Overall structure and design patterns
+- [Page Patterns](page-patterns.md) - **START HERE** for standardized page implementations  
+- [Frontend Guidelines](guidelines/) - Coding standards, testing, and best practices
+- [Component Reference](components/) - Documentation for all Vue.js components

--- a/docs/frontend/page-patterns.md
+++ b/docs/frontend/page-patterns.md
@@ -1,0 +1,591 @@
+---
+layout: default
+title: Page Patterns
+parent: Frontend Documentation
+nav_order: 3
+---
+
+# Vue.js Page Patterns
+
+This guide documents the standardized patterns for creating consistent pages across the entire Vue.js application.
+
+## Overview
+
+All pages in the application follow three main patterns:
+- **Dashboard/Home Page**: Navigation hub with entity tiles
+- **List Pages**: Resource management with filtering, sorting, and actions
+- **Detail Pages**: Individual resource viewing, editing, and creation
+
+## Dashboard/Home Page Pattern
+
+The `Home.vue` page serves as the main navigation hub and **must mirror the navigation menu structure exactly**.
+
+### Section Structure
+
+Organize content in themed sections that match `AppHeader.vue` navigation dropdowns:
+
+1. **Inventory Section**: Items, Partners
+2. **Reference Data Section**: Languages, Countries, Contexts, Projects  
+3. **Tools Section**: System Status, Additional Features
+
+### Implementation
+
+```vue
+<template>
+  <div>
+    <div class="mb-8">
+      <Title variant="page" description="Welcome to the Inventory Management System">
+        Dashboard
+      </Title>
+    </div>
+
+    <!-- Section Example -->
+    <div class="mb-8">
+      <h2 class="text-xl font-semibold text-gray-900 mb-4 border-b border-gray-200 pb-2">
+        Reference Data
+      </h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        <NavigationCard
+          title="Contexts"
+          description="Manage system contexts and operational environments"
+          main-color="green"
+          button-text="Manage Contexts"
+          button-route="/contexts"
+        >
+          <template #icon>
+            <ContextIcon />
+          </template>
+        </NavigationCard>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { CogIcon as ContextIcon } from '@heroicons/vue/24/solid'
+  import NavigationCard from '@/components/format/card/NavigationCard.vue'
+  import Title from '@/components/format/title/Title.vue'
+</script>
+```
+
+### Navigation Consistency Requirements
+
+- Each entity with a tile in `Home.vue` **MUST** have a corresponding menu item in `AppHeader.vue`
+- Both must use the **same icon** and **same entity color**
+- Section groupings must be identical between Home and navigation menu
+- Item order within sections should be consistent
+
+## List Page Pattern
+
+List pages display collections of resources with comprehensive management features.
+
+### Core Structure
+
+```vue
+<template>
+  <ListView
+    title="Contexts"
+    description="Manage contexts in your inventory system"
+    add-button-route="/contexts/new"
+    add-button-label="Add Context"
+    color="green"
+    :is-empty="filteredContexts.length === 0"
+    empty-title="No contexts found"
+    empty-message="Get started by creating a new context."
+    @retry="fetchContexts"
+  >
+    <template #icon>
+      <ContextIcon />
+    </template>
+    
+    <template #filters>
+      <FilterButton
+        label="All Contexts"
+        :is-active="filterMode === 'all'"
+        :count="contexts.length"
+        variant="primary"
+        @click="filterMode = 'all'"
+      />
+      <FilterButton
+        label="Default"
+        :is-active="filterMode === 'default'"
+        :count="defaultContexts.length"
+        variant="success"
+        @click="filterMode = 'default'"
+      />
+    </template>
+
+    <template #search>
+      <SearchControl v-model="searchQuery" placeholder="Search contexts..." />
+    </template>
+
+    <template #headers>
+      <TableRow>
+        <TableHeader
+          sortable
+          :sort-direction="sortKey === 'internal_name' ? sortDirection : null"
+          @sort="handleSort('internal_name')"
+        >
+          Context
+        </TableHeader>
+        <TableHeader class="hidden md:table-cell">Default</TableHeader>
+        <TableHeader class="hidden lg:table-cell">Created</TableHeader>
+        <TableHeader class="hidden sm:table-cell" variant="actions">
+          <span class="sr-only">Actions</span>
+        </TableHeader>
+      </TableRow>
+    </template>
+
+    <template #rows>
+      <TableRow
+        v-for="context in filteredContexts"
+        :key="context.id"
+        class="cursor-pointer hover:bg-green-50 transition"
+        @click="openContextDetail(context.id)"
+      >
+        <TableCell>
+          <InternalName
+            small
+            :internal-name="context.internal_name"
+            :backward-compatibility="context.backward_compatibility"
+          >
+            <template #icon>
+              <ContextIcon class="h-5 w-5 text-green-600" />
+            </template>
+          </InternalName>
+        </TableCell>
+        <TableCell class="hidden md:table-cell">
+          <div @click.stop>
+            <Toggle
+              small
+              title="Default"
+              :status-text="context.is_default ? 'Default' : 'Not default'"
+              :is-active="context.is_default"
+              @toggle="updateContextStatus(context, 'is_default', !context.is_default)"
+            />
+          </div>
+        </TableCell>
+        <TableCell class="hidden lg:table-cell">
+          <DateDisplay :date="context.created_at" format="short" variant="small-dark" />
+        </TableCell>
+        <TableCell class="hidden sm:table-cell">
+          <div class="flex space-x-2" @click.stop>
+            <ViewButton @click="router.push(`/contexts/${context.id}`)" />
+            <EditButton @click="router.push(`/contexts/${context.id}?edit=true`)" />
+            <DeleteButton @click="handleDeleteContext(context)" />
+          </div>
+        </TableCell>
+      </TableRow>
+    </template>
+  </ListView>
+</template>
+```
+
+### Required Features
+
+#### 1. Filtering System
+```typescript
+const filterMode = ref<'all' | 'default'>('all')
+
+const filteredContexts = computed(() => {
+  let filtered = contexts.value
+  
+  // Apply filter mode
+  if (filterMode.value === 'default') {
+    filtered = filtered.filter(context => context.is_default)
+  }
+  
+  // Apply search and sorting
+  return filtered
+})
+```
+
+#### 2. Sorting System
+```typescript
+const sortKey = ref<string>('internal_name')
+const sortDirection = ref<'asc' | 'desc'>('asc')
+
+const handleSort = (key: string) => {
+  if (sortKey.value === key) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    sortDirection.value = 'asc'
+  }
+}
+```
+
+#### 3. Search System
+```typescript
+const searchQuery = ref('')
+
+// In computed filteredContexts:
+if (searchQuery.value.trim()) {
+  const query = searchQuery.value.toLowerCase()
+  filtered = filtered.filter(context =>
+    context.internal_name.toLowerCase().includes(query) ||
+    (context.backward_compatibility && 
+     context.backward_compatibility.toLowerCase().includes(query))
+  )
+}
+```
+
+#### 4. Action Buttons (MANDATORY)
+Every list page row must include:
+- `<ViewButton @click="router.push(\`/contexts/\${context.id}\`)" />`
+- `<EditButton @click="router.push(\`/contexts/\${context.id}?edit=true\`)" />`
+- `<DeleteButton @click="handleDeleteContext(context)" />`
+
+Wrap in `<div class="flex space-x-2" @click.stop>` to prevent row click propagation.
+
+#### 5. Status Toggles (where applicable)
+Use `<Toggle small>` for inline status changes:
+```vue
+<div @click.stop>
+  <Toggle
+    small
+    title="Default"
+    :status-text="context.is_default ? 'Default' : 'Not default'"
+    :is-active="context.is_default"
+    @toggle="updateContextStatus(context, 'is_default', !context.is_default)"
+  />
+</div>
+```
+
+#### 6. Row Click Navigation
+- Make rows clickable: `class="cursor-pointer hover:bg-green-50 transition"`
+- Use `@click="openContextDetail(context.id)"` for navigation
+- Prevent event bubbling on actions with `@click.stop`
+
+## Detail Page Pattern
+
+Detail pages handle viewing, editing, and creating individual resources.
+
+### Core Structure
+
+```vue
+<template>
+  <DetailView
+    :store-loading="contextStore.loading"
+    :resource="mode === 'create' ? null : context"
+    :mode="mode"
+    :save-disabled="!hasUnsavedChanges"
+    :has-unsaved-changes="hasUnsavedChanges"
+    :back-link="backLink"
+    :status-cards="statusCardsConfig"
+    :create-title="'New Context'"
+    information-title="Context Information"
+    :information-description="informationDescription"
+    :fetch-data="fetchContext"
+    @edit="enterEditMode"
+    @save="saveContext"
+    @cancel="cancelAction"
+    @delete="deleteContext"
+    @status-toggle="handleStatusToggle"
+  >
+    <template #resource-icon>
+      <CogIcon class="h-6 w-6 text-green-600" />
+    </template>
+    
+    <template #information>
+      <DescriptionList>
+        <DescriptionRow variant="gray">
+          <DescriptionTerm>Internal Name</DescriptionTerm>
+          <DescriptionDetail>
+            <FormInput
+              v-if="mode === 'edit' || mode === 'create'"
+              v-model="editForm.internal_name"
+              type="text"
+            />
+            <DisplayText v-else>{{ context?.internal_name }}</DisplayText>
+          </DescriptionDetail>
+        </DescriptionRow>
+        <!-- More rows with alternating variants... -->
+      </DescriptionList>
+    </template>
+  </DetailView>
+</template>
+```
+
+### Mode Handling (CRITICAL)
+
+All detail pages must implement exactly three modes:
+
+```typescript
+type Mode = 'view' | 'edit' | 'create'
+const mode = ref<Mode>('view') // Single source of truth
+
+// Required mode functions:
+const enterCreateMode = () => {
+  mode.value = 'create'
+  editForm.value = getDefaultFormValues()
+}
+
+const enterEditMode = () => {
+  if (!context.value) return
+  mode.value = 'edit'  
+  editForm.value = getFormValuesFromContext()
+}
+
+const enterViewMode = () => {
+  mode.value = 'view'
+  editForm.value = getDefaultFormValues() // Clear form data
+}
+```
+
+### Component Initialization Pattern
+
+```typescript
+const initializeComponent = async () => {
+  const contextId = route.params.id as string
+  const isCreateRoute = route.name === 'context-new' || route.path === '/contexts/new'
+
+  if (isCreateRoute) {
+    contextStore.clearCurrentContext()
+    enterCreateMode()
+  } else if (contextId) {
+    await fetchContext()
+    if (route.query.edit === 'true' && context.value) {
+      enterEditMode()
+    } else {
+      enterViewMode()
+    }
+  }
+}
+
+onMounted(initializeComponent)
+```
+
+### Required Features
+
+#### 1. Form Data Management
+```typescript
+interface ContextFormData {
+  id?: string
+  internal_name: string
+  backward_compatibility: string
+}
+
+const editForm = ref<ContextFormData>({
+  id: '',
+  internal_name: '',
+  backward_compatibility: '',
+})
+
+const getDefaultFormValues = (): ContextFormData => ({
+  id: '',
+  internal_name: '',
+  backward_compatibility: '',
+})
+
+const getFormValuesFromContext = (): ContextFormData => {
+  if (!context.value) return getDefaultFormValues()
+  
+  return {
+    id: context.value.id,
+    internal_name: context.value.internal_name,
+    backward_compatibility: context.value.backward_compatibility || '',
+  }
+}
+```
+
+#### 2. Unsaved Changes Detection
+```typescript
+const hasUnsavedChanges = computed(() => {
+  if (mode.value === 'view') return false
+
+  if (mode.value === 'create') {
+    const defaultValues = getDefaultFormValues()
+    return editForm.value.internal_name !== defaultValues.internal_name
+    // ... compare all fields
+  }
+
+  if (!context.value) return false
+  const originalValues = getFormValuesFromContext()
+  return editForm.value.internal_name !== originalValues.internal_name
+  // ... compare all fields
+})
+
+// Watch for changes and sync with stores
+watch(hasUnsavedChanges, (hasChanges: boolean) => {
+  if (hasChanges) {
+    cancelChangesStore.addChange()
+  } else {
+    cancelChangesStore.resetChanges()
+  }
+})
+```
+
+#### 3. Status Cards Configuration (where applicable)
+```typescript
+const statusCardsConfig = computed(() => {
+  if (!context.value) return []
+
+  return [
+    {
+      title: 'Default Context',
+      description: 'This context is set as the default for the entire database',
+      mainColor: 'green',
+      statusText: context.value.is_default ? 'Default' : 'Not Default',
+      toggleTitle: 'Default Context',
+      isActive: context.value.is_default,
+      loading: false,
+      disabled: false,
+      activeIconBackgroundClass: 'bg-green-100',
+      inactiveIconBackgroundClass: 'bg-gray-100',
+      activeIconClass: 'text-green-600',
+      inactiveIconClass: 'text-gray-600',
+      activeIconComponent: CheckCircleIcon,
+      inactiveIconComponent: XCircleIcon,
+    },
+  ]
+})
+```
+
+#### 4. Navigation Guards
+```typescript
+onBeforeRouteLeave(
+  async (
+    _to: RouteLocationNormalized,
+    _from: RouteLocationNormalized,
+    next: NavigationGuardNext
+  ) => {
+    if ((mode.value === 'edit' || mode.value === 'create') && hasUnsavedChanges.value) {
+      const result = await cancelChangesStore.trigger(
+        mode.value === 'create' ? 'New Context has unsaved changes' : 'Context has unsaved changes',
+        // ... confirmation message
+      )
+
+      if (result === 'stay') {
+        next(false) // Cancel navigation
+      } else {
+        cancelChangesStore.resetChanges()
+        next() // Allow navigation
+      }
+    } else {
+      next()
+    }
+  }
+)
+```
+
+## Entity Standards
+
+### Color Consistency (CRITICAL)
+
+Each entity has a unique color used across ALL components:
+
+| Entity | Color | Text Class | Background Classes |
+|--------|-------|------------|-------------------|
+| Items | teal | `text-teal-600` | `bg-teal-*`, `hover:bg-teal-50` |
+| Partners | yellow | `text-yellow-600` | `bg-yellow-*`, `hover:bg-yellow-50` |
+| Languages | purple | `text-purple-600` | `bg-purple-*`, `hover:bg-purple-50` |
+| Countries | blue | `text-blue-600` | `bg-blue-*`, `hover:bg-blue-50` |
+| Contexts | green | `text-green-600` | `bg-green-*`, `hover:bg-green-50` |
+| Projects | orange | `text-orange-600` | `bg-orange-*`, `hover:bg-orange-50` |
+
+### Icon Standards (STRICT)
+
+**ONLY Heroicons allowed** - No inline SVG or custom icon components.
+
+| Entity | Icon | Import |
+|--------|------|--------|
+| Items | ArchiveBoxIcon | `from '@heroicons/vue/24/solid'` |
+| Partners | UserGroupIcon | `from '@heroicons/vue/24/solid'` |
+| Languages | LanguageIcon | `from '@heroicons/vue/24/outline'` |
+| Countries | GlobeAltIcon | `from '@heroicons/vue/24/outline'` |
+| Contexts | CogIcon | `from '@heroicons/vue/24/outline'` |
+| Projects | FolderIcon | `from '@heroicons/vue/24/outline'` |
+
+**Icon Size Standards:**
+- Navigation menu: `w-4 h-4`
+- List page icons: `h-5 w-5`
+- Detail page resource icons: `h-6 w-6`
+
+## Store Integration
+
+All pages must integrate with Pinia stores following these patterns:
+
+### Required Store Imports
+```typescript
+import { useContextStore } from '@/stores/context'
+import { useLoadingOverlayStore } from '@/stores/loadingOverlay'
+import { useErrorDisplayStore } from '@/stores/errorDisplay'
+import { useDeleteConfirmationStore } from '@/stores/deleteConfirmation'
+import { useCancelChangesConfirmationStore } from '@/stores/cancelChangesConfirmation'
+```
+
+### Data Fetching Pattern
+```typescript
+onMounted(async () => {
+  let usedCache = false
+  
+  // If cache exists, display immediately and refresh in background
+  if (contexts.value && contexts.value.length > 0) {
+    usedCache = true
+  } else {
+    loadingStore.show()
+  }
+  
+  try {
+    await contextStore.fetchContexts()
+    if (usedCache) {
+      errorStore.addMessage('info', 'List refreshed')
+    }
+  } catch {
+    errorStore.addMessage('error', 'Failed to fetch contexts. Please try again.')
+  } finally {
+    if (!usedCache) {
+      loadingStore.hide()
+    }
+  }
+})
+```
+
+## Adding New Entities
+
+When adding a new entity, you **MUST** update both:
+
+### 1. Home.vue Dashboard Tile
+Add to the appropriate section (Inventory/Reference Data):
+```vue
+<NavigationCard
+  title="NewEntity"
+  description="Clear description of entity purpose"
+  main-color="entity-color"
+  button-text="Manage NewEntity"
+  button-route="/new-entities"
+>
+  <template #icon>
+    <NewEntityIcon />
+  </template>
+</NavigationCard>
+```
+
+### 2. AppHeader.vue Navigation Menu
+Add to the corresponding dropdown section:
+```vue
+<RouterLink
+  to="/new-entities"
+  class="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2"
+  @click="closeDropdown"
+>
+  <NewEntityIcon class="w-4 h-4 text-entitycolor-600" />
+  NewEntity
+</RouterLink>
+```
+
+## Validation Checklist
+
+Before submitting any page:
+
+- [ ] **Pattern Compliance**: Page follows correct pattern (Dashboard/List/Detail)
+- [ ] **Entity Colors**: Consistent color usage across all components
+- [ ] **Icons**: Only Heroicons used, no inline SVG or custom components
+- [ ] **Navigation**: Home.vue tiles match AppHeader.vue menu structure
+- [ ] **Required Features**: All mandatory features implemented (filtering, sorting, actions, etc.)
+- [ ] **Mode Handling**: Detail pages implement all three modes correctly
+- [ ] **Store Integration**: Proper Pinia store usage and error handling
+- [ ] **Event Handling**: Correct `@click.stop` usage for nested clickables
+- [ ] **TypeScript**: No `any` types, proper interfaces defined
+- [ ] **Responsive Design**: Proper Tailwind responsive classes used

--- a/docs/frontend/quick-reference.md
+++ b/docs/frontend/quick-reference.md
@@ -1,0 +1,199 @@
+---
+layout: default
+title: Quick Reference
+parent: Frontend Documentation  
+nav_order: 1
+---
+
+# Vue.js Quick Reference
+
+Essential patterns and standards for Vue.js development in the Inventory Management system.
+
+## 🚀 Getting Started
+
+1. **Read First**: [Page Patterns](page-patterns.md) - Complete implementation guide
+2. **Component Docs**: [Components](components/) - Reusable component reference
+3. **Guidelines**: [Coding Guidelines](guidelines/coding-guidelines.md) - Standards and best practices
+
+## 📋 Pre-Development Checklist
+
+Before creating any component:
+- [ ] Determine page type: Dashboard, List, or Detail
+- [ ] Identify entity color and icon from standards table
+- [ ] Plan required features (filtering, sorting, actions, etc.)
+- [ ] Ensure navigation consistency (Home.vue ↔ AppHeader.vue)
+
+## 🎨 Entity Standards Quick Reference
+
+| Entity | Color | Icon | Text Class | Hover Class |
+|--------|-------|------|------------|-------------|
+| Items | teal | `ArchiveBoxIcon` | `text-teal-600` | `hover:bg-teal-50` |
+| Partners | yellow | `UserGroupIcon` | `text-yellow-600` | `hover:bg-yellow-50` |
+| Languages | purple | `LanguageIcon` | `text-purple-600` | `hover:bg-purple-50` |
+| Countries | blue | `GlobeAltIcon` | `text-blue-600` | `hover:bg-blue-50` |
+| Contexts | green | `CogIcon` | `text-green-600` | `hover:bg-green-50` |
+| Projects | orange | `FolderIcon` | `text-orange-600` | `hover:bg-orange-50` |
+
+## 🔧 Essential Component Patterns
+
+### Page Type Templates
+
+```vue
+<!-- DASHBOARD/HOME PAGE -->
+<template>
+  <div>
+    <Title variant="page" description="Welcome message">Dashboard</Title>
+    
+    <div class="mb-8">
+      <h2 class="text-xl font-semibold text-gray-900 mb-4 border-b border-gray-200 pb-2">
+        Section Name
+      </h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        <NavigationCard
+          title="EntityName"
+          description="Entity description"
+          main-color="entity-color"
+          button-text="Manage EntityName"
+          button-route="/entities"
+        >
+          <template #icon><EntityIcon /></template>
+        </NavigationCard>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+```vue
+<!-- LIST PAGE -->
+<template>
+  <ListView
+    title="EntityName"
+    description="Manage entities..."
+    add-button-route="/entities/new"
+    add-button-label="Add EntityName"
+    color="entity-color"
+    :is-empty="filteredEntities.length === 0"
+    empty-title="No entities found"
+    empty-message="Get started by creating a new entity."
+  >
+    <template #icon><EntityIcon /></template>
+    <template #filters><!-- Filter buttons --></template>
+    <template #search><SearchControl v-model="searchQuery" /></template>
+    <template #headers><!-- Table headers --></template>
+    <template #rows>
+      <TableRow v-for="entity in filteredEntities" :key="entity.id">
+        <!-- Row content with actions -->
+      </TableRow>
+    </template>
+  </ListView>
+</template>
+```
+
+```vue
+<!-- DETAIL PAGE -->
+<template>
+  <DetailView
+    :store-loading="entityStore.loading"
+    :resource="mode === 'create' ? null : entity"
+    :mode="mode"
+    :save-disabled="!hasUnsavedChanges"
+    :has-unsaved-changes="hasUnsavedChanges"
+    :back-link="backLink"
+    information-title="Entity Information"
+    @edit="enterEditMode"
+    @save="saveEntity"
+    @cancel="cancelAction"
+    @delete="deleteEntity"
+  >
+    <template #resource-icon>
+      <EntityIcon class="h-6 w-6 text-entity-600" />
+    </template>
+    <template #information>
+      <DescriptionList>
+        <DescriptionRow variant="gray">
+          <DescriptionTerm>Field Name</DescriptionTerm>
+          <DescriptionDetail>
+            <FormInput v-if="mode === 'edit' || mode === 'create'" v-model="editForm.field" />
+            <DisplayText v-else>{{ entity?.field }}</DisplayText>
+          </DescriptionDetail>
+        </DescriptionRow>
+      </DescriptionList>
+    </template>
+  </DetailView>
+</template>
+```
+
+## 🚫 Common Mistakes to Avoid
+
+### Icons
+- ❌ `<svg>...</svg>` (inline SVG)
+- ❌ `<CustomIcon />` (custom components)  
+- ✅ `import { CogIcon } from '@heroicons/vue/24/solid'`
+
+### Colors
+- ❌ `text-blue-600` for contexts (wrong color)
+- ❌ Different colors in same entity components
+- ✅ `text-green-600` for all context components
+
+### Navigation
+- ❌ Home tile without corresponding menu item
+- ❌ Different icons/colors between Home and menu
+- ✅ Synchronized Home.vue and AppHeader.vue
+
+### List Pages
+- ❌ Missing action buttons (View/Edit/Delete)
+- ❌ No filtering or sorting
+- ✅ Complete feature implementation
+
+### Detail Pages  
+- ❌ Only handling view mode
+- ❌ Missing unsaved changes detection
+- ✅ All three modes: view/edit/create
+
+## 📚 Required Imports by Page Type
+
+### List Pages
+```typescript
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useEntityStore } from '@/stores/entity'
+import { useLoadingOverlayStore } from '@/stores/loadingOverlay'
+import { useErrorDisplayStore } from '@/stores/errorDisplay'
+import { useDeleteConfirmationStore } from '@/stores/deleteConfirmation'
+import ListView from '@/components/layout/list/ListView.vue'
+import { EntityIcon } from '@heroicons/vue/24/solid'
+```
+
+### Detail Pages
+```typescript
+import { computed, ref, onMounted, watch } from 'vue'
+import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
+import { useEntityStore } from '@/stores/entity'
+import { useLoadingOverlayStore } from '@/stores/loadingOverlay'
+import { useErrorDisplayStore } from '@/stores/errorDisplay'
+import { useDeleteConfirmationStore } from '@/stores/deleteConfirmation'
+import { useCancelChangesConfirmationStore } from '@/stores/cancelChangesConfirmation'
+import DetailView from '@/components/layout/detail/DetailView.vue'
+import { EntityIcon } from '@heroicons/vue/24/solid'
+```
+
+## 🔍 Validation Checklist
+
+Before submitting:
+- [ ] Correct page pattern implemented
+- [ ] Entity colors consistent across all usage
+- [ ] Only Heroicons used (no inline SVG)
+- [ ] Navigation sync (Home.vue ↔ AppHeader.vue)  
+- [ ] All required features implemented
+- [ ] Proper TypeScript typing (no `any`)
+- [ ] Event handling with `@click.stop` where needed
+- [ ] Store integration and error handling
+- [ ] Responsive design with Tailwind classes
+
+## 🆘 Need Help?
+
+1. **Examples**: Check existing pages (Contexts.vue, ContextDetail.vue) 
+2. **Components**: Browse [Component Reference](components/)
+3. **Patterns**: Review [Page Patterns](page-patterns.md) guide
+4. **Standards**: Check [Coding Guidelines](guidelines/coding-guidelines.md)

--- a/docs/guidelines/generate-api-client-docs.md
+++ b/docs/guidelines/generate-api-client-docs.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: API Client Documentation Generator
-nav_order: 5
+nav_order: 2
 parent: Guidelines
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,10 @@ Overview of the database models in the application, their main properties, and r
 
 Comprehensive deployment instructions for production and development environments.
 
+### [Frontend Documentation](frontend/)
+
+Complete Vue.js frontend documentation covering components, patterns, and development standards.
+
 ### [Guidelines](guidelines/)
 
 Comprehensive development guidelines covering API integration, coding standards, and testing practices.


### PR DESCRIPTION
# Fix Jekyll documentation navigation structure and nav_order conflicts

## Problem Solved
The Jekyll documentation site had multiple nav_order conflicts and missing navigation structure that would cause incorrect ordering and broken navigation in the generated GitHub Pages site.

## What This PR Fixes

### 🔧 Navigation Structure Issues
- **Nav_order conflicts**: Multiple pages sharing same nav_order values causing unpredictable navigation order
- **Missing frontmatter**: Component documentation files lacking proper Jekyll frontmatter
- **Parent name conflicts**: Frontend "Guidelines" conflicting with main "Guidelines" section
- **Broken navigation links**: Frontend index not properly linking to all child sections

### 📚 Documentation Enhancements  
- **Comprehensive frontend docs**: Added complete Vue.js patterns, component docs, and development standards
- **Enhanced coding guidelines**: Added strict icon usage rules and entity color standards
- **Proper component documentation**: All frontend components now have proper Jekyll navigation structure

## Changes Summary

### Main Navigation Structure (Root Level)
- Established clean 1-10 nav_order sequence for all main sections
- Added missing Frontend Documentation reference in main index
- Fixed deployment configuration nav_order conflict (3→6)

### Frontend Documentation Section  
- **Renamed parent section**: "Guidelines" → "Frontend Guidelines" to avoid conflicts
- **Fixed child page sequence**: Proper nav_order 1-5 for all frontend subsections
- **Enhanced index page**: Updated to properly link all child sections with descriptions
- **Added comprehensive patterns**: Complete Vue.js page patterns and component usage guide

### Component Documentation
- **Added missing frontmatter**: Actions, Format, Icons, Layout components now have proper Jekyll structure
- **Established proper sequence**: nav_order 1-5 for all component categories
- **Enhanced content**: Added strict Heroicons-only requirements and entity color standards

## Impact on GitHub Pages
- ✅ **Clean navigation**: No more nav_order conflicts or duplicate values  
- ✅ **Proper hierarchy**: Parent-child relationships correctly established
- ✅ **Complete structure**: All documentation sections properly linked and ordered
- ✅ **Enhanced content**: Comprehensive frontend documentation for developers

## Validation
- [x] No nav_order conflicts remain
- [x] All files have proper Jekyll frontmatter  
- [x] Parent-child relationships are correct
- [x] Navigation links are functional
- [x] Content is comprehensive and accurate

This ensures the Jekyll-generated documentation site will have proper navigation structure and comprehensive coverage of all frontend development patterns and standards.
