### PR TITLE
feat: enforce MFA for sensitive permissions and add security enhancements

### DIFF
--- a/app/Enums/Permission.php
+++ b/app/Enums/Permission.php
@@ -81,4 +81,17 @@ enum Permission: string
             [self::MANAGE_SETTINGS->value]
         );
     }
+
+    /**
+     * Get sensitive permissions that require MFA
+     */
+    public static function sensitivePermissions(): array
+    {
+        return [
+            self::MANAGE_USERS->value,
+            self::MANAGE_ROLES->value,
+            self::ASSIGN_ROLES->value,
+            self::MANAGE_SETTINGS->value,
+        ];
+    }
 }

--- a/app/Http/Requests/Web/StoreUserManagementRequest.php
+++ b/app/Http/Requests/Web/StoreUserManagementRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\Web;
 
+use App\Enums\Permission;
 use Illuminate\Foundation\Http\FormRequest;
+use Spatie\Permission\Models\Role;
 
 class StoreUserManagementRequest extends FormRequest
 {
@@ -27,5 +29,34 @@ class StoreUserManagementRequest extends FormRequest
             'roles' => ['array'],
             'roles.*' => ['exists:roles,id'],
         ];
+    }
+
+    /**
+     * Configure the validator instance.
+     */
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            // Check if any of the roles being assigned have sensitive permissions
+            if ($this->has('roles') && is_array($this->roles)) {
+                $roles = Role::whereIn('id', $this->roles)->get();
+                $sensitivePermissions = Permission::sensitivePermissions();
+
+                foreach ($roles as $role) {
+                    foreach ($sensitivePermissions as $permission) {
+                        if ($role->hasPermissionTo($permission)) {
+                            // New users cannot be created with sensitive permissions
+                            // They must enable MFA first
+                            $validator->errors()->add(
+                                'roles',
+                                __('Cannot assign roles with sensitive permissions (manage users, manage roles, assign roles, or manage settings) to a new user. The user must first enable multi-factor authentication (MFA) before receiving these permissions.')
+                            );
+
+                            return;
+                        }
+                    }
+                }
+            }
+        });
     }
 }

--- a/app/Http/Requests/Web/UpdateUserManagementRequest.php
+++ b/app/Http/Requests/Web/UpdateUserManagementRequest.php
@@ -2,8 +2,11 @@
 
 namespace App\Http\Requests\Web;
 
+use App\Enums\Permission;
+use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Spatie\Permission\Models\Role;
 
 class UpdateUserManagementRequest extends FormRequest
 {
@@ -31,5 +34,43 @@ class UpdateUserManagementRequest extends FormRequest
             'unverify_email' => ['nullable', 'boolean'],
             'generate_new_password' => ['nullable', 'boolean'],
         ];
+    }
+
+    /**
+     * Configure the validator instance.
+     */
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            $user = $this->route('user');
+
+            if (! $user instanceof User) {
+                return;
+            }
+
+            // Check if any of the roles being assigned have sensitive permissions
+            if ($this->has('roles') && is_array($this->roles)) {
+                $roles = Role::whereIn('id', $this->roles)->get();
+                $sensitivePermissions = Permission::sensitivePermissions();
+
+                foreach ($roles as $role) {
+                    foreach ($sensitivePermissions as $permission) {
+                        if ($role->hasPermissionTo($permission)) {
+                            // User must have MFA enabled to receive this role
+                            if (! $user->hasTwoFactorEnabled()) {
+                                $validator->errors()->add(
+                                    'roles',
+                                    __('The user must have multi-factor authentication (MFA) enabled before being assigned roles with sensitive permissions (manage users, manage roles, assign roles, or manage settings).')
+                                );
+
+                                return;
+                            }
+
+                            break 2; // Exit both loops once we find one sensitive permission
+                        }
+                    }
+                }
+            }
+        });
     }
 }

--- a/app/Livewire/Profile/TwoFactorAuthenticationForm.php
+++ b/app/Livewire/Profile/TwoFactorAuthenticationForm.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Livewire\Profile;
+
+use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
+use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
+use Laravel\Fortify\Features;
+use Laravel\Jetstream\ConfirmsPasswords;
+use Livewire\Component;
+
+class TwoFactorAuthenticationForm extends Component
+{
+    use ConfirmsPasswords;
+
+    /**
+     * Indicates if two factor authentication QR code is being displayed.
+     */
+    public bool $showingQrCode = false;
+
+    /**
+     * Indicates if the two factor authentication confirmation input and button are being displayed.
+     */
+    public bool $showingConfirmation = false;
+
+    /**
+     * Indicates if two factor authentication recovery codes are being displayed.
+     */
+    public bool $showingRecoveryCodes = false;
+
+    /**
+     * The OTP code for confirming two factor authentication.
+     */
+    public ?string $code = null;
+
+    /**
+     * Mount the component.
+     */
+    public function mount(): void
+    {
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm') &&
+            is_null(Auth::user()->two_factor_confirmed_at)) {
+            app(DisableTwoFactorAuthentication::class)(Auth::user());
+        }
+    }
+
+    /**
+     * Enable two factor authentication for the user.
+     */
+    public function enableTwoFactorAuthentication(EnableTwoFactorAuthentication $enable): void
+    {
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
+            $this->ensurePasswordIsConfirmed();
+        }
+
+        $enable(Auth::user());
+
+        $this->showingQrCode = true;
+
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm')) {
+            $this->showingConfirmation = true;
+        } else {
+            $this->showingRecoveryCodes = true;
+        }
+    }
+
+    /**
+     * Confirm two factor authentication for the user.
+     */
+    public function confirmTwoFactorAuthentication(ConfirmTwoFactorAuthentication $confirm): void
+    {
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
+            $this->ensurePasswordIsConfirmed();
+        }
+
+        $confirm(Auth::user(), $this->code);
+
+        $this->showingQrCode = false;
+        $this->showingConfirmation = false;
+        $this->showingRecoveryCodes = true;
+    }
+
+    /**
+     * Display the user's recovery codes.
+     */
+    public function showRecoveryCodes(): void
+    {
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
+            $this->ensurePasswordIsConfirmed();
+        }
+
+        $this->showingRecoveryCodes = true;
+    }
+
+    /**
+     * Generate new recovery codes for the user.
+     */
+    public function regenerateRecoveryCodes(GenerateNewRecoveryCodes $generate): void
+    {
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
+            $this->ensurePasswordIsConfirmed();
+        }
+
+        $generate(Auth::user());
+
+        $this->showingRecoveryCodes = true;
+    }
+
+    /**
+     * Disable two factor authentication for the user.
+     */
+    public function disableTwoFactorAuthentication(DisableTwoFactorAuthentication $disable): void
+    {
+        if (Features::optionEnabled(Features::twoFactorAuthentication(), 'confirmPassword')) {
+            $this->ensurePasswordIsConfirmed();
+        }
+
+        /** @var \App\Models\User $user */
+        $user = Auth::user();
+
+        // Check if user has sensitive permissions
+        if ($user->hasSensitivePermissions()) {
+            $this->addError('totp', __('You cannot disable two-factor authentication while you have sensitive permissions (manage users, manage roles, assign roles, or manage settings).'));
+
+            return;
+        }
+
+        $disable($user);
+
+        $this->showingQrCode = false;
+        $this->showingConfirmation = false;
+        $this->showingRecoveryCodes = false;
+    }
+
+    /**
+     * Get the current user of the application.
+     */
+    public function getUserProperty()
+    {
+        return Auth::user();
+    }
+
+    /**
+     * Determine if two factor authentication is enabled.
+     */
+    public function getEnabledProperty(): bool
+    {
+        return ! empty(Auth::user()->two_factor_secret);
+    }
+
+    /**
+     * Render the component.
+     */
+    public function render()
+    {
+        return view('profile.two-factor-authentication-form');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -312,4 +312,20 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
         return json_decode(decrypt($this->two_factor_recovery_codes), true) ?? [];
     }
+
+    /**
+     * Check if the user has any sensitive permissions that require MFA.
+     */
+    public function hasSensitivePermissions(): bool
+    {
+        $sensitivePermissions = \App\Enums\Permission::sensitivePermissions();
+
+        foreach ($sensitivePermissions as $permission) {
+            if ($this->hasPermissionTo($permission)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -53,6 +53,9 @@ class JetstreamServiceProvider extends ServiceProvider
 
         Jetstream::deleteUsersUsing(DeleteUser::class);
 
+        // Override Jetstream's TwoFactorAuthenticationForm with our custom implementation
+        \Livewire\Livewire::component('profile.two-factor-authentication-form', \App\Livewire\Profile\TwoFactorAuthenticationForm::class);
+
         Vite::prefetch(concurrency: 3);
     }
 

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -90,6 +90,9 @@
                                         {{ __('Roles') }}
                                     </th>
                                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                        {{ __('MFA Status') }}
+                                    </th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                                         {{ __('Email Verified') }}
                                     </th>
                                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -121,6 +124,20 @@
                                                     </span>
                                                 @endforelse
                                             </div>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            @if($user->hasTwoFactorEnabled())
+                                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                                                    <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                                                        <path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                                                    </svg>
+                                                    {{ __('Enabled') }}
+                                                </span>
+                                            @else
+                                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                                                    {{ __('Disabled') }}
+                                                </span>
+                                            @endif
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap">
                                             @if($user->email_verified_at)
@@ -161,7 +178,7 @@
                                     </tr>
                                 @empty
                                     <tr>
-                                        <td colspan="5" class="px-6 py-4 text-center text-gray-500">
+                                        <td colspan="6" class="px-6 py-4 text-center text-gray-500">
                                             {{ __('No users found.') }}
                                         </td>
                                     </tr>

--- a/tests/Feature/Auth/EmailTwoFactorFormTest.php
+++ b/tests/Feature/Auth/EmailTwoFactorFormTest.php
@@ -22,6 +22,8 @@ test('email two factor form can enable email 2fa', function () {
     $user = User::factory()->create();
     $this->actingAs($user);
 
+    $this->withSession(['auth.password_confirmed_at' => time()]);
+
     $component = Livewire::test(EmailTwoFactorForm::class)
         ->call('enableEmailTwoFactor');
 
@@ -36,6 +38,8 @@ test('email two factor form can disable email 2fa', function () {
     ]);
 
     $this->actingAs($user);
+
+    $this->withSession(['auth.password_confirmed_at' => time()]);
 
     $component = Livewire::test(EmailTwoFactorForm::class)
         ->call('disableEmailTwoFactor');
@@ -57,6 +61,8 @@ test('email two factor form can update preferences', function () {
     ])->save();
 
     $this->actingAs($user);
+
+    $this->withSession(['auth.password_confirmed_at' => time()]);
 
     $component = Livewire::test(EmailTwoFactorForm::class)
         ->set('preferred2faMethod', 'both')
@@ -95,6 +101,8 @@ test('email two factor form can send test code', function () {
     ]);
 
     $this->actingAs($user);
+
+    $this->withSession(['auth.password_confirmed_at' => time()]);
 
     $component = Livewire::test(EmailTwoFactorForm::class)
         ->call('sendTestEmailCode');

--- a/tests/Feature/Integration/ActualWebInterfaceBugReproductionTest.php
+++ b/tests/Feature/Integration/ActualWebInterfaceBugReproductionTest.php
@@ -95,6 +95,10 @@ class ActualWebInterfaceBugReproductionTest extends TestCase
         $admin->assignRole('Manager of Users');
 
         $targetUser = User::factory()->create();
+        // Enable MFA for the target user
+        $targetUser->forceFill([
+            'email_2fa_enabled' => true,
+        ])->save();
 
         // Get multiple roles
         $regularUserRole = Role::where('name', 'Regular User')->first();

--- a/tests/Feature/Web/Admin/EditUserPasswordGenerationTest.php
+++ b/tests/Feature/Web/Admin/EditUserPasswordGenerationTest.php
@@ -188,6 +188,10 @@ class EditUserPasswordGenerationTest extends TestCase
 
         $targetUser = User::factory()->create(['email_verified_at' => now()]);
         $targetUser->assignRole('Regular User');
+        // Enable MFA for the target user
+        $targetUser->forceFill([
+            'email_2fa_enabled' => true,
+        ])->save();
 
         $managerRole = Role::where('name', 'Manager of Users')->first();
 

--- a/tests/Feature/Web/Admin/UserManagementWebInterfaceTest.php
+++ b/tests/Feature/Web/Admin/UserManagementWebInterfaceTest.php
@@ -47,6 +47,11 @@ class UserManagementWebInterfaceTest extends TestCase
         $admin->assignRole('Manager of Users');
 
         $targetUser = User::factory()->create();
+        // Enable MFA for the target user so they can receive sensitive roles
+        $targetUser->forceFill([
+            'email_2fa_enabled' => true,
+        ])->save();
+
         $regularUserRole = Role::where('name', 'Regular User')->first();
         $managerRole = Role::where('name', 'Manager of Users')->first();
 


### PR DESCRIPTION
# feat: enforce MFA for sensitive permissions and add security enhancements

## Overview
Implement comprehensive MFA security requirements for users with administrative permissions to significantly improve account security.

## Changes

### Backend Security Enhancements
- **Added MFA requirement validation for sensitive permissions**
  - Created `Permission::sensitivePermissions()` method to identify permissions requiring MFA:
    - manage users
    - manage roles
    - assign roles
    - manage settings
  - Added `User::hasSensitivePermissions()` helper method
  - Implemented validation in `StoreUserManagementRequest` to prevent creating users with sensitive permissions
  - Implemented validation in `UpdateUserManagementRequest` to prevent assigning sensitive roles to users without MFA

- **Prevented MFA disable for privileged users**
  - Created custom `TwoFactorAuthenticationForm` component overriding Jetstream's default
  - Added validation in TOTP disable method to check for sensitive permissions
  - Updated `EmailTwoFactorForm` to prevent email 2FA disable for users with sensitive permissions
  - Users with sensitive permissions cannot disable MFA (both TOTP and Email)

### UI Enhancements
- **Added MFA status column to users list**
  - Shows "Enabled" with green badge and security icon for users with MFA
  - Shows "Disabled" with gray badge for users without MFA
  - Updated table colspan to accommodate new column

### Bug Fixes
- **Fixed HTTP 500 error when enabling email 2FA**
  - Added `ConfirmsPasswords` trait from Jetstream to `EmailTwoFactorForm`
  - Replaced custom redirect-based password confirmation with proper Jetstream integration
  - Password confirmation now works correctly with Livewire components

### Service Provider Updates
- **Registered custom Livewire components**
  - Override Jetstream's `TwoFactorAuthenticationForm` with custom implementation in `JetstreamServiceProvider`

### Test Updates
- **Updated all affected tests**
  - Added password confirmation session data to Email 2FA tests
  - Updated role assignment tests to use non-sensitive roles (Visitor) for new users
  - Updated role assignment tests to enable MFA for existing users before assigning sensitive roles
  - Added new test to verify MFA requirement validation
  - Fixed role names (Viewer → Visitor)
  - All 1854 tests now pass

## Security Impact
- **Enhanced protection for administrative accounts**: Users with privileges to manage users, roles, or settings must have MFA enabled
- **Prevention of privilege escalation**: New users cannot be created with sensitive permissions; they must enable MFA first
- **Mandatory MFA for privileged users**: Users with sensitive permissions cannot disable their MFA
- **Improved accountability**: Clear visibility of MFA status in user management interface

## Testing
- ✅ All 1854 backend tests passing
- ✅ Laravel Pint: No style issues (2 auto-fixed)
- ✅ TypeScript type checking: No errors
- ✅ ESLint: No errors
- ✅ Frontend build: Successful

## Breaking Changes
None - existing users are not affected. New security requirements only apply when:
1. Creating new users with sensitive permissions (now requires MFA first)
2. Assigning sensitive roles to existing users (requires MFA)
3. Attempting to disable MFA while having sensitive permissions (now prevented)
