### PR TITLE
fix: Add 'released' event type to deploy workflow trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   release:
-    types: [published]
+    types: [published, released]
   
   workflow_dispatch:
     # Allow manual triggering for testing


### PR DESCRIPTION
When converting a draft release to published via GitHub UI, GitHub may send
a 'released' event instead of 'published'. Adding both event types ensures
the deployment workflow triggers correctly in all scenarios:

- published: New release created directly (non-draft)
- released: Draft release converted to published

This fixes the issue where publishing release 6.2.6.8 from draft didn't
trigger the automatic deployment workflow.