### PR TITLE
Fix: CD workflow must install both root and SPA npm dependencies

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -155,17 +155,28 @@ jobs:
 
       - name: Install Node.js dependencies
         run: |
-          # Install NPM dependencies
+          # Install NPM dependencies at root (backend/Blade)
 
-          Write-Host "::group::Running npm install"
+          Write-Host "::group::Installing root npm dependencies"
           $global:LASTEXITCODE = 0
           & "$env:NPM_PATH" install --no-audit --no-fund
           if ($global:LASTEXITCODE -ne 0) {
-            Write-Host "::error::NPM install failed with exit code $global:LASTEXITCODE"
+            Write-Host "::error::Root npm install failed with exit code $global:LASTEXITCODE"
             exit $global:LASTEXITCODE
           }
           Write-Host "::endgroup::"
-          Write-Host "NPM dependencies installed successfully."
+          Write-Host "Root npm dependencies installed successfully."
+          
+          # Install SPA dependencies
+          Write-Host "::group::Installing SPA npm dependencies"
+          $global:LASTEXITCODE = 0
+          & "$env:NPM_PATH" --prefix ./spa install --no-audit --no-fund
+          if ($global:LASTEXITCODE -ne 0) {
+            Write-Host "::error::SPA npm install failed with exit code $global:LASTEXITCODE"
+            exit $global:LASTEXITCODE
+          }
+          Write-Host "::endgroup::"
+          Write-Host "SPA npm dependencies installed successfully."
         shell: powershell
 
       - name: Build frontend assets


### PR DESCRIPTION
ISSUE: 'vue-tsc' is not recognized - SPA dependencies not installed
- The CD workflow was only installing root npm dependencies
- When running 'npm --prefix ./spa run build', the spa/node_modules didn't exist
- Result: vue-tsc and all SPA build tools were missing

SOLUTION: Install both dependency sets
- Step 1: npm install (root, for backend/Blade)
- Step 2: npm --prefix ./spa install (SPA)
- Both must succeed before attempting builds

This matches the CI workflow pattern which already had both steps.

Result:
- SPA build tools (vue-tsc, vite) now available during deployment
- Both builds can execute successfully
- Prevents similar issues with any missing dev dependencies