### PR TITLE
fix: CD GitHub Packages authentication for self-hosted runner

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -36,6 +36,7 @@ name: Continuous Deployment
 
 permissions:
   contents: read
+  packages: read   # Need read permissions for GitHub Packages
 
 on:
   push:
@@ -136,6 +137,18 @@ jobs:
           }
           Write-Host "::endgroup::"
           Write-Host "Composer dependencies installed successfully."
+        shell: powershell
+
+      - name: Setup npm authentication for GitHub Packages
+        run: |
+          # Configure npm authentication for GitHub Packages
+          Write-Host "::group::Setting up npm authentication"
+          & "$env:NPM_PATH" config set @metanull:registry https://npm.pkg.github.com/
+          & "$env:NPM_PATH" config set //npm.pkg.github.com/:_authToken $env:GITHUB_TOKEN
+          Write-Host "::endgroup::"
+          Write-Host "npm authentication configured for GitHub Packages."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: powershell
 
       - name: Install Node.js dependencies


### PR DESCRIPTION
## Summary

Fixes the CD (Continuous Deployment) workflow authentication issue with GitHub Packages that was causing deployment failures with error: "authentication token not provided" when trying to install `@metanull/inventory-app-api-client`.

## Changes

- **Add packages:read permission** to CD workflow for GitHub Packages access
- **Add npm authentication setup step** before npm install to configure GitHub token
- **Configure npm registry and auth token** for `@metanull` scope specifically

## Technical Details

The CD workflow runs on a self-hosted Windows runner and uses PowerShell to call npm directly (rather than using the GitHub Actions setup-node action like CI). This requires manually configuring npm authentication:

```powershell
npm config set @metanull:registry https://npm.pkg.github.com/
npm config set //npm.pkg.github.com/:_authToken $env:GITHUB_TOKEN
```

## Testing

- CI workflow authentication was already fixed in previous PR
- This specifically addresses the CD workflow authentication issue
- Self-hosted runner should now be able to authenticate with GitHub Packages

## Related Issues

Resolves deployment failure: `npm error 401 Unauthorized - GET https://npm.pkg.github.com/download/@metanull/inventory-app-api-client/...`