### PR TITLE
Fix table name typo in importer scripts

### DIFF
--- a/scripts/importer/src/importers/phase-06/explore-region-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-region-importer.ts
@@ -6,7 +6,7 @@
  * parented under their respective country collections.
  *
  * Legacy schema:
- * - mwnf3_explore.region (regionId, countryId, label, geoCoordinates, zoom, type)
+ * - mwnf3_explore.regions (regionId, countryId, label, geoCoordinates, zoom, type)
  * - mwnf3_explore.regiontranslated (regionId, langId, spelling)
  * - mwnf3_explore.regionsthemes (regionId, cycleId)
  *
@@ -93,7 +93,7 @@ export class ExploreRegionImporter extends BaseImporter {
       // Query regions
       const regions = await this.context.legacyDb.query<LegacyRegion>(
         `SELECT regionId, countryId, label, geoCoordinates, zoom, type
-         FROM mwnf3_explore.region
+         FROM mwnf3_explore.regions
          WHERE label IS NOT NULL AND label != ''
          ORDER BY countryId, regionId`
       );

--- a/scripts/importer/src/importers/phase-06/explore-region-location-linker.ts
+++ b/scripts/importer/src/importers/phase-06/explore-region-location-linker.ts
@@ -7,7 +7,7 @@
  *
  * Legacy schema:
  * - mwnf3_explore.regionlocations (regionId, locationId)
- * - mwnf3_explore.region (regionId, type) — type = territory_level
+ * - mwnf3_explore.regions (regionId, type) — type = territory_level
  *
  * Steps:
  * 1. Query regionlocations (204 rows)
@@ -52,7 +52,7 @@ export class ExploreRegionLocationLinker extends BaseImporter {
 
       // Fetch region territory levels
       const regionInfos = await this.context.legacyDb.query<LegacyRegionInfo>(
-        `SELECT regionId, type FROM mwnf3_explore.region`
+        `SELECT regionId, type FROM mwnf3_explore.regions`
       );
       const regionLevelMap = new Map<number, number>();
       for (const r of regionInfos) {


### PR DESCRIPTION
Correct the table name from `mwnf3_explore.region` to `mwnf3_explore.regions` in the importer scripts to ensure accurate database queries.