### PR TITLE
Fix importer MySQL zero-date rejection and add deployment AI instructions

### DIFF
--- a/.github/agents/legacy-importer.agent.md
+++ b/.github/agents/legacy-importer.agent.md
@@ -1,5 +1,5 @@
 ---
-description: "Use when: running or troubleshooting the legacy data importer, populating the inventory-app database from legacy MWNF databases, managing .env configuration for importer environments, syncing legacy images, running import commands locally or on the production server via PSSession."
+description: "Use when: running or troubleshooting the legacy data importer, populating the inventory-app database from legacy MWNF databases, managing .env configuration for importer environments, syncing legacy images, running import commands locally or on the production server via PSSession, or importing data to the OVH VPS via SSH tunnel."
 tools: [read, search, execute]
 ---
 You are a specialist in using the `scripts/importer` tool to populate the inventory-app database with data from the legacy MWNF system. You know the importer architecture, its CLI commands, environment configuration for both local development and production, and can orchestrate full or partial import runs.
@@ -152,6 +152,65 @@ git reset --hard origin/main
 - Legacy images: `C:\mwnf-server\pictures\images`
 - Target images: resolved via `php artisan storage:image-path pictures` or set explicitly
 
+**OVH VPS** (run from developer machine via SSH tunnel):
+
+The OVH VPS (`inventory.metanull.eu`) has **no legacy database**, **no legacy images**, and **no Node.js runtime**. The `deploy` user has no sudo. The importer cannot run directly on the VPS.
+
+Instead, run the importer from the developer's local machine using an SSH tunnel to reach the OVH MySQL database (which is bound to `127.0.0.1` only). Images are synced via SCP after the import.
+
+**Prerequisites:**
+- VPN active (to reach the legacy DB on the MWNF Windows server)
+- SSH key: `~/.ssh/inventory_deploy` (for the `deploy` user on the OVH VPS)
+- The OVH VPS host IP or hostname (stored in GitHub Environment secret `VPS_HOST`)
+
+**SSH tunnel for OVH MySQL access:**
+```powershell
+# Open an SSH tunnel: local port 3307 → OVH localhost:3306
+ssh -L 3307:127.0.0.1:3306 deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy -N
+```
+Keep this tunnel open in a separate terminal while running the importer.
+
+**Importer `.env` configuration for OVH:**
+```env
+# Legacy Database source (via VPN — same as local dev)
+LEGACY_DB_HOST=192.168.255.157
+LEGACY_DB_PORT=3306
+LEGACY_DB_USER=<vpn_user>
+LEGACY_DB_PASSWORD=<vpn_password>
+LEGACY_DB_DATABASE=mwnf3
+
+# Target: OVH inventory database (via SSH tunnel on port 3307)
+DB_HOST=127.0.0.1
+DB_PORT=3307
+DB_USERNAME=inventory
+DB_PASSWORD=<ovh_db_password>
+DB_DATABASE=inventory
+```
+
+The OVH MySQL credentials are stored in `/home/deploy/.inventory-db-credentials` on the VPS (created by `provision-inventory.sh`). Retrieve them via SSH:
+```powershell
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cat ~/.inventory-db-credentials'
+```
+
+**Image sync for OVH:**
+
+Image-sync runs locally against the legacy images, writing to a local temporary folder. Then SCP the images to the VPS:
+```powershell
+# 1. Run image-sync to a local temp folder
+npx tsx src/cli/import.ts image-sync --copy --target-dir E:\temp\ovh-images
+
+# 2. SCP images to VPS production storage
+scp -i ~/.ssh/inventory_deploy -r E:\temp\ovh-images/* deploy@<VPS_HOST>:/opt/inventory/shared/storage/app/public/images/
+```
+
+Note: The OVH target images path is `/opt/inventory/shared/storage/app/public/images/` (in the shared storage directory, which is symlinked into each release's `storage/app/public/images`).
+
+**Post-import artisan commands on OVH** (run via SSH, not PSSession):
+```powershell
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan glossary:resync --remove-existing --force'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan queue:work --queue=glossary --stop-when-empty'
+```
+
 ## Full Reset & Import Workflow
 
 The complete sequence to wipe and rebuild the target database from legacy data:
@@ -256,6 +315,59 @@ Remove-PSSession $session
 | Laravel logs | `…\production\inventory-app\storage\logs\laravel.log` |
 | Importer logs | `…\temp\inventory-app\scripts\importer\logs\` |
 
+### OVH VPS (via SSH tunnel from developer machine)
+
+The OVH VPS has no Node.js, no legacy DB, and no legacy images. The importer runs locally with an SSH tunnel to the OVH MySQL.
+
+**In a separate terminal — keep the SSH tunnel open:**
+```powershell
+ssh -L 3307:127.0.0.1:3306 deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy -N
+```
+
+**Retrieve OVH DB credentials (one-time):**
+```powershell
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cat ~/.inventory-db-credentials'
+```
+
+**Configure `.env` for OVH** (in `scripts/importer/.env`):
+- Legacy DB: `192.168.255.157:3306` via VPN (same as local dev)
+- Target DB: `127.0.0.1:3307` (SSH tunnel to OVH)
+- Legacy images: `Z:\mwnf\images` or local copy
+- Target images: local temp folder (SCP'd to VPS after), preferably on Z: drive for space (Z:\mwnf\temp\ovh-images)
+
+```powershell
+# 1. Ensure VPN is active and SSH tunnel is open (see above)
+
+# 2. Reset the OVH database (via SSH)
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan db:wipe'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan migrate:refresh --quiet'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan db:seed --class=MinimalDatabaseSeeder --quiet'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan permission:sync'
+
+# 3. Run the importer locally (writes to OVH DB via tunnel)
+cd E:\inventory\inventory-app\scripts\importer
+npx tsx src/cli/import.ts import
+
+# 4. Sync images locally, then SCP to VPS
+npx tsx src/cli/import.ts image-sync --copy --target-dir E:\temp\ovh-images
+scp -i ~/.ssh/inventory_deploy -r E:\temp\ovh-images/* deploy@<VPS_HOST>:/opt/inventory/shared/storage/app/public/images/
+
+# 5. Post-import glossary resync (via SSH)
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan glossary:resync --remove-existing --force'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan queue:work --queue=glossary --stop-when-empty'
+```
+
+**OVH paths:**
+
+| Item | Path |
+|------|------|
+| App root | `/opt/inventory/current` (symlink → `releases/<timestamp>`) |
+| Shared storage | `/opt/inventory/shared/storage/` |
+| Target images | `/opt/inventory/shared/storage/app/public/images/` |
+| `.env` (Laravel) | `/opt/inventory/shared/.env` |
+| DB credentials | `/home/deploy/.inventory-db-credentials` |
+| Laravel logs | `/opt/inventory/shared/storage/logs/laravel.log` |
+
 ## Architecture Quick Reference
 
 - **Importers** extend `BaseImporter` → implement `import(): Promise<ImportResult>`
@@ -272,8 +384,10 @@ Remove-PSSession $session
 - **NEVER run destructive database commands** (`db:wipe`, `migrate:refresh`) without explicit user confirmation
 - **NEVER run production commands** without explicit user confirmation — always confirm the target environment first
 - **Always validate connections** (`npx tsx src/cli/import.ts validate`) before a full import run
-- **Always confirm the active `.env` profile** (local vs production) before executing import commands
+- **Always confirm the active `.env` profile** (local vs production vs OVH) before executing import commands
 - When running on production via PSSession, follow the same read-only-by-default approach — only execute mutating commands when the user explicitly requests it
+- When targeting OVH, always ensure the SSH tunnel is open before running the importer
+- **NEVER expose OVH MySQL to the internet** — always use SSH tunnels for remote access
 
 ## Approach
 

--- a/.github/agents/server-inspector.agent.md
+++ b/.github/agents/server-inspector.agent.md
@@ -190,6 +190,14 @@ The server uses symlinks extensively for upgradability. When inspecting:
 5. Flag anything unexpected (broken symlinks, missing directories, apps without vhost links, stale Git state)
 6. Close the session
 
+## Related Instructions
+
+For deployment pipeline and server configuration details beyond what this inspector covers:
+
+- **`server-setup-windows.instructions.md`** — MWNF Windows server topology, blue-green deployment pattern, GitHub Actions runner, MWNF-SVR environment config
+- **`server-setup-ovh.instructions.md`** — OVH VPS topology, deploy-ovh.sh, Nginx/PHP-FPM setup, Valkey isolation
+- **`build-workflow.instructions.md`** — Build pipeline, artifact packaging (ZIP for Windows, tarball for OVH), release creation, VERSION file
+
 ## Output Format
 
 Return structured findings with:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -405,6 +405,9 @@ For detailed language and framework-specific guidelines, see:
 - `test-vuejs.instructions.md` - Frontend testing guidelines
 - `md.instructions.md` - Documentation writing standards
 - `ps1.instructions.md` - PowerShell scripting guidelines
+- `server-setup-windows.instructions.md` - Primary Windows server deployment (MWNF)
+- `server-setup-ovh.instructions.md` - Secondary OVH VPS deployment
+- `build-workflow.instructions.md` - Build pipeline, artifact packaging, release creation
 
 ## Common Pitfalls to Avoid
 

--- a/.github/instructions/build-workflow.instructions.md
+++ b/.github/instructions/build-workflow.instructions.md
@@ -1,0 +1,131 @@
+---
+description: "Use when: modifying the Build workflow (build.yml), changing artifact packaging, adjusting release creation, debugging deployment package contents, or understanding how build artifacts flow to the Windows (deploy.yml) and OVH (deploy-ovh.yml) deployment pipelines."
+applyTo: ".github/workflows/build.yml"
+---
+
+# Build Workflow — Artifact Packaging & Release Creation
+
+The `build.yml` workflow builds the application on `ubuntu-latest` and produces **two distinct artifacts** for the two deployment targets.
+
+## Triggers
+
+| Trigger | Condition |
+|---------|-----------|
+| `push` to `main` | Automatic on every merge |
+| `push` tag `v*.*.*` | Automatic on version tags |
+| `workflow_dispatch` | Manual |
+
+## Build Steps
+
+1. Checkout code
+2. Setup PHP 8.4 + Node.js (LTS/Krypton)
+3. `composer install --no-dev` (production dependencies only)
+4. `npm ci` + `npm run build` (Blade/Vite frontend assets → `public/build/`)
+5. SPA demo: `npm ci` + `npm run build` (Vue app → `public/cli/`)
+6. Validate asset paths exist (`public/build`, `public/cli`)
+7. Create deployment package (selective copy, not full repo)
+8. Generate `VERSION` file (JSON with version, commit, build number)
+9. Create **two archives** from the same deployment directory
+10. Create GitHub Release with ZIP attached
+11. Upload tarball as workflow artifact
+
+## Deployment Package Contents
+
+The package is a **curated subset** of the repository — not a full clone. It contains only production-necessary files:
+
+### Included directories
+
+| Directory | Purpose |
+|-----------|---------|
+| `app/` | Laravel application code |
+| `bootstrap/` | Framework bootstrap |
+| `config/` | Configuration files |
+| `database/` | Migrations, factories, seeders |
+| `public/` | Web root (includes `build/` and `cli/` compiled assets) |
+| `resources/` | Blade templates, CSS, JS sources |
+| `routes/` | Route definitions |
+| `vendor/` | Production Composer dependencies (no dev) |
+| `storage/` | Directory structure only (empty — content is shared/persistent) |
+
+### Included files
+
+`composer.json`, `composer.lock`, `artisan`, `.env.example`, `package.json`, `package-lock.json`
+
+### Excluded (NOT in the package)
+
+`tests/`, `scripts/`, `spa/src/`, `docs/`, `node_modules/`, `.github/`, dev dependencies, IDE config
+
+### Generated files
+
+| File | Location | Content |
+|------|----------|---------|
+| `VERSION` | Root | JSON: `app_version`, `api_client_version`, `commit_sha`, `build_timestamp`, `build_number`, `unique_build_id`, `repository`, `repository_url`, `branch` |
+| `version.json` | `public/` | Copy of `VERSION` (accessible via HTTP for SPA/monitoring) |
+
+## Two Artifacts, Two Consumers
+
+The build produces **two archives from the same deployment directory** with different formats for different consumers:
+
+### 1. ZIP → GitHub Release → Windows deployment (`deploy.yml`)
+
+| Property | Value |
+|----------|-------|
+| Format | `inventory-app.zip` |
+| Storage | Attached to a GitHub Release (tag: `<version>.<run_number>`) |
+| Retention | Permanent (GitHub Releases) |
+| Consumer | `deploy.yml` (self-hosted Windows runner) |
+| How consumed | Runner downloads ZIP via GitHub API using release tag |
+| Release type | `prerelease: true` |
+
+The Windows deployment workflow (`deploy.yml`) is triggered manually via `workflow_dispatch` with a release tag input. The self-hosted runner downloads the ZIP from the GitHub Release API, extracts it, and deploys using the blue-green symlink pattern.
+
+### 2. Tarball → Workflow Artifact → OVH deployment (`deploy-ovh.yml`)
+
+| Property | Value |
+|----------|-------|
+| Format | `release.tar.gz` |
+| Artifact name | `release-<commit-sha>` |
+| Storage | GitHub Actions artifact (via `actions/upload-artifact@v7`) |
+| Retention | 7 days |
+| Consumer | `deploy-ovh.yml` (triggered automatically by `workflow_run`) |
+| How consumed | `actions/download-artifact@v8` with `run-id` from the Build run |
+
+The OVH deployment workflow (`deploy-ovh.yml`) is triggered automatically when a Build run succeeds on `main`. It downloads the tarball artifact, SCPs it to the VPS, and runs `deploy-ovh.sh` via SSH.
+
+## Version & Tag Scheme
+
+```
+Tag:        <APP_VERSION>.<GITHUB_RUN_NUMBER>
+Example:    1.2.3.42
+```
+
+- `APP_VERSION` is read from `package.json` → `version` field
+- `GITHUB_RUN_NUMBER` is appended as the build number
+- The tag is created as a `prerelease` GitHub Release
+
+## Flow Diagram
+
+```
+build.yml (ubuntu-latest)
+    │
+    ├── inventory-app.zip ──► GitHub Release (permanent)
+    │                              │
+    │                              ▼
+    │                         deploy.yml (manual trigger, self-hosted Windows runner)
+    │                         → Blue-green symlink on MWNF server
+    │
+    └── release.tar.gz ────► Workflow Artifact (7-day retention)
+                                   │
+                                   ▼
+                              deploy-ovh.yml (auto-trigger on success)
+                              → SCP + deploy-ovh.sh on OVH VPS
+```
+
+## Forbidden
+
+- **NEVER include dev dependencies** (`--no-dev` for Composer, no `devDependencies` in the package).
+- **NEVER include test files, scripts, or docs** in the deployment package — they belong in the repo only.
+- **NEVER change the artifact naming convention** (`release-<sha>` for OVH, `inventory-app.zip` for Windows) without updating both consumer workflows.
+- **NEVER remove `VERSION`** or `public/version.json` — they are used for deployment traceability.
+- **NEVER change the tarball retention** below 7 days — OVH deploy may run later.
+- **NEVER use `draft: true`** on releases — the Windows deploy workflow fetches by tag, not by draft status.

--- a/.github/instructions/server-setup-ovh.instructions.md
+++ b/.github/instructions/server-setup-ovh.instructions.md
@@ -1,0 +1,158 @@
+---
+description: "Use when: configuring the OVH VPS, writing or modifying OVH deployment scripts, editing deploy-ovh workflow, managing Nginx vhost for inventory, SSH access to the VPS, queue worker setup, or MySQL backup for the inventory-app on the shared OVH server."
+applyTo: "scripts/deploy-ovh.sh,scripts/provision-inventory.sh,.github/workflows/deploy-ovh.yml"
+---
+
+# Server Setup — OVH VPS (Secondary Deployment)
+
+The inventory-app is deployed to a shared OVH VPS as a **secondary** deployment target. The **primary** deployment is to the MWNF Windows server via the `deploy.yml` workflow and a self-hosted GitHub Actions runner.
+
+## Topology
+
+The OVH VPS is shared with the Motivya app (separate project, out of scope). Both apps run on the same server but are fully isolated at the application level.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  OVH VPS Starter (France)                                │
+│  1 vCPU · 2 GB RAM · 20 GB SSD                          │
+│  Ubuntu 24.04 LTS                                        │
+│                                                          │
+│  PHP 8.4-FPM · Nginx · MySQL · Valkey                   │
+│  (installed once by motivya's provision.sh)              │
+│                                                          │
+│  ┌────────────────────┐  ┌─────────────────────────────┐ │
+│  │ Motivya            │  │ Inventory App               │ │
+│  │ motivya.metanull.eu│  │ inventory.metanull.eu       │ │
+│  │ /opt/motivya/      │  │ /opt/inventory/             │ │
+│  │ Docker Compose     │  │ Native PHP-FPM + Nginx      │ │
+│  │ Redis DB 0/1       │  │ Valkey DB 2/3               │ │
+│  │ MySQL: motivya     │  │ MySQL: inventory            │ │
+│  └────────────────────┘  └─────────────────────────────┘ │
+│                                                          │
+│  Certbot (Let's Encrypt) — auto-renewing                 │
+│  UFW firewall: 22, 80, 443 only                         │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Key difference from Motivya:** Inventory-app runs natively on PHP-FPM + Nginx — there is NO Docker involved. Never suggest Docker Compose, Dockerfiles, or container-based deployment for the inventory-app.
+
+## Domain & DNS
+
+- **Domain**: `inventory.metanull.eu` (CNAME → `metanull.eu`)
+- **SSL**: Let's Encrypt via Certbot, auto-renewing
+
+## Two-Account Model
+
+The VPS has exactly two user accounts:
+
+| Account  | Purpose                  | SSH key                  | sudo   | Used by              |
+|----------|--------------------------|--------------------------|--------|----------------------|
+| `ubuntu` | System administration    | `~/.ssh/ubuntu`          | Yes    | Human operator only  |
+| `deploy` | Application deployment   | `~/.ssh/inventory_deploy`| **No** | CD pipeline + human  |
+
+**Rules:**
+- `ubuntu` is NEVER used in GitHub Actions or deploy scripts — manual admin only.
+- `deploy` has NO sudo — owns `/opt/inventory/` and deploys without elevation.
+- The inventory-app uses its own SSH key (`~/.ssh/inventory_deploy`), distinct from Motivya's `~/.ssh/motivya_deploy`, to avoid mixing concerns.
+
+## Application Directory
+
+Owned by `deploy:www-data`. No root/sudo operations during deployment.
+
+```
+/opt/inventory/
+├── current -> releases/<timestamp>/   # Symlink to active release (atomic swap)
+├── releases/                          # Timestamped release directories (keep last 5)
+├── shared/
+│   ├── .env                           # Production .env (not in Git)
+│   └── storage/                       # Laravel storage (symlinked into releases)
+│       ├── app/public/
+│       ├── framework/cache/data/
+│       ├── framework/sessions/
+│       ├── framework/views/
+│       └── logs/
+├── backups/                           # Daily MySQL dumps (14-day retention)
+└── backup-db.sh                       # Backup script (cron at 3:30 AM)
+```
+
+## Redis/Valkey Isolation
+
+Inventory-app uses Valkey DB 2 and 3 to avoid collision with Motivya (DB 0 and 1):
+- `REDIS_DB=2` — sessions, queues
+- `REDIS_CACHE_DB=3` — cache
+
+## Scripts
+
+| Script | Run as | Purpose |
+|--------|--------|---------|
+| `scripts/provision-inventory.sh` | root (once) | MySQL DB/user, `/opt/inventory/` structure, Nginx vhost, SSL, queue worker systemd unit, daily backup cron |
+| `scripts/deploy-ovh.sh` | deploy (each deploy) | Extract release, symlink storage, configure `.env`, migrate, warm caches, restart queue, prune old releases, health check |
+
+Both scripts are idempotent.
+
+## Deployment Flow
+
+Deploy is **artifact-based** — no git, composer, or npm on the VPS.
+
+```
+Push to main
+    │
+    ▼
+Build workflow (build.yml) — runs on ubuntu-latest
+  → produces release.tar.gz artifact
+    │ (success)
+    ▼
+Deploy to OVH workflow (deploy-ovh.yml) — triggered by workflow_run
+  1. Download release artifact from Build run
+  2. SSH pre-checks (netcat + whoami) — fail fast
+  3. SCP release.tar.gz + deploy-ovh.sh to VPS /tmp/
+  4. SSH: bash deploy-ovh.sh /tmp/inventory-release.tar.gz
+  5. Cleanup /tmp/ files
+    │
+    ▼
+VPS: deploy-ovh.sh (runs as deploy, NO sudo)
+  1. Extract to /opt/inventory/releases/<timestamp>/
+  2. Symlink shared/storage into release
+  3. Create/symlink .env (first deploy only)
+  4. php artisan migrate --force
+  5. config:cache, route:cache, view:cache
+  6. php artisan queue:restart
+  7. Swap /opt/inventory/current symlink (atomic)
+  8. Prune old releases (keep last 5)
+  9. Health check (curl localhost with Host header)
+```
+
+## GitHub Environment Secrets
+
+Stored in the **`inventory.metanull.eu`** GitHub Environment (Settings → Environments):
+
+| Secret         | Value                                      | Used by           |
+|----------------|--------------------------------------------|--------------------|
+| `VPS_HOST`     | VPS IP address                             | `deploy-ovh.yml`   |
+| `VPS_SSH_KEY`  | Private SSH key for `deploy` (inventory_deploy) | `deploy-ovh.yml` |
+| `VPS_SSH_USER` | `deploy`                                   | `deploy-ovh.yml`   |
+
+Application secrets (DB password, etc.) live in `/opt/inventory/shared/.env` on the VPS — never in GitHub.
+
+## Queue Worker
+
+Systemd service `inventory-queue.service` runs as `www-data`:
+- `php artisan queue:work redis --sleep=3 --tries=3 --max-time=3600 --memory=128`
+- Logs to `/opt/inventory/shared/storage/logs/queue-worker.log`
+- Restarted gracefully via `php artisan queue:restart` after each deploy
+
+## Backup Strategy
+
+- **Database**: Daily mysqldump cron at 3:30 AM → `/opt/inventory/backups/inventory-YYYY-MM-DD.sql.gz`
+- **Retention**: 14 days
+- **Code**: Git is the source of truth — no code backup needed
+
+## Forbidden
+
+- **NEVER use `sudo` in deploy scripts or the deploy-ovh workflow.** `deploy` owns `/opt/inventory/` — no elevation needed.
+- **NEVER use the `ubuntu` account in GitHub secrets, workflows, or automated scripts.**
+- **NEVER install packages (`apt-get`) in deploy scripts.** Dependencies are installed once via `provision-inventory.sh`.
+- **NEVER use Docker** for the inventory-app — it runs natively on PHP-FPM + Nginx.
+- **NEVER run `migrate:fresh` or `migrate:refresh` in production** — only `migrate --force`.
+- Do NOT expose MySQL or Valkey ports to the internet — localhost only.
+- Do NOT store production secrets in Git or GitHub Secrets (except the SSH key for deploy).

--- a/.github/instructions/server-setup-windows.instructions.md
+++ b/.github/instructions/server-setup-windows.instructions.md
@@ -1,0 +1,190 @@
+---
+description: "Use when: configuring the MWNF Windows production server, writing or modifying the deploy.yml workflow, editing Deploy-Application.ps1 or the InventoryApp.Deployment module, managing Apache vhosts for inventory.museumwnf.org, understanding the blue-green symlink deployment, connecting to virtual-office.museumwnf.org via PSSession, or inspecting the self-hosted GitHub Actions runner."
+applyTo: "scripts/Deploy-Application.ps1,scripts/InventoryApp.Deployment/**,.github/workflows/deploy.yml"
+---
+
+# Server Setup — MWNF Windows Server (Primary Deployment)
+
+The inventory-app's **primary** deployment target is the Museum With No Frontiers Windows server at `virtual-office.museumwnf.org`. A secondary deployment to an OVH VPS is documented in `server-setup-ovh.instructions.md`.
+
+## Topology
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  virtual-office.museumwnf.org (Windows Server)              │
+│  VPN-only access                                            │
+│                                                             │
+│  Apache (XAMPP) · MariaDB · PHP 8.x                         │
+│  Self-hosted GitHub Actions runner (SVR-MWNF)               │
+│                                                             │
+│  C:\mwnf-server\                                            │
+│  ├── software\current\ → versioned installs (Apache, PHP)   │
+│  ├── apps\             → legacy apps (webhooks, etc.)        │
+│  ├── github-apps\      → inventory-app deployments           │
+│  │   ├── production\   → blue-green releases + symlink       │
+│  │   │   ├── inventory-app → staging-YYYYMMDD-HHmmss (sym)  │
+│  │   │   └── shared-storage\                                 │
+│  │   └── temp\         → full repo clone (scripts, importer) │
+│  ├── configuration\current\mwnf\ → vhost symlinks           │
+│  ├── reverse-proxy\    → Apache reverse proxy + mod_security │
+│  ├── pictures\         → museum images + cache               │
+│  └── ssl\              → TLS certificates                    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Remote Access
+
+The server is reachable only through a dedicated VPN connection. When connected:
+
+```powershell
+# Connect via PSSession (PowerShell 5+)
+$session = New-PSSession -ComputerName virtual-office.museumwnf.org
+
+# Run commands remotely
+Invoke-Command -Session $session { Get-ChildItem C:\mwnf-server\github-apps\production }
+
+# Close when done
+Remove-PSSession $session
+```
+
+The `server-inspector` agent provides read-only inspection capabilities via this PSSession pattern.
+
+## Two Instances on the Server
+
+| Instance | Path | Purpose |
+|----------|------|---------|
+| **Production** | `C:\mwnf-server\github-apps\production\inventory-app` (symlink) | Deployed by CI/CD, serves the web app |
+| **Temp** | `C:\mwnf-server\github-apps\temp\inventory-app` | Full repo clone for running scripts/importer |
+
+**Warning:** The temp instance shares the same database as production. Destructive commands (`db:wipe`, `migrate:refresh`) affect live data.
+
+## Blue-Green Deployment (Symlink Swap)
+
+The `deploy.yml` workflow uses atomic symlink swapping for zero-downtime deployment:
+
+```
+C:\mwnf-server\github-apps\production\
+├── inventory-app          → staging-20260415-143022  (current symlink)
+├── staging-20260415-143022\  (current release)
+├── staging-20260410-091500\  (previous release)
+├── staging-20260405-120000\  (oldest kept)
+└── shared-storage\           (persists across deployments)
+    └── app\
+        ├── private\
+        ├── public\
+        └── public\images\
+```
+
+The swap sequence:
+1. Extract release into `staging-<timestamp>/`
+2. Symlink `staging-<timestamp>/storage/app` → `shared-storage/app`
+3. Rename current `inventory-app` symlink to `inventory-app_swap` (backup)
+4. Rename new temp symlink to `inventory-app` (atomic swap)
+5. On failure: roll back by renaming `inventory-app_swap` back
+6. Cleanup: remove `_swap` symlink, prune old staging dirs (keep last 3)
+
+## Deployment Flow
+
+```
+Manual trigger (workflow_dispatch) with release tag
+    │
+    ▼
+deploy.yml — runs on [self-hosted, windows] (SVR-MWNF runner)
+    │
+    ├── download job
+    │   Download release asset (inventory-app.zip) from GitHub Release
+    │   Extract to runner temp, copy to staging-<timestamp>
+    │
+    ├── down job
+    │   php artisan down --retry=120
+    │
+    ├── deploy job
+    │   Setup shared storage symlink (storage/app → shared-storage/app)
+    │   Atomic symlink swap (blue-green)
+    │
+    ├── configure job
+    │   Generate .env from .env.example + GitHub Environment variables
+    │   php artisan migrate --force
+    │   php artisan permissions:sync --production
+    │   php artisan config:cache, route:cache, view:cache
+    │
+    ├── up job
+    │   php artisan up
+    │
+    └── intendance job
+        Cleanup swap symlinks
+        Prune old staging dirs (keep last 3)
+```
+
+## GitHub Actions Runner
+
+| Property | Value |
+|----------|-------|
+| Install path | `C:\mwnf-server\software\github\actions-runner` |
+| Windows service | `actions.runner.metanull-inventory-app.SVR-MWNF` |
+| Agent name | `SVR-MWNF` |
+| Runs as | `NT AUTHORITY\NETWORK SERVICE` |
+| Scope | Repo-level self-hosted runner |
+
+## GitHub Environment: MWNF-SVR
+
+All deployment configuration is stored in the **`MWNF-SVR`** GitHub Environment (Settings → Environments).
+
+### Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `PHP_PATH` | `C:\Program Files\PHP\php.exe` | Path to PHP executable |
+| `WEBSERVER_PATH` | `C:\Apache24\htdocs\inventory-app` | Production symlink path |
+| `APP_NAME` | `inventory-app` | Application display name |
+| `APP_ENV` | `production` | Laravel environment |
+| `APP_DEBUG` | `false` | Debug mode |
+| `APP_URL` | `http://localhost` | Application URL |
+| `DB_CONNECTION` | `mysql` | Database driver |
+| `DB_HOST` | `127.0.0.1` | Database host |
+| `DB_PORT` | `3306` | Database port |
+| `APACHE_SERVICE_USER` | `SYSTEM` | Apache service user |
+
+### Secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `APP_KEY` | Laravel encryption key |
+| `MARIADB_DATABASE` | Database name |
+| `MARIADB_USER` | Database username |
+| `MARIADB_SECRET` | Database password |
+
+## Deployment Module
+
+The `scripts/InventoryApp.Deployment/` PowerShell module provides reusable deployment functions:
+
+| Function | Purpose |
+|----------|---------|
+| `Test-SystemPrerequisites` | Verify PHP, paths, permissions |
+| `Test-DeploymentPackage` | Validate extracted release |
+| `New-StagingDirectory` | Create timestamped staging dir |
+| `Remove-OldStagingDirectories` | Prune old releases |
+| `New-StorageSymlink` | Link shared storage into release |
+| `Swap-WebserverSymlink` | Atomic symlink swap |
+| `Remove-SwapBackup` | Cleanup backup symlink |
+| `New-EnvironmentFile` | Generate .env from template |
+| `Invoke-LaravelSetup` | Run migrations, caches |
+| `Invoke-LaravelDown` | Maintenance mode |
+| `Deploy-Application` | Full orchestration |
+
+## Apache Configuration
+
+- **Backend vhost**: `C:\mwnf-server\github-apps\production\inventory.museumwnf.org.conf`
+- **Vhost symlink**: `C:\mwnf-server\configuration\current\mwnf\inventory.museumwnf.org.conf`
+- **DocumentRoot**: `C:/mwnf-server/github-apps/production/inventory-app/public`
+- **Backend port**: 8443 (SSL), proxied from 443 by the reverse proxy
+- **Reverse proxy entry**: `C:\mwnf-server\reverse-proxy\Apache24\conf\extra\httpd-vhosts.conf`
+
+## Forbidden
+
+- **NEVER modify Apache config, restart services, or install software in deploy scripts or workflows.** Infrastructure changes belong in manual provisioning only.
+- **NEVER run destructive database commands** (`migrate:fresh`, `migrate:refresh`, `db:wipe`) in production — only `migrate --force`.
+- **NEVER commit production secrets to Git.** Use GitHub Environment secrets/variables.
+- **NEVER bypass the blue-green symlink pattern.** Direct file replacement in the production directory breaks rollback.
+- **NEVER use the temp instance path in deploy.yml.** It is for manual script execution only.
+- **NEVER expose internal server paths or credentials in logs.** Use `::add-mask::` for sensitive values.

--- a/scripts/importer/src/domain/transformers/project-transformer.ts
+++ b/scripts/importer/src/domain/transformers/project-transformer.ts
@@ -17,7 +17,7 @@ import type {
 } from '../../core/types.js';
 import { mapLanguageCode } from '../../utils/code-mappings.js';
 import { formatBackwardCompatibility } from '../../utils/backward-compatibility.js';
-import { convertHtmlToMarkdown } from '../../utils/html-to-markdown.js';
+import { convertHtmlToMarkdown, isZeroDate } from '../../utils/html-to-markdown.js';
 
 /**
  * Transformed project bundle (context + collection + project)
@@ -92,7 +92,7 @@ export function transformProject(
     internal_name: projectName,
     backward_compatibility: projectBackwardCompat,
     language_id: defaultLanguageId,
-    launch_date: legacy.launchdate || null,
+    launch_date: legacy.launchdate && !isZeroDate(legacy.launchdate) ? legacy.launchdate : null,
     is_launched: legacy.active === 1 || legacy.active === true,
   };
 

--- a/scripts/importer/src/domain/transformers/sh-project-transformer.ts
+++ b/scripts/importer/src/domain/transformers/sh-project-transformer.ts
@@ -15,7 +15,7 @@ import type {
   ProjectTranslationData,
 } from '../../core/types.js';
 import { mapLanguageCode } from '../../utils/code-mappings.js';
-import { convertHtmlToMarkdown } from '../../utils/html-to-markdown.js';
+import { convertHtmlToMarkdown, isZeroDate } from '../../utils/html-to-markdown.js';
 
 const SH_SCHEMA = 'mwnf3_sharing_history';
 const SH_PROJECTS_TABLE = 'sh_projects';
@@ -105,7 +105,7 @@ export function transformShProject(
     internal_name: internalName,
     backward_compatibility: backwardCompat,
     language_id: defaultLanguageId,
-    launch_date: legacy.addeddate || null,
+    launch_date: legacy.addeddate && !isZeroDate(legacy.addeddate) ? legacy.addeddate : null,
     is_launched: legacy.show === 'Y',
   };
 

--- a/scripts/importer/src/utils/html-to-markdown.ts
+++ b/scripts/importer/src/utils/html-to-markdown.ts
@@ -73,6 +73,20 @@ export function convertHtmlFieldsToMarkdown<T extends Record<string, unknown>>(
 const SKIP_SANITIZE_FIELDS = new Set(['extra']);
 
 /**
+ * MySQL zero-date patterns produced by legacy Windows MySQL.
+ * MySQL 8+ with STRICT_TRANS_TABLES + NO_ZERO_DATE rejects these on INSERT.
+ */
+const ZERO_DATE_PATTERN = /^0000-00-00/;
+
+/**
+ * Returns true if the value is a MySQL zero-date string.
+ * Matches '0000-00-00', '0000-00-00 00:00:00', and similar variants.
+ */
+export function isZeroDate(value: string): boolean {
+  return ZERO_DATE_PATTERN.test(value);
+}
+
+/**
  * Sanitize ALL string fields in an object by converting HTML to Markdown
  *
  * This function iterates over all properties of the object and converts
@@ -99,7 +113,11 @@ export function sanitizeAllStrings<T extends object>(data: T): T {
       continue;
     }
     if (typeof value === 'string') {
-      (result as Record<string, unknown>)[key as string] = convertHtmlToMarkdown(value);
+      if (isZeroDate(value)) {
+        (result as Record<string, unknown>)[key as string] = null;
+      } else {
+        (result as Record<string, unknown>)[key as string] = convertHtmlToMarkdown(value);
+      }
     }
   }
 

--- a/scripts/importer/src/utils/index.ts
+++ b/scripts/importer/src/utils/index.ts
@@ -17,7 +17,7 @@ export {
   mapCountryCode,
 } from './code-mappings.js';
 
-export { convertHtmlToMarkdown, convertHtmlFieldsToMarkdown } from './html-to-markdown.js';
+export { convertHtmlToMarkdown, convertHtmlFieldsToMarkdown, isZeroDate } from './html-to-markdown.js';
 
 export {
   normalizePath,

--- a/scripts/importer/tests/unit/zero-date.test.ts
+++ b/scripts/importer/tests/unit/zero-date.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for isZeroDate and sanitizeAllStrings zero-date handling
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isZeroDate, sanitizeAllStrings } from '../../src/utils/html-to-markdown.js';
+
+describe('isZeroDate', () => {
+  it('should detect 0000-00-00 as zero date', () => {
+    expect(isZeroDate('0000-00-00')).toBe(true);
+  });
+
+  it('should detect 0000-00-00 00:00:00 as zero date', () => {
+    expect(isZeroDate('0000-00-00 00:00:00')).toBe(true);
+  });
+
+  it('should detect 0000-00-00T00:00:00 as zero date', () => {
+    expect(isZeroDate('0000-00-00T00:00:00')).toBe(true);
+  });
+
+  it('should not flag a valid date', () => {
+    expect(isZeroDate('2025-04-17')).toBe(false);
+  });
+
+  it('should not flag a valid datetime', () => {
+    expect(isZeroDate('2025-04-17 12:00:00')).toBe(false);
+  });
+
+  it('should not flag a regular string', () => {
+    expect(isZeroDate('hello')).toBe(false);
+  });
+
+  it('should not flag an empty string', () => {
+    expect(isZeroDate('')).toBe(false);
+  });
+});
+
+describe('sanitizeAllStrings zero-date handling', () => {
+  it('should convert zero-date string fields to null', () => {
+    const data = {
+      id: 'abc',
+      name: 'Test Project',
+      launch_date: '0000-00-00 00:00:00',
+      is_enabled: true,
+    };
+
+    const result = sanitizeAllStrings(data);
+
+    expect(result.launch_date).toBeNull();
+    expect(result.name).toBe('Test Project');
+    expect(result.id).toBe('abc');
+    expect(result.is_enabled).toBe(true);
+  });
+
+  it('should preserve valid date strings', () => {
+    const data = {
+      launch_date: '2025-04-17 12:00:00',
+    };
+
+    const result = sanitizeAllStrings(data);
+
+    expect(result.launch_date).toBe('2025-04-17 12:00:00');
+  });
+
+  it('should handle multiple zero-date fields', () => {
+    const data = {
+      start_date: '0000-00-00',
+      end_date: '0000-00-00 00:00:00',
+      name: 'Test',
+    };
+
+    const result = sanitizeAllStrings(data);
+
+    expect(result.start_date).toBeNull();
+    expect(result.end_date).toBeNull();
+    expect(result.name).toBe('Test');
+  });
+
+  it('should not affect null or non-string fields', () => {
+    const data = {
+      launch_date: null as string | null,
+      count: 42,
+    };
+
+    const result = sanitizeAllStrings(data);
+
+    expect(result.launch_date).toBeNull();
+    expect(result.count).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary

Two changes bundled: new Copilot AI instructions for the deployment infrastructure, and a bug fix for the legacy data importer on the OVH VPS.

## Commit 1: AI Instructions

- **`server-setup-windows.instructions.md`** — MWNF Windows server: topology, blue-green symlink deployment, self-hosted runner, GitHub Environment config
- **`server-setup-ovh.instructions.md`** — OVH VPS: topology, deploy-ovh workflow, Nginx/PHP-FPM
- **`build-workflow.instructions.md`** — Build pipeline: two artifacts (ZIP → Windows, tarball → OVH), release creation, VERSION file
- **Updated `legacy-importer.agent.md`** — OVH import support via SSH tunnel from developer machine
- **Updated `server-inspector.agent.md`** — Cross-references to the three deployment instructions
- **Updated `copilot-instructions.md`** — Lists the new instruction files

## Commit 2: MySQL Zero-Date Fix

**Problem:** Legacy MySQL on Windows accepted `'0000-00-00 00:00:00'` as a default date value. MariaDB 11.4 (local/production) silently accepts it despite `STRICT_TRANS_TABLES` + `NO_ZERO_DATE`, but MySQL 8.4 (OVH) rejects it as a hard error. This caused 6 projects (AMA, AMT, BAR, GPA, IAM, ISL) to fail INSERT, producing 657+ cascading "project not found" warnings downstream.

**Fix:**
- Added `isZeroDate()` utility to detect MySQL zero-date strings (`/^0000-00-00/`)
- Integrated into `sanitizeAllStrings()` at the persistence layer — converts zero-dates to `null` for all entities before INSERT
- Added explicit checks in `project-transformer.ts` and `sh-project-transformer.ts`
- Added 11 unit tests (all passing, 89/89 total)

**Root cause:** The `|| null` pattern in transformers doesn't catch `'0000-00-00 00:00:00'` because it's a truthy string.