### PR TITLE
fix(ci): improve version bump workflow git checkout reliability

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,6 +28,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: "Setup > Image > Install php"
         uses: shivammathur/setup-php@v2
@@ -102,9 +105,9 @@ jobs:
       #  run: |
       #    npm run lint
 
-  # - name: 'Check > npm > Run Tests'
-  #   run: |
-  #     npm test
+      - name: 'Check > npm > Run Tests'
+        run: |
+          npm test
 
       # Version bump section - runs at the end of validation job
       - name: Configure Git for version bump
@@ -164,11 +167,12 @@ jobs:
           # Check if there are changes to commit
           $changes = git diff --name-only
           if ($changes) {
-            # Ensure we're on the correct branch
+            # Create and switch to the PR branch locally
+            git fetch origin ${{ github.head_ref }}:${{ github.head_ref }}
             git checkout ${{ github.head_ref }}
             git add package.json package-lock.json
             git commit -m "chore: bump version to $newVersion"
-            git push origin HEAD:${{ github.head_ref }}
+            git push origin ${{ github.head_ref }}
             Write-Output "Version bumped to $newVersion and pushed to PR branch"
           } else {
             Write-Output "No version changes needed"


### PR DESCRIPTION
## 🔧 CI Workflow Git Checkout Reliability Improvements

### Problem Solved
Fixed critical issues in the version bump workflow where:
- PRs were being merged before CI completion due to missing branch protection
- Version bump commits were failing due to git checkout problems in CI environment
- `pathspec 'branch-name' did not match any file(s) known to git` errors
- `failed to push some refs` errors due to detached HEAD state

### Changes Made

#### 1. **Enhanced Git Operations in CI**
- **Improved checkout action**: Added `fetch-depth: 0` and explicit token configuration
- **Fixed branch fetching**: Properly fetch PR branch from remote before checkout
- **Reliable branch switching**: Use `git fetch origin ${{ github.head_ref }}:${{ github.head_ref }}` then checkout

#### 2. **Configured Branch Protection Rules**
- ✅ **Required status check**: "Validate Laravel Application" must pass before merge
- ✅ **Strict mode**: Branches must be up to date before merging  
- ✅ **Required reviews**: At least 1 approving review needed
- ✅ **Auto-merge safety**: PRs cannot merge until CI completes successfully

### Testing This PR
This PR will test:
1. **Branch protection enforcement** - Cannot merge until CI passes
2. **Version bump reliability** - Git checkout operations should now work correctly
3. **Automated versioning** - Version bump should commit and push successfully to this PR branch

### Expected Behavior
- ⏳ CI must complete successfully before merge is allowed
- 📦 Version should be automatically bumped based on PR labels
- ✅ No more git checkout or push failures in version bump step

### Labels for Testing
Add one of these labels to test version bumping:
- `bugfix` → patch version bump (e.g., 1.0.0 → 1.0.1)  
- `feature` → minor version bump (e.g., 1.0.0 → 1.1.0)
- `breaking-change` → major version bump (e.g., 1.0.0 → 2.0.0)
