### PR TITLE
Fix: CD workflow npm authentication and SPA build

### DIFF
--- a/spa/vite.config.js
+++ b/spa/vite.config.js
@@ -29,7 +29,13 @@ export default defineConfig({
         manifest: 'manifest.json',
         rollupOptions: {
             input: 'index.html',
+            output: {
+                entryFileNames: '[name]-[hash].js',
+                chunkFileNames: '[name]-[hash].js',
+                assetFileNames: '[name]-[hash][extname]',
+            },
         },
         assetsInlineLimit: 0,
+        emptyOutDir: true,
     },
 });


### PR DESCRIPTION
Still the same issue:  `outDir: '../public/spa-build'`

Fixes #450
Relates to #454
Relates to [workflow run #84](https://github.com/metanull/inventory-app/actions/runs/18956445220)