### PR TITLE
fix(ci): downgrade upload-artifact from v8 to v7 (v8 does not exist)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,7 +250,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload deployment artifact (OVH)
-      uses: actions/upload-artifact@v8
+      uses: actions/upload-artifact@v7
       with:
         name: release-${{ github.sha }}
         path: ${{ env.PACKAGE_TGZ }}


### PR DESCRIPTION
## Fix

`actions/upload-artifact@v8` does not exist. The latest major version is `v7` (v7.0.1).

This was introduced in #674 and causes the `build.yml` workflow to fail on every run with:
```
Unable to resolve action `actions/upload-artifact@v8`, unable to find version `v8`
```

### Change

- `.github/workflows/build.yml`: `actions/upload-artifact@v8` → `actions/upload-artifact@v7`