### PR TITLE
Fix documentation navigation and 404 links

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -174,6 +174,12 @@
       &nbsp;&#124;&nbsp;
       <a href="{{ '/api-documentation' | relative_url }}">API Documentation</a>
       &nbsp;&#124;&nbsp;
+      <a href="{{ '/models/' | relative_url }}">Database Models</a>
+      &nbsp;&#124;&nbsp;
+      <a href="{{ '/deployment/' | relative_url }}">Deployment Guide</a>
+      &nbsp;&#124;&nbsp;
+      <a href="{{ '/frontend/' | relative_url }}">Frontend Documentation</a>
+      &nbsp;&#124;&nbsp;
       <a href="{{ '/guidelines/' | relative_url }}">Guidelines</a>
       &nbsp;&#124;&nbsp;
       <a href="{{ '/contributing' | relative_url }}">Contributing</a>

--- a/docs/frontend/components/index.md
+++ b/docs/frontend/components/index.md
@@ -12,23 +12,23 @@ This documentation covers all Vue components in the Inventory Management UI appl
 
 ## Component Categories
 
-### [Global Components](./Global.md)
+### [Global Components](./Global)
 
 Centrally managed features that provide consistent user interaction patterns across the entire application. These components are rendered globally in App.vue and controlled via Pinia stores, including loading overlays, error displays, and confirmation modals.
 
-### [Format Components](./Format.md)
+### [Format Components](./Format)
 
 Components for displaying and formatting data, including text display, form inputs, dropdowns, and specialized formatters.
 
-### [Layout Components](./Layout.md)
+### [Layout Components](./Layout)
 
 High-level layout components for structuring pages and sections, including detail views, list views, and application layout.
 
-### [Icon Components](./Icons.md)
+### [Icon Components](./Icons)
 
 SVG icon components used throughout the application.
 
-### [Action Components](./Actions.md)
+### [Action Components](./Actions)
 
 Button components for various user actions like editing, saving, deleting, etc.
 

--- a/docs/frontend/index.md
+++ b/docs/frontend/index.md
@@ -59,8 +59,8 @@ The Vue.js application is integrated into Laravel as a Single Page Application (
 
 ## Documentation Sections
 
-- [Quick Reference](quick-reference.md) - Developer cheat sheet and quick start guide
-- [Application Architecture](application-architecture.md) - Overall structure and design patterns
-- [Page Patterns](page-patterns.md) - **START HERE** for standardized page implementations  
+- [Quick Reference](quick-reference) - Developer cheat sheet and quick start guide
+- [Application Architecture](application-architecture) - Overall structure and design patterns
+- [Page Patterns](page-patterns) - for standardized page implementations  
 - [Frontend Guidelines](guidelines/) - Coding standards, testing, and best practices
 - [Component Reference](components/) - Documentation for all Vue.js components

--- a/docs/frontend/quick-reference.md
+++ b/docs/frontend/quick-reference.md
@@ -11,9 +11,9 @@ Essential patterns and standards for Vue.js development in the Inventory Managem
 
 ## 🚀 Getting Started
 
-1. **Read First**: [Page Patterns](page-patterns.md) - Complete implementation guide
+1. **Read First**: [Page Patterns](page-patterns) - Complete implementation guide
 2. **Component Docs**: [Components](components/) - Reusable component reference
-3. **Guidelines**: [Coding Guidelines](guidelines/coding-guidelines.md) - Standards and best practices
+3. **Guidelines**: [Coding Guidelines](guidelines/coding-guidelines) - Standards and best practices
 
 ## 📋 Pre-Development Checklist
 
@@ -195,5 +195,5 @@ Before submitting:
 
 1. **Examples**: Check existing pages (Contexts.vue, ContextDetail.vue) 
 2. **Components**: Browse [Component Reference](components/)
-3. **Patterns**: Review [Page Patterns](page-patterns.md) guide
-4. **Standards**: Check [Coding Guidelines](guidelines/coding-guidelines.md)
+3. **Patterns**: Review [Page Patterns](page-patterns) guide
+4. **Standards**: Check [Coding Guidelines](guidelines/coding-guidelines)


### PR DESCRIPTION
Fix documentation navigation and 404 links

This PR addresses two key issues with the documentation site:

## 🔗 Frontend Documentation 404 Fixes
- **Remove .md extensions** from internal page links in `frontend/index.md`
- **Update Page Patterns description** for better consistency  
- **Ensure Jekyll compatibility** - Jekyll requires internal markdown links to omit the .md extension for proper HTML generation and routing

**Fixed Pages:**
- ✅ Quick Reference  
- ✅ Application Architecture
- ✅ Page Patterns

## 🧭 Complete Main Navigation  
- **Add missing "Database Models"** link to main navigation
- **Add missing "Deployment Guide"** link to main navigation  
- **Add missing "Frontend Documentation"** link to main navigation
- **Align navigation structure** with the sections defined in `docs/index.md`

**Updated Navigation Order:**
Home | API Documentation | Database Models | Deployment Guide | Frontend Documentation | Guidelines | Contributing | Development Archive

## Impact
- ✅ Resolves 404 errors on GitHub Pages for frontend documentation links
- ✅ Provides complete navigation access to all documentation sections  
- ✅ Improves user experience and documentation discoverability
- ✅ Ensures consistency between homepage and navigation menu
