### PR TITLE
Fix importer handling of mysql2 date objects

### DIFF
--- a/scripts/importer/src/domain/transformers/project-transformer.ts
+++ b/scripts/importer/src/domain/transformers/project-transformer.ts
@@ -17,7 +17,7 @@ import type {
 } from '../../core/types.js';
 import { mapLanguageCode } from '../../utils/code-mappings.js';
 import { formatBackwardCompatibility } from '../../utils/backward-compatibility.js';
-import { convertHtmlToMarkdown, isZeroDate } from '../../utils/html-to-markdown.js';
+import { convertHtmlToMarkdown, sanitizeDateValue } from '../../utils/html-to-markdown.js';
 
 /**
  * Transformed project bundle (context + collection + project)
@@ -92,7 +92,7 @@ export function transformProject(
     internal_name: projectName,
     backward_compatibility: projectBackwardCompat,
     language_id: defaultLanguageId,
-    launch_date: legacy.launchdate && !isZeroDate(legacy.launchdate) ? legacy.launchdate : null,
+    launch_date: sanitizeDateValue(legacy.launchdate),
     is_launched: legacy.active === 1 || legacy.active === true,
   };
 

--- a/scripts/importer/src/domain/transformers/sh-project-transformer.ts
+++ b/scripts/importer/src/domain/transformers/sh-project-transformer.ts
@@ -15,7 +15,7 @@ import type {
   ProjectTranslationData,
 } from '../../core/types.js';
 import { mapLanguageCode } from '../../utils/code-mappings.js';
-import { convertHtmlToMarkdown, isZeroDate } from '../../utils/html-to-markdown.js';
+import { convertHtmlToMarkdown, sanitizeDateValue } from '../../utils/html-to-markdown.js';
 
 const SH_SCHEMA = 'mwnf3_sharing_history';
 const SH_PROJECTS_TABLE = 'sh_projects';
@@ -105,7 +105,7 @@ export function transformShProject(
     internal_name: internalName,
     backward_compatibility: backwardCompat,
     language_id: defaultLanguageId,
-    launch_date: legacy.addeddate && !isZeroDate(legacy.addeddate) ? legacy.addeddate : null,
+    launch_date: sanitizeDateValue(legacy.addeddate),
     is_launched: legacy.show === 'Y',
   };
 

--- a/scripts/importer/src/domain/types/legacy.ts
+++ b/scripts/importer/src/domain/types/legacy.ts
@@ -43,7 +43,7 @@ export interface LegacyCountryName {
 export interface LegacyProject {
   project_id: string;
   name?: string;
-  launchdate?: string | null;
+  launchdate?: Date | string | null;
   active?: number | boolean;
 }
 

--- a/scripts/importer/src/domain/types/sh-legacy.ts
+++ b/scripts/importer/src/domain/types/sh-legacy.ts
@@ -18,7 +18,7 @@
 export interface ShLegacyProject {
   project_id: string;
   name: string;
-  addeddate?: string | null;
+  addeddate?: Date | string | null;
   new_status?: 'Y' | 'N';
   show?: 'Y' | 'N';
   category?: 'SP' | 'PP'; // SP: SH Projects, PP: Portal Projects

--- a/scripts/importer/src/utils/html-to-markdown.ts
+++ b/scripts/importer/src/utils/html-to-markdown.ts
@@ -79,11 +79,41 @@ const SKIP_SANITIZE_FIELDS = new Set(['extra']);
 const ZERO_DATE_PATTERN = /^0000-00-00/;
 
 /**
- * Returns true if the value is a MySQL zero-date string.
- * Matches '0000-00-00', '0000-00-00 00:00:00', and similar variants.
+ * Sanitize a date value from the legacy database.
+ *
+ * mysql2 returns DATETIME columns as Date objects by default.
+ * Legacy MySQL on Windows stored '0000-00-00 00:00:00' as a default,
+ * which mysql2 converts to an Invalid Date object.
+ *
+ * This function explicitly handles:
+ * - null / undefined → null
+ * - empty string → null
+ * - Date object that is Invalid Date → null
+ * - string matching '0000-00-00...' → null
+ * - valid Date object → ISO string (YYYY-MM-DD HH:mm:ss)
+ * - valid date string → returned as-is
  */
-export function isZeroDate(value: string): boolean {
-  return ZERO_DATE_PATTERN.test(value);
+export function sanitizeDateValue(value: Date | string | null | undefined): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    if (isNaN(value.getTime())) {
+      return null;
+    }
+    return value.toISOString().slice(0, 19).replace('T', ' ');
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '' || ZERO_DATE_PATTERN.test(trimmed)) {
+      return null;
+    }
+    return trimmed;
+  }
+
+  return null;
 }
 
 /**
@@ -113,11 +143,7 @@ export function sanitizeAllStrings<T extends object>(data: T): T {
       continue;
     }
     if (typeof value === 'string') {
-      if (isZeroDate(value)) {
-        (result as Record<string, unknown>)[key as string] = null;
-      } else {
-        (result as Record<string, unknown>)[key as string] = convertHtmlToMarkdown(value);
-      }
+      (result as Record<string, unknown>)[key as string] = convertHtmlToMarkdown(value);
     }
   }
 

--- a/scripts/importer/src/utils/index.ts
+++ b/scripts/importer/src/utils/index.ts
@@ -17,7 +17,7 @@ export {
   mapCountryCode,
 } from './code-mappings.js';
 
-export { convertHtmlToMarkdown, convertHtmlFieldsToMarkdown, isZeroDate } from './html-to-markdown.js';
+export { convertHtmlToMarkdown, convertHtmlFieldsToMarkdown, sanitizeDateValue } from './html-to-markdown.js';
 
 export {
   normalizePath,

--- a/scripts/importer/tests/unit/zero-date.test.ts
+++ b/scripts/importer/tests/unit/zero-date.test.ts
@@ -1,90 +1,68 @@
 /**
- * Tests for isZeroDate and sanitizeAllStrings zero-date handling
+ * Tests for sanitizeDateValue — explicit date sanitization for legacy MySQL values.
+ *
+ * mysql2 returns DATETIME columns as Date objects. Legacy MySQL on Windows
+ * stored '0000-00-00 00:00:00' as a default, which becomes Invalid Date.
+ * MySQL 8+ with STRICT mode rejects zero-dates on INSERT.
  */
 
 import { describe, it, expect } from 'vitest';
-import { isZeroDate, sanitizeAllStrings } from '../../src/utils/html-to-markdown.js';
+import { sanitizeDateValue } from '../../src/utils/html-to-markdown.js';
 
-describe('isZeroDate', () => {
-  it('should detect 0000-00-00 as zero date', () => {
-    expect(isZeroDate('0000-00-00')).toBe(true);
+describe('sanitizeDateValue', () => {
+  it('should return null for null', () => {
+    expect(sanitizeDateValue(null)).toBeNull();
   });
 
-  it('should detect 0000-00-00 00:00:00 as zero date', () => {
-    expect(isZeroDate('0000-00-00 00:00:00')).toBe(true);
+  it('should return null for undefined', () => {
+    expect(sanitizeDateValue(undefined)).toBeNull();
   });
 
-  it('should detect 0000-00-00T00:00:00 as zero date', () => {
-    expect(isZeroDate('0000-00-00T00:00:00')).toBe(true);
+  it('should return null for empty string', () => {
+    expect(sanitizeDateValue('')).toBeNull();
   });
 
-  it('should not flag a valid date', () => {
-    expect(isZeroDate('2025-04-17')).toBe(false);
+  it('should return null for whitespace-only string', () => {
+    expect(sanitizeDateValue('   ')).toBeNull();
   });
 
-  it('should not flag a valid datetime', () => {
-    expect(isZeroDate('2025-04-17 12:00:00')).toBe(false);
+  it('should return null for zero-date string 0000-00-00', () => {
+    expect(sanitizeDateValue('0000-00-00')).toBeNull();
   });
 
-  it('should not flag a regular string', () => {
-    expect(isZeroDate('hello')).toBe(false);
+  it('should return null for zero-datetime string 0000-00-00 00:00:00', () => {
+    expect(sanitizeDateValue('0000-00-00 00:00:00')).toBeNull();
   });
 
-  it('should not flag an empty string', () => {
-    expect(isZeroDate('')).toBe(false);
-  });
-});
-
-describe('sanitizeAllStrings zero-date handling', () => {
-  it('should convert zero-date string fields to null', () => {
-    const data = {
-      id: 'abc',
-      name: 'Test Project',
-      launch_date: '0000-00-00 00:00:00',
-      is_enabled: true,
-    };
-
-    const result = sanitizeAllStrings(data);
-
-    expect(result.launch_date).toBeNull();
-    expect(result.name).toBe('Test Project');
-    expect(result.id).toBe('abc');
-    expect(result.is_enabled).toBe(true);
+  it('should return null for zero-datetime with T separator', () => {
+    expect(sanitizeDateValue('0000-00-00T00:00:00')).toBeNull();
   });
 
-  it('should preserve valid date strings', () => {
-    const data = {
-      launch_date: '2025-04-17 12:00:00',
-    };
-
-    const result = sanitizeAllStrings(data);
-
-    expect(result.launch_date).toBe('2025-04-17 12:00:00');
+  it('should return null for Invalid Date object (from mysql2 zero-date)', () => {
+    const invalidDate = new Date('0000-00-00 00:00:00');
+    expect(invalidDate.toString()).toBe('Invalid Date');
+    expect(sanitizeDateValue(invalidDate)).toBeNull();
   });
 
-  it('should handle multiple zero-date fields', () => {
-    const data = {
-      start_date: '0000-00-00',
-      end_date: '0000-00-00 00:00:00',
-      name: 'Test',
-    };
-
-    const result = sanitizeAllStrings(data);
-
-    expect(result.start_date).toBeNull();
-    expect(result.end_date).toBeNull();
-    expect(result.name).toBe('Test');
+  it('should return null for explicitly constructed Invalid Date', () => {
+    expect(sanitizeDateValue(new Date(NaN))).toBeNull();
   });
 
-  it('should not affect null or non-string fields', () => {
-    const data = {
-      launch_date: null as string | null,
-      count: 42,
-    };
+  it('should convert valid Date object to ISO-like string', () => {
+    const date = new Date('2025-04-17T12:00:00Z');
+    const result = sanitizeDateValue(date);
+    expect(result).toBe('2025-04-17 12:00:00');
+  });
 
-    const result = sanitizeAllStrings(data);
+  it('should preserve valid date string', () => {
+    expect(sanitizeDateValue('2025-04-17')).toBe('2025-04-17');
+  });
 
-    expect(result.launch_date).toBeNull();
-    expect(result.count).toBe(42);
+  it('should preserve valid datetime string', () => {
+    expect(sanitizeDateValue('2025-04-17 12:00:00')).toBe('2025-04-17 12:00:00');
+  });
+
+  it('should trim whitespace from valid date strings', () => {
+    expect(sanitizeDateValue('  2025-04-17  ')).toBe('2025-04-17');
   });
 });


### PR DESCRIPTION
## Summary

Fixes the importer date normalization for legacy DATETIME fields when using `mysql2`.

## Problem

The earlier zero-date fix assumed legacy DATETIME values arrived as strings. In practice, `mysql2` returns DATETIME columns as JavaScript `Date` objects by default.

That means legacy values like `0000-00-00 00:00:00` become `Invalid Date`, so the previous string-only zero-date handling never ran. As a result, projects like `AMA`, `AMT`, `BAR`, `GPA`, `IAM`, and `ISL` still failed to insert on OVH MySQL 8 with:

- `Incorrect date value: '0000-00-00 00:00:00' for column 'launch_date'`

## Fix

- Add explicit `sanitizeDateValue()` handling for known date fields
- Handle all expected cases explicitly:
  - `null`
  - `undefined`
  - empty string
  - zero-date strings like `0000-00-00 00:00:00`
  - `Invalid Date` objects returned by `mysql2`
  - valid `Date` objects
  - valid date strings
- Apply the fix directly in the project import transformers instead of relying on a generic string sanitizer
- Update legacy type definitions so DATETIME fields are typed as `Date | string | null`
- Refresh unit coverage for the explicit date handling path

## Validation

- Importer unit tests: 91 passing