### PR TITLE
Fix CI workflow paths-ignore to include .github/instructions/**

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,7 @@ on:
     types: [opened, synchronize, reopened]
     paths-ignore:
       - 'docs/**'
+      - '.github/instructions/**'
       - '.github/workflows/continuous-deployment.yml'
       - '.github/workflows/continuous-deployment_github-pages.yml'
       - '.github/workflows/publish-npm-github-package.yml'


### PR DESCRIPTION
Fix CI workflow paths-ignore configuration for instruction files

## Problem

The continuous integration workflow was unexpectedly triggered by changes to `.github/instructions/vue.instructions.md` in the previous PR, even though the `paths-ignore` configuration was intended to skip CI for documentation-only changes.

## Root Cause

The current `paths-ignore` configuration only includes:
- `docs/**` - Jekyll documentation
- Specific workflow files

However, it does not include `.github/instructions/**` files, which are Copilot agent instruction files that don't affect application functionality.

## Solution

Added `.github/instructions/**` to the `paths-ignore` list in the continuous integration workflow.

## Changes

- **Modified**: `.github/workflows/continuous-integration.yml`
  - Added `.github/instructions/**` to paths-ignore configuration
  - Maintains all existing ignore patterns

## Benefits

1. **Reduced CI overhead**: Instruction file changes won't trigger unnecessary CI runs
2. **Logical consistency**: Instruction files are documentation, similar to `docs/**`
3. **Cost efficiency**: Fewer GitHub Actions minutes consumed for non-functional changes
4. **Developer experience**: Faster feedback for documentation-only PRs

## Validation

This change will prevent CI from running when only the following types of files are modified:
- `docs/**` (Jekyll documentation)
- `.github/instructions/**` (Copilot agent instructions)
- Specific deployment workflow files

CI will continue to run for all application code changes as expected.
