### PR TITLE
Fix: CD workflow npm authentication and SPA build

### DIFF
--- a/spa/vite.config.js
+++ b/spa/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { fileURLToPath, URL } from 'node:url';
+import path from 'node:path';
 
 export default defineConfig({
     plugins: [
@@ -24,7 +25,7 @@ export default defineConfig({
     build: {
         target: 'esnext',
         sourcemap: true,
-        outDir: '../public/spa-build',
+        outDir: path.resolve(__dirname, '../public/spa-build'),
         manifest: 'manifest.json',
         rollupOptions: {
             input: 'index.html',


### PR DESCRIPTION
The issue is `outDir: '../public/spa-build'` - this relative path from the spa directory is being resolved incorrectly when the build happens in the deployment environment. The path gets calculated as an absolute path because the current working directory is set differently.

The fix is to use a computed path that's always relative to the spa directory root.

Fixes #450
Relates to #454
Relates to [workflow run #84](https://github.com/metanull/inventory-app/actions/runs/18956445220)