### PR TITLE
ci: split mandatory audit gate from conditional build/test checks (#675)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,19 @@ updates:
     registries:
       - npm-github
 
+  - package-ecosystem: "npm"
+    directory: "/scripts/importer"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "npm"
+      - "dependencies"
+    groups:
+      importer-dev-dependencies:
+        dependency-type: "development"
+      importer-prod-dependencies:
+        dependency-type: "production"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,8 @@ The `/.github/workflows` directory contains GitHub Actions workflows for continu
   - [Table of contents](#table-of-contents)
   - [Notes](#notes)
   - [Continuous Integration and Testing](#continuous-integration-and-testing)
-    - [Continuous Integration](#continuous-integration)
+    - [Mandatory Checks](#mandatory-checks)
+    - [Build and Test](#build-and-test)
   - [Continuous Deployment](#continuous-deployment)
     - [Deploy Laravel Application](#deploy-laravel-application)
     - [Deploy Documentation to GitHub Pages](#deploy-documentation-to-github-pages)
@@ -30,9 +31,9 @@ The `/.github/workflows` directory contains GitHub Actions workflows for continu
 
 ## Continuous Integration and Testing
 
-### Continuous Integration
+### Mandatory Checks
 
-Validates code quality, runs tests, and ensures the application builds correctly before merging changes.
+Runs mandatory dependency audits on every pull request. Provides the `CI Success` status check required by branch protection rules.
 
 **Workflow properties**
 
@@ -41,52 +42,115 @@ Validates code quality, runs tests, and ensures the application builds correctly
 | **Workflow** | `continuous-integration.yml` |
 | **Trigger** | Pull requests to `main` branch (opened, synchronize, reopened) |
 | **Manual trigger** | Yes (`workflow_dispatch`) |
-| **Runner** | `windows-latest` (GitHub-hosted) |
-| **Concurrency** | Group: `ci-${{ github.ref }}`, cancel-in-progress: `true` |
+| **Runner** | `ubuntu-latest` (GitHub-hosted) |
+| **Concurrency** | Group: `ci-mandatory-${{ github.ref }}`, cancel-in-progress: `true` |
 
 **Jobs**
 
-1. **backend-validation** - Validates PHP/Laravel backend
-   - Installs PHP 8.2+ with extensions (fileinfo, zip, sqlite3, pdo_sqlite, gd, exif)
-   - Validates `composer.json` and checks platform requirements
-   - Installs dependencies with `composer install`
-   - Audits dependencies for security vulnerabilities
-   - Creates `.env` file from `.env.local.example`
-   - Runs database migrations (up and rollback tests)
-   - Lints code with Laravel Pint
-   - Runs test suites: CI/CD, Unit, and Feature tests with coverage
+1. **audit-composer** - Audits PHP/Composer dependencies
+   - Installs PHP 8.4 with extensions
+   - Validates `composer.json` with strict checks
+   - Installs Composer dependencies
+   - Runs `composer audit --format=summary`
 
-2. **frontend-validation** - Validates Node.js/Vue frontend
-   - Installs Node.js lts\Krypton (24.x)
-   - Installs npm dependencies with `npm ci`
-   - Audits npm packages for vulnerabilities
-   - Builds frontend assets with `npm run build`
-   - Lints code with `npm run lint`
-   - Runs all tests with `npm run test:all`
+2. **audit-npm-root** - Audits root npm dependencies
+   - Installs Node.js lts/Krypton (24.x)
+   - Installs root npm dependencies
+   - Runs `npm audit --audit-level moderate`
 
-3. **ci-success** - Aggregates results
-   - Checks that both backend and frontend validation jobs succeeded
-   - Fails the workflow if either validation job failed
+3. **audit-npm-importer** - Audits `scripts/importer` npm dependencies
+   - Installs Node.js lts/Krypton (24.x)
+   - Installs importer npm dependencies from `scripts/importer/`
+   - Runs `npm audit --audit-level moderate`
+
+4. **audit-npm-spa** - Audits SPA npm dependencies
+   - Installs Node.js lts/Krypton (24.x)
+   - Installs SPA npm dependencies (authenticated with `GITHUB_TOKEN` for GitHub Packages)
+   - Runs `npm audit --audit-level moderate`
+
+5. **ci-success** - Aggregates audit results
+   - Requires all 4 audit jobs to succeed
+   - Fails the workflow if any audit job failed or was skipped
+   - This job name satisfies the `CI Success` branch protection required check
 
 **Permissions**
 
-- `contents: write` - For potential version bumps
-- `pull-requests: write` - For PR comments and labels
-- `packages: read` - For accessing GitHub Packages
+- `contents: read` - For reading repository contents
+- `packages: read` - For accessing GitHub Packages (SPA dependencies)
+
+**Branch protection**
+
+The `CI Success` job in this workflow satisfies the `CI Success` required status check configured in branch protection rules for `main`. All 4 audits must pass before a PR can be merged.
 
 **Usage**
 
-This workflow runs automatically on pull requests. For manual testing:
+This workflow runs automatically on pull requests. For manual triggering:
 
-```powershell
-# Trigger via GitHub UI: Actions > Continuous Integration > Run workflow
+```
+Actions > Mandatory Checks > Run workflow
 ```
 
-**Links**
+---
 
-| Reference | URL |
+### Build and Test
+
+Runs build and test jobs conditionally based on which paths changed in the pull request. Jobs are skipped when no relevant files were modified. This workflow does not provide a required status check.
+
+**Workflow properties**
+
+| Property | Value |
 | --- | --- |
-| GitHub Actions workflow_dispatch | [https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) |
+| **Workflow** | `ci-build-test.yml` |
+| **Trigger** | Pull requests to `main` branch (opened, synchronize, reopened) |
+| **Manual trigger** | Yes (`workflow_dispatch`) — all jobs run when triggered manually |
+| **Runner** | `ubuntu-latest` (GitHub-hosted) |
+| **Concurrency** | Group: `ci-build-test-${{ github.ref }}`, cancel-in-progress: `true` |
+
+**Path groups and triggered jobs**
+
+| Changed paths | Jobs triggered |
+| --- | --- |
+| `app/**`, `routes/**`, `config/**`, `database/**`, `tests/**`, `bootstrap/**`, `composer.json`, `composer.lock`, `phpunit.xml`, `artisan` | `backend-lint`, `backend-tests` |
+| `resources/css/**`, `resources/js/**`, `resources/views/**`, `vite.config.js`, `tailwind.config.js`, `postcss.config.js`, `package.json`, `package-lock.json`, `tsconfig.json`, `eslint.config.js` | `backend-rendered-frontend-validation` |
+| `spa/**` | `spa-frontend-validation` |
+
+**Jobs**
+
+1. **detect-changes** - Classifies changed files using `git diff` against the PR base SHA
+   - Emits outputs: `backend`, `root-frontend`, `spa` (true/false)
+   - All outputs are `true` when triggered by `workflow_dispatch`
+
+2. **backend-lint** *(when `backend=true`)* - Laravel backend linting
+   - Installs PHP 8.4 with extensions and Pint
+   - Installs Composer dependencies
+   - Creates `.env` from `.env.local.example`, migrates database
+   - Runs `./vendor/bin/pint --bail`
+
+3. **backend-tests** *(when `backend=true`)* - Laravel test matrix
+   - Matrix: `Unit`, `Api`, `Web`, `Configuration`, `Console`, `Event`, `Integration`
+   - `fail-fast: true` — stops remaining suites on first failure
+   - Runs each suite with `--coverage --parallel --stop-on-failure`
+
+4. **backend-rendered-frontend-validation** *(when `root-frontend=true`)* - Blade/Tailwind build
+   - Installs Node.js lts/Krypton and root npm dependencies
+   - Runs `npm run build`
+
+5. **spa-frontend-validation** *(when `spa=true`)* - SPA (Vue 3) validation
+   - Installs Node.js lts/Krypton and SPA npm dependencies
+   - Runs lint, build, and `npm run test:all`
+
+**Permissions**
+
+- `contents: read` - For reading repository contents
+- `packages: read` - For accessing GitHub Packages (SPA dependencies)
+
+**Usage**
+
+This workflow runs automatically on pull requests. Skipped jobs are expected when their path group has no changed files. For manual triggering (all jobs run):
+
+```
+Actions > Build and Test > Run workflow
+```
 
 ---
 
@@ -477,11 +541,11 @@ Several workflows interact with scripts and other workflows:
 
 | Workflow | Depends On | Triggers |
 | --- | --- | --- |
-| `continuous-integration.yml` | - | `version-bump.yml` |
-| `continuous-deployment.yml` | - | - |
+| `continuous-integration.yml` | - | - |
+| `ci-build-test.yml` | - | - |
+| `build.yml` | - | `deploy-ovh.yml` |
 | `continuous-deployment_github-pages.yml` | [/scripts/README.md](../../scripts/README.md) scripts | - |
-| `publish-npm-github-package.yml` | API client generation | - |
-| `version-bump.yml` | `continuous-integration.yml` | - |
+| `publish-api-client.yml` | API client generation | - |
 | `merge-dependabot-pr.yml` | - | - |
 
 **Scripts used by workflows:**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,13 +199,18 @@ jobs:
         echo "  :white_check_mark: VERSION copied to public/version.json"
         echo "::endgroup::"
         
-        echo "::group::Creating deployment archive"
+        echo "::group::Creating deployment archives"
         archivePath="${{ runner.temp }}/inventory-app.zip"
         cd "$deployDir"
         zip -r "$archivePath" .
-        cd -
-        echo "  :white_check_mark: Archive created at $archivePath"
+        echo "  :white_check_mark: ZIP archive created at $archivePath"
         echo "PACKAGE_ZIP=$archivePath" >> $GITHUB_ENV
+
+        tarballPath="${{ runner.temp }}/release.tar.gz"
+        tar czf "$tarballPath" .
+        echo "  :white_check_mark: Tarball created at $tarballPath"
+        echo "PACKAGE_TGZ=$tarballPath" >> $GITHUB_ENV
+        cd -
         echo "::endgroup::"
       shell: bash
 
@@ -217,7 +222,7 @@ jobs:
       shell: bash
 
     - name: Create Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ env.RELEASE_TAG }}
         name: Release ${{ env.RELEASE_TAG }}
@@ -244,11 +249,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Upload deployment artifact
+    - name: Upload deployment artifact (OVH)
       uses: actions/upload-artifact@v7
       with:
-        name: deployment-${{ github.sha }}
-        path: ${{ env.PACKAGE_ZIP }}
+        name: release-${{ github.sha }}
+        path: ${{ env.PACKAGE_TGZ }}
         retention-days: 7
 
     - name: Done

--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -1,0 +1,232 @@
+name: Build and Test
+
+permissions:
+  contents: read
+  packages: read
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize, reopened]
+
+  workflow_dispatch:
+
+concurrency:
+  group: ci-build-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  detect-changes:
+    name: Detect Changed Paths
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.detect.outputs.backend }}
+      root-frontend: ${{ steps.detect.outputs.root-frontend }}
+      spa: ${{ steps.detect.outputs.spa }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: detect
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "backend=true" >> $GITHUB_OUTPUT
+            echo "root-frontend=true" >> $GITHUB_OUTPUT
+            echo "spa=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          BASE="${{ github.event.pull_request.base.sha }}"
+          CHANGED=$(git diff --name-only "$BASE" HEAD)
+
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          if echo "$CHANGED" | grep -qE '^(app|routes|config|database|tests|bootstrap)/|^(composer\.json|composer\.lock|phpunit\.xml|artisan)$'; then
+            echo "backend=true" >> $GITHUB_OUTPUT
+          else
+            echo "backend=false" >> $GITHUB_OUTPUT
+          fi
+
+          if echo "$CHANGED" | grep -qE '^(resources/css|resources/js|resources/views)/|^(vite\.config\.js|tailwind\.config\.js|postcss\.config\.js|package\.json|package-lock\.json|tsconfig\.json|eslint\.config\.js)$'; then
+            echo "root-frontend=true" >> $GITHUB_OUTPUT
+          else
+            echo "root-frontend=false" >> $GITHUB_OUTPUT
+          fi
+
+          if echo "$CHANGED" | grep -qE '^spa/'; then
+            echo "spa=true" >> $GITHUB_OUTPUT
+          else
+            echo "spa=false" >> $GITHUB_OUTPUT
+          fi
+
+  backend-lint:
+    name: Backend Linting and Validation
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.backend == 'true'
+
+    env:
+      DB_CONNECTION: sqlite
+      DB_DATABASE: ':memory:'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Setup > Image > Install php"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: fileinfo, zip, sqlite3, pdo_sqlite, gd, exif
+          tools: pint
+
+      - name: "Check > Composer > Check requirements"
+        run: |
+          composer check-platform-reqs
+
+      - name: "Setup > Composer > Install Dependencies"
+        run: |
+          composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: "Setup > Laravel > Create .env file from example"
+        run: |
+          cp .env.local.example .env
+          rm -rf bootstrap/cache/*.php || true
+
+      - name: "Setup > Laravel > Generate application key"
+        run: |
+          php artisan key:generate
+
+      - name: "Setup > Laravel > Create database"
+        run: |
+          php artisan migrate --force
+
+      - name: "Check > Laravel > Linting"
+        run: |
+          ./vendor/bin/pint --bail
+
+  backend-tests:
+    name: Backend Tests (${{ matrix.suite }})
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.backend == 'true'
+
+    env:
+      DB_CONNECTION: sqlite
+      DB_DATABASE: ':memory:'
+
+    strategy:
+      fail-fast: true
+      matrix:
+        suite:
+          - Unit
+          - Api
+          - Web
+          - Configuration
+          - Console
+          - Event
+          - Integration
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Setup > Image > Install php"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: fileinfo, zip, sqlite3, pdo_sqlite, gd, exif
+          coverage: xdebug
+          tools: phpunit, pest
+
+      - name: "Setup > Composer > Install Dependencies"
+        run: |
+          composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: "Setup > Laravel > Create .env file from example"
+        run: |
+          cp .env.local.example .env
+          rm -rf bootstrap/cache/*.php || true
+
+      - name: "Setup > Laravel > Generate application key"
+        run: |
+          php artisan key:generate
+
+      - name: "Setup > Laravel > Create database"
+        run: |
+          php artisan migrate --force
+
+      - name: "Check > Laravel > Run ${{ matrix.suite }} Tests"
+        run: |
+          php artisan test --testsuite=${{ matrix.suite }} --coverage --parallel --no-ansi --stop-on-failure
+
+  backend-rendered-frontend-validation:
+    name: Backend Rendered Frontend Validation (Blade/Tailwind)
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.root-frontend == 'true'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Setup > Image > Install Node.js"
+        uses: actions/setup-node@v6
+        with:
+          node-version: "lts/Krypton"
+          registry-url: https://npm.pkg.github.com/
+
+      - name: "Setup > node > Enable Corepack"
+        run: |
+          corepack enable
+
+      - name: "Setup > npm > Install Dependencies"
+        run: |
+          npm ci --no-audit --no-fund
+
+      - name: "Check > npm > Build Backend Assets"
+        run: |
+          npm run build
+
+  spa-frontend-validation:
+    name: Frontend Validation - SPA (Vue 3)
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.spa == 'true'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Setup > Image > Install Node.js"
+        uses: actions/setup-node@v6
+        with:
+          node-version: "lts/Krypton"
+          registry-url: https://npm.pkg.github.com/
+
+      - name: "Setup > node > Enable Corepack"
+        run: |
+          corepack enable
+
+      - name: "Setup > npm > Install Dependencies (SPA)"
+        working-directory: spa
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm ci --no-audit --no-fund
+
+      - name: "Check > npm > Linting (SPA)"
+        working-directory: spa
+        run: |
+          npm run lint
+
+      - name: "Check > npm > Build (SPA)"
+        working-directory: spa
+        run: |
+          npm run build
+
+      - name: "Check > npm > Run Tests (SPA)"
+        working-directory: spa
+        run: |
+          npm run test:all

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,9 +1,8 @@
-name: Checks and Tests
+name: Mandatory Checks
 
 permissions:
-  contents: write  # Need write permissions for version bump
-  pull-requests: write
-  packages: read   # Need read permissions for GitHub Packages
+  contents: read
+  packages: read
 
 on:
   pull_request:
@@ -11,21 +10,16 @@ on:
     types: [opened, synchronize, reopened]
 
   workflow_dispatch:
-    # Allow manual triggering
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-mandatory-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  
-  backend-lint:
-    name: Backend Linting and Validation
+
+  audit-composer:
+    name: Audit - Composer (PHP)
     runs-on: ubuntu-latest
-    
-    env:
-      DB_CONNECTION: sqlite
-      DB_DATABASE: ':memory:'
 
     steps:
       - uses: actions/checkout@v6
@@ -33,13 +27,8 @@ jobs:
       - name: "Setup > Image > Install php"
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'  # If not specified, setup-php will use the version defined in composer.lock
+          php-version: '8.4'
           extensions: fileinfo, zip, sqlite3, pdo_sqlite, gd, exif
-          tools: pint
-
-      - name: "Check > Composer > Check requirements"
-        run: |
-          composer check-platform-reqs
 
       - name: "Check > Composer > Validate composer.json"
         run: |
@@ -49,112 +38,12 @@ jobs:
         run: |
           composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
 
-      - name: "Setup > Composer > Check Vulnerabilities"
+      - name: "Check > Composer > Audit Vulnerabilities"
         run: |
           composer audit --format=summary
 
-      - name: "Setup > Laravel > Create .env file from example"
-        run: |
-          if [ ! -f ".env.local.example" ]; then
-            echo "::error::No .env.local.example file found!"
-            exit 1
-          fi
-          if [ ! -f ".env" ]; then
-            echo "Creating .env file from .env.local.example"
-            cp .env.local.example .env
-          else
-            echo ".env file already exists, skipping creation"
-          fi
-          echo "Removing cached files"
-          rm -rf bootstrap/cache/*.php || true
-          
-          echo "::group::Debug Environment"
-          echo "=== DB_CONNECTION environment variable:"
-          echo "DB_CONNECTION=${DB_CONNECTION:-NOT SET}"
-          echo "=== All DB_* environment variables:"
-          env | grep "^DB_" || echo "No DB_* environment variables found"
-          echo "=== From .env file:"
-          grep "^DB_CONNECTION=" .env || echo "DB_CONNECTION not in .env"
-          echo "::endgroup::"
-
-      - name: "Setup > Laravel > Generate application key"
-        run: |
-          php artisan key:generate
-
-      - name: "Setup > Laravel > Create database"
-        run: |
-          echo "::group::Create the database and run migrations"
-          php artisan migrate --force
-          echo "::endgroup::"
-
-      - name: "Check > Laravel > Linting"
-        run: |
-          ./vendor/bin/pint --bail
-
-  backend-tests:
-    name: Backend Tests (${{ matrix.suite }})
-    runs-on: ubuntu-latest
-    
-    env:
-      DB_CONNECTION: sqlite
-      DB_DATABASE: ':memory:'
-    
-    strategy:
-      fail-fast: true  # Stop running other suites as soon as one fails
-      matrix:
-        suite:
-          - Unit
-          - Api
-          - Web
-          - Configuration
-          - Console
-          - Event
-          - Integration
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: "Setup > Image > Install php"
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.4'  # If not specified, setup-php will use the version defined in composer.lock
-          extensions: fileinfo, zip, sqlite3, pdo_sqlite, gd, exif
-          coverage: xdebug
-          tools: phpunit, pest
-
-      - name: "Setup > Composer > Install Dependencies"
-        run: |
-          composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-
-      - name: "Setup > Laravel > Create .env file from example"
-        run: |
-          if [ ! -f ".env.local.example" ]; then
-            echo "::error::No .env.local.example file found!"
-            exit 1
-          fi
-          if [ ! -f ".env" ]; then
-            echo "Creating .env file from .env.local.example"
-            cp .env.local.example .env
-          else
-            echo ".env file already exists, skipping creation"
-          fi
-          echo "Removing cached files"
-          rm -rf bootstrap/cache/*.php || true
-
-      - name: "Setup > Laravel > Generate application key"
-        run: |
-          php artisan key:generate
-
-      - name: "Setup > Laravel > Create database"
-        run: |
-          php artisan migrate --force
-
-      - name: "Check > Laravel > Run ${{ matrix.suite }} Tests"
-        run: |
-          php artisan test --testsuite=${{ matrix.suite }} --coverage --parallel --no-ansi --stop-on-failure
-
-  backend-rendered-frontend-validation:
-    name: Backend Rendered Frontend Validation (Blade/Tailwind)
+  audit-npm-root:
+    name: Audit - npm (Root)
     runs-on: ubuntu-latest
 
     steps:
@@ -164,7 +53,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "lts/Krypton"
-          registry-url: https://npm.pkg.github.com/
 
       - name: "Setup > node > Enable Corepack"
         run: |
@@ -174,16 +62,38 @@ jobs:
         run: |
           npm ci --no-audit --no-fund
 
-      - name: "Check > npm > Check Vulnerabilities"
+      - name: "Check > npm > Audit Vulnerabilities"
         run: |
           npm audit --audit-level moderate
 
-      - name: "Check > npm > Build Backend Assets"
-        run: |
-          npm run build
+  audit-npm-importer:
+    name: Audit - npm (Importer)
+    runs-on: ubuntu-latest
 
-  spa-frontend-validation:
-    name: Frontend Validation - SPA (Vue 3)
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Setup > Image > Install Node.js"
+        uses: actions/setup-node@v6
+        with:
+          node-version: "lts/Krypton"
+
+      - name: "Setup > node > Enable Corepack"
+        run: |
+          corepack enable
+
+      - name: "Setup > npm > Install Dependencies (Importer)"
+        working-directory: scripts/importer
+        run: |
+          npm ci --no-audit --no-fund
+
+      - name: "Check > npm > Audit Vulnerabilities (Importer)"
+        working-directory: scripts/importer
+        run: |
+          npm audit --audit-level moderate
+
+  audit-npm-spa:
+    name: Audit - npm (SPA)
     runs-on: ubuntu-latest
 
     steps:
@@ -200,51 +110,40 @@ jobs:
           corepack enable
 
       - name: "Setup > npm > Install Dependencies (SPA)"
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         working-directory: spa
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm ci --no-audit --no-fund
 
-      - name: "Check > npm > Check Vulnerabilities (SPA)"
+      - name: "Check > npm > Audit Vulnerabilities (SPA)"
         working-directory: spa
         run: |
           npm audit --audit-level moderate
 
-      - name: "Check > npm > Linting (SPA)"
-        working-directory: spa
-        run: |
-          npm run lint
-
-      - name: "Check > npm > Build (SPA)"
-        working-directory: spa
-        run: |
-          npm run build
-
-      - name: "Check > npm > Run Tests (SPA)"
-        working-directory: spa
-        run: |
-          npm run test:all
-
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [backend-lint, backend-tests, backend-rendered-frontend-validation, spa-frontend-validation]
+    needs: [audit-composer, audit-npm-root, audit-npm-importer, audit-npm-spa]
     if: always()
 
     steps:
-      - name: Check all jobs succeeded
+      - name: Check all mandatory checks passed
         run: |
-          backendLintResult="${{ needs.backend-lint.result }}"
-          backendTestsResult="${{ needs.backend-tests.result }}"
-          backendFrontendResult="${{ needs.backend-rendered-frontend-validation.result }}"
-          spaFrontendResult="${{ needs.spa-frontend-validation.result }}"
+          composerResult="${{ needs.audit-composer.result }}"
+          npmRootResult="${{ needs.audit-npm-root.result }}"
+          npmImporterResult="${{ needs.audit-npm-importer.result }}"
+          npmSpaResult="${{ needs.audit-npm-spa.result }}"
 
-          if [ "$backendLintResult" != "success" ] || [ "$backendTestsResult" != "success" ] || [ "$backendFrontendResult" != "success" ] || [ "$spaFrontendResult" != "success" ]; then
-            echo "One or more validation jobs failed"
-            echo "Backend Lint: $backendLintResult"
-            echo "Backend Tests: $backendTestsResult"
-            echo "Backend Frontend: $backendFrontendResult"
-            echo "SPA Frontend: $spaFrontendResult"
+          if [ "$composerResult" != "success" ] || \
+             [ "$npmRootResult" != "success" ] || \
+             [ "$npmImporterResult" != "success" ] || \
+             [ "$npmSpaResult" != "success" ]; then
+            echo "One or more mandatory checks failed"
+            echo "Composer Audit:       $composerResult"
+            echo "npm Audit (Root):     $npmRootResult"
+            echo "npm Audit (Importer): $npmImporterResult"
+            echo "npm Audit (SPA):      $npmSpaResult"
             exit 1
           fi
+          echo "All mandatory checks passed"

--- a/.github/workflows/deploy-ovh.yml
+++ b/.github/workflows/deploy-ovh.yml
@@ -64,18 +64,18 @@ jobs:
       - name: Download deployment artifact
         uses: actions/download-artifact@v7
         with:
-          name: deployment-${{ steps.source.outputs.head_sha }}
+          name: release-${{ steps.source.outputs.head_sha }}
           run-id: ${{ steps.source.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify artifact
         run: |
-          if [[ ! -f inventory-app.zip ]]; then
-            echo "::error::inventory-app.zip not found in downloaded artifact"
+          if [[ ! -f release.tar.gz ]]; then
+            echo "::error::release.tar.gz not found in downloaded artifact"
             ls -la
             exit 1
           fi
-          echo "Artifact size: $(du -h inventory-app.zip | cut -f1)"
+          echo "Artifact size: $(du -h release.tar.gz | cut -f1)"
 
       - name: Setup SSH
         run: |
@@ -104,7 +104,7 @@ jobs:
           VPS_USER: ${{ secrets.VPS_SSH_USER }}
         run: |
           scp -i ~/.ssh/deploy_key -o ConnectTimeout=30 \
-            inventory-app.zip "${VPS_USER}@${VPS_HOST}:/tmp/inventory-release.zip"
+            release.tar.gz "${VPS_USER}@${VPS_HOST}:/tmp/inventory-release.tar.gz"
 
       - name: Upload deploy script to VPS
         env:
@@ -120,7 +120,7 @@ jobs:
           VPS_USER: ${{ secrets.VPS_SSH_USER }}
         run: |
           ssh -i ~/.ssh/deploy_key -o ConnectTimeout=30 "${VPS_USER}@${VPS_HOST}" \
-            'bash /tmp/inventory-deploy-ovh.sh /tmp/inventory-release.zip'
+            'bash /tmp/inventory-deploy-ovh.sh /tmp/inventory-release.tar.gz'
 
       - name: Cleanup
         if: always()
@@ -130,4 +130,4 @@ jobs:
         run: |
           ssh -i ~/.ssh/deploy_key -o ConnectTimeout=30 \
             "${VPS_USER}@${VPS_HOST}" \
-            'rm -f /tmp/inventory-release.zip /tmp/inventory-deploy-ovh.sh' || true
+            'rm -f /tmp/inventory-release.tar.gz /tmp/inventory-deploy-ovh.sh' || true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "inventory-app",
-    "version": "6.12.6",
+    "version": "6.12.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "inventory-app",
-            "version": "6.12.6",
+            "version": "6.12.7",
             "dependencies": {
                 "glob": "^13.0.6"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "inventory-app",
-    "version": "6.12.6",
+    "version": "6.12.7",
     "private": true,
     "type": "module",
     "scripts": {

--- a/scripts/deploy-ovh.sh
+++ b/scripts/deploy-ovh.sh
@@ -3,7 +3,7 @@
 # deploy-ovh.sh — Deploy a pre-built inventory-app release to the OVH VPS
 #
 # Usage (run as 'deploy' user):
-#   bash deploy-ovh.sh /tmp/inventory-release.zip
+#   bash deploy-ovh.sh /tmp/inventory-release.tar.gz
 #
 # The archive is built by CI (build.yml) and contains the full application
 # with production vendor/ and compiled public/build/ assets.
@@ -29,7 +29,7 @@ PHP_VERSION="8.4"
 
 # --- Arguments ---------------------------------------------------------------
 ARCHIVE="${1:-}"
-[[ -z "$ARCHIVE" ]] && { echo "[DEPLOY] ERROR: Usage: deploy-ovh.sh <archive.zip>"; exit 1; }
+[[ -z "$ARCHIVE" ]] && { echo "[DEPLOY] ERROR: Usage: deploy-ovh.sh <archive.tar.gz>"; exit 1; }
 [[ ! -f "$ARCHIVE" ]] && { echo "[DEPLOY] ERROR: Archive not found: ${ARCHIVE}"; exit 1; }
 
 # --- Colors -------------------------------------------------------------------
@@ -50,8 +50,8 @@ preflight() {
     # Verify PHP is available
     command -v php &>/dev/null || error "PHP not found. Run provision-inventory.sh first (as root)."
 
-    # Verify unzip is available
-    command -v unzip &>/dev/null || error "unzip not found. Install with: apt install unzip"
+    # Verify tar is available
+    command -v tar &>/dev/null || error "tar not found."
 
     # Verify app directory is writable
     [[ -w "$APP_DIR" ]] || error "${APP_DIR} is not writable. Run provision-inventory.sh first."
@@ -66,7 +66,7 @@ deploy_release() {
     mkdir -p "$RELEASE_DIR"
 
     info "Extracting release to ${RELEASE_DIR}..."
-    unzip -q "$ARCHIVE" -d "$RELEASE_DIR"
+    tar xzf "$ARCHIVE" -C "$RELEASE_DIR"
 
     # Symlink shared storage into the release
     rm -rf "${RELEASE_DIR}/storage"


### PR DESCRIPTION
## Summary

Implements story #675 and all four child stories.

---

## Changes

### `continuous-integration.yml` — repurposed as always-on mandatory audit workflow (closes #676)
- 4 parallel audit jobs: `audit-composer`, `audit-npm-root`, `audit-npm-importer`, `audit-npm-spa`
- `ci-success` gate job preserves the required status check name `CI Success` used by branch protection — no ruleset changes needed (closes #678)
- Permissions reduced to `contents: read / packages: read`

### `.github/workflows/ci-build-test.yml` — new conditional build/test workflow (closes #677)
- `detect-changes` job classifies PR file changes into three path groups: `backend`, `root-frontend`, `spa`
- `backend-lint` and `backend-tests` matrix run only when backend paths changed
- `backend-rendered-frontend-validation` runs only when root frontend paths changed
- `spa-frontend-validation` runs only when `spa/**` paths changed
- `workflow_dispatch` forces all jobs to run (no PR base SHA available)

### `.github/workflows/README.md` — documentation aligned with actual CI (closes #679)
- Replaced stale "Continuous Integration" section with accurate "Mandatory Checks" and "Build and Test" sections
- Corrected runner (`ubuntu-latest`), removed stale `version-bump.yml` / `continuous-deployment.yml` references
- Updated workflow dependencies table

### `.github/dependabot.yml` — added Dependabot entry for `scripts/importer` (follow-up to #675)
- Weekly npm update monitoring for `/scripts/importer`
- No registry entry required (importer uses only public npm packages)