### PR TITLE
Fix (importer) internal_name generation for items and collections

### DIFF
--- a/.github/agents/legacy-importer.agent.md
+++ b/.github/agents/legacy-importer.agent.md
@@ -200,10 +200,10 @@ Image-sync runs locally against the legacy images, writing to a local temporary 
 npx tsx src/cli/import.ts image-sync --copy --target-dir E:\temp\ovh-images
 
 # 2. SCP images to VPS production storage
-scp -i ~/.ssh/inventory_deploy -r E:\temp\ovh-images/* deploy@<VPS_HOST>:/opt/inventory/shared/storage/app/public/images/
+scp -i ~/.ssh/inventory_deploy -r E:\temp\ovh-images/* deploy@<VPS_HOST>:/opt/inventory/shared/storage/app/public/pictures/
 ```
 
-Note: The OVH target images path is `/opt/inventory/shared/storage/app/public/images/` (in the shared storage directory, which is symlinked into each release's `storage/app/public/images`).
+Note: The OVH target images path is `/opt/inventory/shared/storage/app/public/pictures/` (in the shared storage directory, which is symlinked into each release's `storage/app/public/pictures`).
 
 **Post-import artisan commands on OVH** (run via SSH, not PSSession):
 ```powershell
@@ -224,21 +224,30 @@ git fetch origin fix/importer-gap
 git reset --hard origin/fix/importer-gap
 
 # 2. Reset the database
-php artisan db:wipe
-php artisan migrate:refresh --quiet
-php artisan db:seed --class=MinimalDatabaseSeeder --quiet
+php artisan db:wipe --force
+php artisan migrate --force
+php artisan db:seed --class=MinimalDatabaseSeeder --force
 php artisan permission:sync
 
-# 3. Run the importer
+# 3. Create admin and regular users
+php artisan user:create havelangep@hotmail.com havelangep@hotmail.com
+php artisan user:email-verification havelangep@hotmail.com verify
+php artisan user:assign-role havelangep@hotmail.com "Manager of Users"
+
+php artisan user:create havelangep@gmail.com havelangep@gmail.com
+php artisan user:email-verification havelangep@gmail.com verify
+php artisan user:assign-role havelangep@gmail.com "Regular User"
+
+# 4. Run the importer
 cd E:\inventory\inventory-app\scripts\importer
 npm install
 npm run build
 npx tsx src/cli/import.ts import
 
-# 4. Sync images
+# 5. Sync images
 npx tsx src/cli/import.ts image-sync
 
-# 5. Post-import glossary resync (from app root)
+# 6. Post-import glossary resync (from app root)
 cd E:\inventory\inventory-app
 php artisan glossary:resync --remove-existing --force
 php artisan queue:work --queue=glossary
@@ -268,19 +277,31 @@ Invoke-Command -Session $session {
 # 1. Reset database (artisan via production instance)
 Invoke-Command -Session $session {
     Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
-    php artisan db:wipe
-    php artisan migrate:refresh --quiet
-    php artisan db:seed --class=MinimalDatabaseSeeder --quiet
+    php artisan db:wipe --force
+    php artisan migrate --force
+    php artisan db:seed --class=MinimalDatabaseSeeder --force
     php artisan permission:sync
 }
 
-# 2. Run importer (via temp instance — has scripts/ directory)
+# 2. Create admin and regular users (artisan via production instance)
+Invoke-Command -Session $session {
+    Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
+    php artisan user:create havelangep@hotmail.com havelangep@hotmail.com
+	php artisan user:email-verification havelangep@hotmail.com verify
+	php artisan user:assign-role havelangep@hotmail.com "Manager of Users"
+
+	php artisan user:create havelangep@gmail.com havelangep@gmail.com
+	php artisan user:email-verification havelangep@gmail.com verify
+	php artisan user:assign-role havelangep@gmail.com "Regular User"
+}
+
+# 3. Run importer (via temp instance — has scripts/ directory)
 Invoke-Command -Session $session {
     Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer'
     npx tsx src/cli/import.ts import
 }
 
-# 3. Sync images (via temp instance, but target production storage)
+# 4. Sync images (via temp instance, but target production storage)
 Invoke-Command -Session $session {
     # Resolve the production image storage path
     Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
@@ -291,7 +312,7 @@ Invoke-Command -Session $session {
     npx tsx src/cli/import.ts image-sync --target-dir $targetDir
 }
 
-# 4. Post-import glossary resync (artisan via production instance)
+# 5. Post-import glossary resync (artisan via production instance)
 Invoke-Command -Session $session {
     Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
     php artisan glossary:resync --remove-existing --force
@@ -339,20 +360,29 @@ ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cat ~/.inventory-db-credential
 # 1. Ensure VPN is active and SSH tunnel is open (see above)
 
 # 2. Reset the OVH database (via SSH)
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan db:wipe'
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan migrate:refresh --quiet'
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan db:seed --class=MinimalDatabaseSeeder --quiet'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan db:wipe --force'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan migrate --force'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan db:seed --class=MinimalDatabaseSeeder --force'
 ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan permission:sync'
 
-# 3. Run the importer locally (writes to OVH DB via tunnel)
+# 3. Create an admin user and a regular user (password is auto-generated and must be reset by the user via "Forgot password" flow)
+ssh deploy@51.75.246.163 -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:create havelangep@hotmail.com havelangep@hotmail.com'
+ssh deploy@51.75.246.163 -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:email-verification havelangep@hotmail.com verify'
+ssh deploy@51.75.246.163 -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:assign-role havelangep@hotmail.com "Manager of Users"'
+
+ssh deploy@51.75.246.163 -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:create havelangep@gmail.com havelangep@gmail.com'
+ssh deploy@51.75.246.163 -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:email-verification havelangep@gmail.com verify'
+ssh deploy@51.75.246.163 -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:assign-role havelangep@gmail.com "Regular User"'
+
+# 4. Run the importer locally (writes to OVH DB via tunnel)
 cd E:\inventory\inventory-app\scripts\importer
 npx tsx src/cli/import.ts import
 
-# 4. Sync images locally, then SCP to VPS
+# 5. Sync images locally, then SCP to VPS
 npx tsx src/cli/import.ts image-sync --copy --target-dir E:\temp\ovh-images
-scp -i ~/.ssh/inventory_deploy -r E:\temp\ovh-images/* deploy@<VPS_HOST>:/opt/inventory/shared/storage/app/public/images/
+scp -i ~/.ssh/inventory_deploy -r E:\temp\ovh-images/* deploy@<VPS_HOST>:/opt/inventory/shared/storage/app/public/pictures/
 
-# 5. Post-import glossary resync (via SSH)
+# 6. Post-import glossary resync (via SSH)
 ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan glossary:resync --remove-existing --force'
 ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan queue:work --queue=glossary --stop-when-empty'
 ```
@@ -363,7 +393,7 @@ ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && p
 |------|------|
 | App root | `/opt/inventory/current` (symlink → `releases/<timestamp>`) |
 | Shared storage | `/opt/inventory/shared/storage/` |
-| Target images | `/opt/inventory/shared/storage/app/public/images/` |
+| Target images | `/opt/inventory/shared/storage/app/public/pictures/` |
 | `.env` (Laravel) | `/opt/inventory/shared/.env` |
 | DB credentials | `/home/deploy/.inventory-db-credentials` |
 | Laravel logs | `/opt/inventory/shared/storage/logs/laravel.log` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -459,25 +459,39 @@
             }
         },
         "node_modules/@humanfs/core": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/types": "^0.15.0"
+            },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.7",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@humanfs/core": "^0.19.1",
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
                 "@humanwhocodes/retry": "^0.4.0"
             },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+            "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -568,9 +582,9 @@
             "license": "MIT"
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-            "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1433,9 +1447,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.19",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-            "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+            "version": "2.10.20",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+            "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -1876,9 +1890,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.336",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
-            "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+            "version": "1.5.340",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+            "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
             "dev": true,
             "license": "ISC"
         },
@@ -1996,18 +2010,18 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
-            "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+            "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
-                "@eslint/config-array": "^0.23.4",
-                "@eslint/config-helpers": "^0.5.4",
-                "@eslint/core": "^1.2.0",
-                "@eslint/plugin-kit": "^0.7.0",
+                "@eslint/config-array": "^0.23.5",
+                "@eslint/config-helpers": "^0.5.5",
+                "@eslint/core": "^1.2.1",
+                "@eslint/plugin-kit": "^0.7.1",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
@@ -2653,9 +2667,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3622,9 +3636,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-            "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+            "version": "8.5.10",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+            "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
             "dev": true,
             "funding": [
                 {
@@ -4084,9 +4098,9 @@
             }
         },
         "node_modules/stylelint": {
-            "version": "17.7.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.7.0.tgz",
-            "integrity": "sha512-n/+4RheCRl+cecGnF+S/Adz59iCRaK9BVznJYB+a7GOksfwNzjiOPnYv17pTO0HgRse9IiqbMtekGNhOb2tVYQ==",
+            "version": "17.8.0",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.8.0.tgz",
+            "integrity": "sha512-oHkld9T60LDSaUQ4CSVc+tlt9eUoDlxhaGWShsUCKyIL14boZfmK5bSphZqx64aiC5tCqX+BsQMTMoSz8D1zIg==",
             "dev": true,
             "funding": [
                 {
@@ -4127,7 +4141,7 @@
                 "micromatch": "^4.0.8",
                 "normalize-path": "^3.0.0",
                 "picocolors": "^1.1.1",
-                "postcss": "^8.5.8",
+                "postcss": "^8.5.9",
                 "postcss-safe-parser": "^7.0.1",
                 "postcss-selector-parser": "^7.1.1",
                 "postcss-value-parser": "^4.2.0",

--- a/scripts/importer/package-lock.json
+++ b/scripts/importer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "importer",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "importer",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
         "@types/turndown": "^5.0.6",
         "axios": "^1.15.0",

--- a/scripts/importer/package.json
+++ b/scripts/importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "importer",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "description": "Unified legacy database import utility for Inventory Management System",

--- a/scripts/importer/src/domain/transformers/explore-monument-transformer.ts
+++ b/scripts/importer/src/domain/transformers/explore-monument-transformer.ts
@@ -1,0 +1,91 @@
+import type { ItemData } from '../../core/types.js';
+import { mapLanguageCode } from '../../utils/code-mappings.js';
+import { selectItemInternalName, type ItemInternalNameCandidate } from './item-internal-name-transformer.js';
+
+export interface ExploreMonumentNameTranslation {
+  langId: string;
+  name: string | null;
+}
+
+export interface ExploreLegacyMonument {
+  monumentId: number;
+  locationId: number | null;
+  title: string;
+  geoCoordinates: string | null;
+  zoom: number | null;
+  special_monument: string | null;
+  related_monument: string | null;
+}
+
+export interface TransformedExploreMonument {
+  data: Omit<ItemData, 'collection_id' | 'partner_id' | 'project_id'>;
+  backwardCompatibility: string;
+  warning: string | null;
+  locationId: number | null;
+}
+
+function parseGeoCoordinates(coords: string | null): [number | null, number | null] {
+  if (coords === null) {
+    return [null, null];
+  }
+
+  if (coords.trim() === '') {
+    return [null, null];
+  }
+
+  const cleaned = coords.replace(/\s+/g, '').trim();
+  const parts = cleaned.split(',');
+  if (parts.length !== 2) {
+    return [null, null];
+  }
+
+  const lat = parseFloat(parts[0]);
+  const lon = parseFloat(parts[1]);
+  if (isNaN(lat) || isNaN(lon)) {
+    return [null, null];
+  }
+
+  return [lat, lon];
+}
+
+export function transformExploreMonument(
+  legacy: ExploreLegacyMonument,
+  translations: ExploreMonumentNameTranslation[],
+  defaultLanguageId: string
+): TransformedExploreMonument {
+  const backwardCompatibility = `mwnf3_explore:monument:${legacy.monumentId}`;
+  const candidates: ItemInternalNameCandidate[] = [];
+
+  for (const translation of translations) {
+    candidates.push({
+      languageId: mapLanguageCode(translation.langId),
+      value: translation.name,
+    });
+  }
+
+  const selectedInternalName = selectItemInternalName(
+    candidates,
+    defaultLanguageId,
+    'Explore monument',
+    backwardCompatibility
+  );
+  const [latitude, longitude] = parseGeoCoordinates(legacy.geoCoordinates);
+
+  return {
+    data: {
+      internal_name: selectedInternalName.internalName,
+      backward_compatibility: backwardCompatibility,
+      type: 'monument',
+      country_id: null,
+      parent_id: null,
+      owner_reference: null,
+      mwnf_reference: null,
+      latitude,
+      longitude,
+      map_zoom: legacy.zoom,
+    },
+    backwardCompatibility,
+    warning: selectedInternalName.warning,
+    locationId: legacy.locationId,
+  };
+}

--- a/scripts/importer/src/domain/transformers/item-internal-name-transformer.ts
+++ b/scripts/importer/src/domain/transformers/item-internal-name-transformer.ts
@@ -1,0 +1,64 @@
+import { convertHtmlToMarkdown } from '../../utils/html-to-markdown.js';
+
+export interface ItemInternalNameCandidate {
+  languageId: string;
+  value: string | null;
+}
+
+export interface SelectedItemInternalName {
+  internalName: string;
+  warning: string | null;
+}
+
+function hasDisplayName(value: string | null): value is string {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  if (value.trim() === '') {
+    return false;
+  }
+
+  return true;
+}
+
+export function selectItemInternalName(
+  candidates: ItemInternalNameCandidate[],
+  defaultLanguageId: string,
+  entityLabel: string,
+  backwardCompatibility: string
+): SelectedItemInternalName {
+  let defaultLanguageCandidate: ItemInternalNameCandidate | null = null;
+
+  for (const candidate of candidates) {
+    if (candidate.languageId === defaultLanguageId && hasDisplayName(candidate.value)) {
+      defaultLanguageCandidate = candidate;
+      break;
+    }
+  }
+
+  if (defaultLanguageCandidate !== null) {
+    return {
+      internalName: convertHtmlToMarkdown(defaultLanguageCandidate.value),
+      warning: null,
+    };
+  }
+
+  let fallbackCandidate: ItemInternalNameCandidate | null = null;
+
+  for (const candidate of candidates) {
+    if (hasDisplayName(candidate.value)) {
+      fallbackCandidate = candidate;
+      break;
+    }
+  }
+
+  if (fallbackCandidate !== null) {
+    return {
+      internalName: convertHtmlToMarkdown(fallbackCandidate.value),
+      warning: `${entityLabel} ${backwardCompatibility} has no translation with a name in default language ${defaultLanguageId}, using ${fallbackCandidate.languageId} instead`,
+    };
+  }
+
+  throw new Error(`${entityLabel} ${backwardCompatibility} missing required name field in all translations`);
+}

--- a/scripts/importer/src/domain/transformers/monument-detail-transformer.ts
+++ b/scripts/importer/src/domain/transformers/monument-detail-transformer.ts
@@ -10,6 +10,7 @@ import type { ItemData, ItemTranslationData } from '../../core/types.js';
 import { mapLanguageCode, mapCountryCode } from '../../utils/code-mappings.js';
 import { formatBackwardCompatibility } from '../../utils/backward-compatibility.js';
 import { convertHtmlToMarkdown } from '../../utils/html-to-markdown.js';
+import { selectItemInternalName } from './item-internal-name-transformer.js';
 
 /**
  * Transformed monument detail result
@@ -106,29 +107,19 @@ export function transformMonumentDetail(
 
   const countryId = mapCountryCode(group.country_id);
 
-  // Find translation in default language
-  const defaultTranslation = group.translations.find(
-    (t) => mapLanguageCode(t.lang_id) === defaultLanguageId
+  const selectedInternalName = selectItemInternalName(
+    group.translations.map((translation) => ({
+      languageId: mapLanguageCode(translation.lang_id),
+      value: translation.name === undefined ? null : translation.name,
+    })),
+    defaultLanguageId,
+    'Monument detail',
+    backwardCompatibility
   );
-
-  let selectedTranslation = defaultTranslation;
-  let warning: string | null = null;
-
-  if (!defaultTranslation) {
-    // Warn and use first available translation
-    selectedTranslation = group.translations[0];
-    warning = `Monument detail ${backwardCompatibility} has no translation in default language ${defaultLanguageId}, using ${mapLanguageCode(selectedTranslation!.lang_id)} instead`;
-  }
-
-  // internal_name must always be converted from selected translation name - no fallback
-  if (!selectedTranslation!.name) {
-    throw new Error(`Monument detail ${backwardCompatibility} missing required name field`);
-  }
-  const internalName = convertHtmlToMarkdown(selectedTranslation!.name);
 
   const data: Omit<ItemData, 'collection_id' | 'partner_id' | 'project_id'> = {
     type: 'detail',
-    internal_name: internalName,
+    internal_name: selectedInternalName.internalName,
     owner_reference: null,
     mwnf_reference: null,
     backward_compatibility: backwardCompatibility,
@@ -140,7 +131,7 @@ export function transformMonumentDetail(
     backwardCompatibility,
     countryId,
     parentBackwardCompatibility,
-    warning,
+    warning: selectedInternalName.warning,
   };
 }
 

--- a/scripts/importer/src/domain/transformers/monument-transformer.ts
+++ b/scripts/importer/src/domain/transformers/monument-transformer.ts
@@ -11,6 +11,19 @@ import { mapLanguageCode, mapCountryCode } from '../../utils/code-mappings.js';
 import { formatBackwardCompatibility } from '../../utils/backward-compatibility.js';
 import { convertHtmlToMarkdown } from '../../utils/html-to-markdown.js';
 import { parseTagString } from './object-transformer.js';
+import { selectItemInternalName } from './item-internal-name-transformer.js';
+
+function hasTranslationName(value: string | null | undefined): value is string {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  if (value.trim() === '') {
+    return false;
+  }
+
+  return true;
+}
 
 /**
  * Transformed monument result
@@ -96,25 +109,35 @@ export function transformMonument(
 
   const countryId = mapCountryCode(group.country);
 
-  // Find translation in default language
-  const defaultTranslation = group.translations.find(
-    (t) => mapLanguageCode(t.lang) === defaultLanguageId
+  const selectedInternalName = selectItemInternalName(
+    group.translations.map((translation) => ({
+      languageId: mapLanguageCode(translation.lang),
+      value: translation.name === undefined ? null : translation.name,
+    })),
+    defaultLanguageId,
+    'Monument',
+    backwardCompatibility
   );
 
-  let selectedTranslation = defaultTranslation;
-  let warning: string | null = null;
-
-  if (!defaultTranslation) {
-    // Warn and use first available translation
-    selectedTranslation = group.translations[0];
-    warning = `Monument ${backwardCompatibility} has no translation in default language ${defaultLanguageId}, using ${mapLanguageCode(selectedTranslation!.lang)} instead`;
+  let selectedTranslation = group.translations[0];
+  for (const translation of group.translations) {
+    if (
+      mapLanguageCode(translation.lang) === defaultLanguageId &&
+      hasTranslationName(translation.name)
+    ) {
+      selectedTranslation = translation;
+      break;
+    }
   }
 
-  // internal_name must always be converted from selected translation name - no fallback
-  if (!selectedTranslation!.name) {
-    throw new Error(`Monument ${backwardCompatibility} missing required name field`);
+  if (!hasTranslationName(selectedTranslation.name)) {
+    for (const translation of group.translations) {
+      if (hasTranslationName(translation.name)) {
+        selectedTranslation = translation;
+        break;
+      }
+    }
   }
-  const internalName = convertHtmlToMarkdown(selectedTranslation!.name);
 
   // Parse start_date/end_date from selected translation (year values stored as varchar)
   const startDate = selectedTranslation!.start_date
@@ -126,7 +149,7 @@ export function transformMonument(
 
   const data: Omit<ItemData, 'collection_id' | 'partner_id' | 'project_id'> = {
     type: 'monument',
-    internal_name: internalName,
+    internal_name: selectedInternalName.internalName,
     owner_reference: selectedTranslation!.inventory_id || null,
     mwnf_reference: selectedTranslation!.working_number || null,
     backward_compatibility: backwardCompatibility,
@@ -139,7 +162,7 @@ export function transformMonument(
     data,
     backwardCompatibility,
     countryId,
-    warning,
+    warning: selectedInternalName.warning,
   };
 }
 

--- a/scripts/importer/src/domain/transformers/object-transformer.ts
+++ b/scripts/importer/src/domain/transformers/object-transformer.ts
@@ -15,6 +15,19 @@ import type { ItemData, ItemTranslationData } from '../../core/types.js';
 import { mapLanguageCode, mapCountryCode } from '../../utils/code-mappings.js';
 import { formatBackwardCompatibility } from '../../utils/backward-compatibility.js';
 import { convertHtmlToMarkdown } from '../../utils/html-to-markdown.js';
+import { selectItemInternalName } from './item-internal-name-transformer.js';
+
+function hasTranslationName(value: string | null | undefined): value is string {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  if (value.trim() === '') {
+    return false;
+  }
+
+  return true;
+}
 
 /**
  * Transformed object result
@@ -110,25 +123,35 @@ export function transformObject(group: ObjectGroup, defaultLanguageId: string): 
 
   const countryId = mapCountryCode(group.country);
 
-  // Find translation in default language
-  const defaultTranslation = group.translations.find(
-    (t) => mapLanguageCode(t.lang) === defaultLanguageId
+  const selectedInternalName = selectItemInternalName(
+    group.translations.map((translation) => ({
+      languageId: mapLanguageCode(translation.lang),
+      value: translation.name === undefined ? null : translation.name,
+    })),
+    defaultLanguageId,
+    'Object',
+    backwardCompatibility
   );
 
-  let selectedTranslation = defaultTranslation;
-  let warning: string | null = null;
-
-  if (!defaultTranslation) {
-    // Warn and use first available translation
-    selectedTranslation = group.translations[0];
-    warning = `Object ${backwardCompatibility} has no translation in default language ${defaultLanguageId}, using ${mapLanguageCode(selectedTranslation!.lang)} instead`;
+  let selectedTranslation = group.translations[0];
+  for (const translation of group.translations) {
+    if (
+      mapLanguageCode(translation.lang) === defaultLanguageId &&
+      hasTranslationName(translation.name)
+    ) {
+      selectedTranslation = translation;
+      break;
+    }
   }
 
-  // internal_name must always be converted from selected translation name - no fallback
-  if (!selectedTranslation!.name) {
-    throw new Error(`Object ${backwardCompatibility} missing required name field`);
+  if (!hasTranslationName(selectedTranslation.name)) {
+    for (const translation of group.translations) {
+      if (hasTranslationName(translation.name)) {
+        selectedTranslation = translation;
+        break;
+      }
+    }
   }
-  const internalName = convertHtmlToMarkdown(selectedTranslation!.name);
 
   // Parse start_date/end_date from selected translation (year values stored as varchar)
   const startDate = selectedTranslation!.start_date
@@ -140,7 +163,7 @@ export function transformObject(group: ObjectGroup, defaultLanguageId: string): 
 
   const data: Omit<ItemData, 'collection_id' | 'partner_id' | 'project_id'> = {
     type: 'object',
-    internal_name: internalName,
+    internal_name: selectedInternalName.internalName,
     owner_reference: selectedTranslation!.inventory_id || null,
     mwnf_reference: selectedTranslation!.working_number || null,
     backward_compatibility: backwardCompatibility,
@@ -153,7 +176,7 @@ export function transformObject(group: ObjectGroup, defaultLanguageId: string): 
     data,
     backwardCompatibility,
     countryId,
-    warning,
+    warning: selectedInternalName.warning,
   };
 }
 

--- a/scripts/importer/src/domain/transformers/sh-monument-detail-transformer.ts
+++ b/scripts/importer/src/domain/transformers/sh-monument-detail-transformer.ts
@@ -14,6 +14,7 @@ import type { ItemData, ItemTranslationData } from '../../core/types.js';
 import { mapCountryCode, mapLanguageCode } from '../../utils/code-mappings.js';
 import { convertHtmlToMarkdown } from '../../utils/html-to-markdown.js';
 import { formatShBackwardCompatibility } from './sh-project-transformer.js';
+import { selectItemInternalName } from './item-internal-name-transformer.js';
 
 const SH_MONUMENT_DETAILS_TABLE = 'sh_monument_details';
 
@@ -89,24 +90,18 @@ export function transformShMonumentDetail(
     group.number
   );
 
-  // Find default language translation for internal_name
-  let internalName = `SH Monument Detail ${group.project_id}:${group.country}:${group.number}:${group.detail_id}`;
-  let warning: string | undefined;
-
-  const defaultTranslation = group.translations.find(
-    (t) => mapLanguageCode(t.lang) === defaultLanguageId
+  const selectedInternalName = selectItemInternalName(
+    group.translations.map((translation) => ({
+      languageId: mapLanguageCode(translation.lang),
+      value: translation.name === undefined ? null : translation.name,
+    })),
+    defaultLanguageId,
+    'SH Monument Detail',
+    backwardCompat
   );
 
-  if (defaultTranslation?.name) {
-    internalName = convertHtmlToMarkdown(defaultTranslation.name);
-  } else if (group.translations.length > 0 && group.translations[0].name) {
-    // Fallback to first available translation
-    internalName = convertHtmlToMarkdown(group.translations[0].name);
-    warning = `SH Monument Detail ${backwardCompat} missing translation in default language, using ${group.translations[0].lang}`;
-  }
-
   const data: Omit<ItemData, 'partner_id' | 'collection_id' | 'project_id' | 'parent_id'> = {
-    internal_name: internalName,
+    internal_name: selectedInternalName.internalName,
     type: 'detail',
     backward_compatibility: backwardCompat,
     country_id: mapCountryCode(group.country),
@@ -118,7 +113,7 @@ export function transformShMonumentDetail(
     data,
     backwardCompatibility: backwardCompat,
     parentBackwardCompatibility: parentBackwardCompat,
-    warning,
+    warning: selectedInternalName.warning ?? undefined,
   };
 }
 

--- a/scripts/importer/src/domain/transformers/sh-monument-transformer.ts
+++ b/scripts/importer/src/domain/transformers/sh-monument-transformer.ts
@@ -13,6 +13,7 @@ import type { ItemData, ItemTranslationData } from '../../core/types.js';
 import { mapCountryCode, mapLanguageCode } from '../../utils/code-mappings.js';
 import { convertHtmlToMarkdown } from '../../utils/html-to-markdown.js';
 import { formatShBackwardCompatibility } from './sh-project-transformer.js';
+import { selectItemInternalName } from './item-internal-name-transformer.js';
 
 const SH_MONUMENTS_TABLE = 'sh_monuments';
 
@@ -83,24 +84,18 @@ export function transformShMonument(
     group.number
   );
 
-  // Find default language translation for internal_name
-  let internalName = `SH Monument ${group.project_id}:${group.country}:${group.number}`;
-  let warning: string | undefined;
-
-  const defaultTranslation = group.translations.find(
-    (t) => mapLanguageCode(t.lang) === defaultLanguageId
+  const selectedInternalName = selectItemInternalName(
+    group.translations.map((translation) => ({
+      languageId: mapLanguageCode(translation.lang),
+      value: translation.name === undefined ? null : translation.name,
+    })),
+    defaultLanguageId,
+    'SH Monument',
+    backwardCompat
   );
 
-  if (defaultTranslation?.name) {
-    internalName = convertHtmlToMarkdown(defaultTranslation.name);
-  } else if (group.translations.length > 0 && group.translations[0].name) {
-    // Fallback to first available translation
-    internalName = convertHtmlToMarkdown(group.translations[0].name);
-    warning = `SH Monument ${backwardCompat} missing translation in default language, using ${group.translations[0].lang}`;
-  }
-
   const data: Omit<ItemData, 'partner_id' | 'collection_id' | 'project_id'> = {
-    internal_name: internalName,
+    internal_name: selectedInternalName.internalName,
     type: 'monument',
     backward_compatibility: backwardCompat,
     country_id: mapCountryCode(group.country),
@@ -114,7 +109,7 @@ export function transformShMonument(
   return {
     data,
     backwardCompatibility: backwardCompat,
-    warning,
+    warning: selectedInternalName.warning ?? undefined,
   };
 }
 

--- a/scripts/importer/src/domain/transformers/sh-object-transformer.ts
+++ b/scripts/importer/src/domain/transformers/sh-object-transformer.ts
@@ -13,6 +13,7 @@ import type { ItemData, ItemTranslationData } from '../../core/types.js';
 import { mapCountryCode, mapLanguageCode } from '../../utils/code-mappings.js';
 import { convertHtmlToMarkdown } from '../../utils/html-to-markdown.js';
 import { formatShBackwardCompatibility } from './sh-project-transformer.js';
+import { selectItemInternalName } from './item-internal-name-transformer.js';
 
 const SH_OBJECTS_TABLE = 'sh_objects';
 
@@ -84,24 +85,18 @@ export function transformShObject(
     group.number
   );
 
-  // Find default language translation for internal_name
-  let internalName = `SH Object ${group.project_id}:${group.country}:${group.number}`;
-  let warning: string | undefined;
-
-  const defaultTranslation = group.translations.find(
-    (t) => mapLanguageCode(t.lang) === defaultLanguageId
+  const selectedInternalName = selectItemInternalName(
+    group.translations.map((translation) => ({
+      languageId: mapLanguageCode(translation.lang),
+      value: translation.name === undefined ? null : translation.name,
+    })),
+    defaultLanguageId,
+    'SH Object',
+    backwardCompat
   );
 
-  if (defaultTranslation?.name) {
-    internalName = convertHtmlToMarkdown(defaultTranslation.name);
-  } else if (group.translations.length > 0 && group.translations[0].name) {
-    // Fallback to first available translation
-    internalName = convertHtmlToMarkdown(group.translations[0].name);
-    warning = `SH Object ${backwardCompat} missing translation in default language, using ${group.translations[0].lang}`;
-  }
-
   const data: Omit<ItemData, 'partner_id' | 'collection_id' | 'project_id'> = {
-    internal_name: internalName,
+    internal_name: selectedInternalName.internalName,
     type: 'object',
     backward_compatibility: backwardCompat,
     country_id: mapCountryCode(group.country),
@@ -115,7 +110,7 @@ export function transformShObject(
   return {
     data,
     backwardCompatibility: backwardCompat,
-    warning,
+    warning: selectedInternalName.warning ?? undefined,
   };
 }
 

--- a/scripts/importer/src/domain/transformers/travels-monument-transformer.ts
+++ b/scripts/importer/src/domain/transformers/travels-monument-transformer.ts
@@ -1,0 +1,69 @@
+import type { ItemData } from '../../core/types.js';
+import { mapCountryCode, mapLanguageCode } from '../../utils/code-mappings.js';
+import { selectItemInternalName, type ItemInternalNameCandidate } from './item-internal-name-transformer.js';
+
+export interface TravelMonumentTranslationCandidate {
+  project_id: string;
+  country: string;
+  itinerary_id: string;
+  location_id: string;
+  number: string;
+  lang: string;
+  trail_id: number;
+  title: string;
+}
+
+export interface TravelMonumentTransformGroup {
+  project_id: string;
+  country: string;
+  trail_id: number;
+  itinerary_id: string;
+  location_id: string;
+  number: string;
+  translations: TravelMonumentTranslationCandidate[];
+}
+
+export interface TransformedTravelMonument {
+  data: Omit<ItemData, 'collection_id' | 'partner_id' | 'project_id'>;
+  backwardCompatibility: string;
+  warning: string | null;
+}
+
+export function transformTravelsMonument(
+  group: TravelMonumentTransformGroup,
+  defaultLanguageId: string
+): TransformedTravelMonument {
+  const backwardCompatibility = `mwnf3_travels:monument:${group.project_id}:${group.country}:${group.trail_id}:${group.itinerary_id}:${group.location_id}:${group.number}`;
+  const candidates: ItemInternalNameCandidate[] = [];
+
+  for (const translation of group.translations) {
+    candidates.push({
+      languageId: mapLanguageCode(translation.lang),
+      value: translation.title,
+    });
+  }
+
+  const selectedInternalName = selectItemInternalName(
+    candidates,
+    defaultLanguageId,
+    'Travels monument',
+    backwardCompatibility
+  );
+
+  return {
+    data: {
+      internal_name: selectedInternalName.internalName,
+      backward_compatibility: backwardCompatibility,
+      type: 'monument',
+      country_id: mapCountryCode(group.country),
+      parent_id: null,
+      owner_reference: null,
+      mwnf_reference: null,
+      latitude: null,
+      longitude: null,
+      map_zoom: null,
+    },
+    backwardCompatibility,
+    warning: selectedInternalName.warning,
+  };
+}

--- a/scripts/importer/src/importers/phase-06/explore-country-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-country-importer.ts
@@ -14,6 +14,7 @@
  * Mapping:
  * - countryId → backward_compatibility (mwnf3_explore:country:{countryId})
  * - countryId → country_id (FK to countries table)
+ * - country name → internal_name (human-readable title)
  * - type = 'collection'
  * - parent_id = explore_by_country root collection
  *
@@ -100,7 +101,16 @@ export class ExploreCountryImporter extends BaseImporter {
           // Map country ID (legacy uses 2-letter, our system uses 3-letter ISO codes)
           const countryId = this.mapCountryId(legacy.countryId);
 
-          const internalName = `country_${legacy.countryId}`;
+          const countryName = await this.getCountryName(legacy.countryId);
+          let internalName = '';
+          if (countryName && countryName.trim() !== '') {
+            internalName = countryName;
+          } else {
+            internalName = legacy.countryId.toUpperCase();
+            this.logWarning(
+              `Explore country ${backwardCompat} missing country name, using ${internalName} instead`
+            );
+          }
 
           // Collect sample
           this.collectSample(
@@ -136,7 +146,6 @@ export class ExploreCountryImporter extends BaseImporter {
           this.registerEntity(collectionId, backwardCompat, 'collection');
 
           // Create translation - use country name if available
-          const countryName = await this.getCountryName(legacy.countryId);
           const translationBackwardCompat = `${backwardCompat}:translation:${this.defaultLanguageId}`;
 
           await this.context.strategy.writeCollectionTranslation({

--- a/scripts/importer/src/importers/phase-06/explore-itinerary-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-itinerary-importer.ts
@@ -12,6 +12,7 @@
  *
  * Mapping:
  * - itineraries_id → backward_compatibility (mwnf3_explore:itinerary:{itineraries_id})
+ * - derived title → internal_name (human-readable title)
  * - parent_itineraries_id → parent_id (for nested itineraries)
  * - cycle → link to thematic cycle collection
  * - type = 'itinerary' (or 'exhibition trail' for sub-itineraries)
@@ -180,7 +181,6 @@ export class ExploreItineraryImporter extends BaseImporter {
 
       // Build title from cycle info or country
       const title = await this.buildItineraryTitle(legacy);
-      const internalName = `itinerary_${legacy.itineraries_id}`;
 
       // Determine type - sub-itineraries get 'exhibition trail' type
       const collectionType = legacy.parent_itineraries_id ? 'exhibition trail' : 'itinerary';
@@ -197,7 +197,7 @@ export class ExploreItineraryImporter extends BaseImporter {
 
       if (this.isDryRun || this.isSampleOnlyMode) {
         this.logInfo(
-          `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create collection: ${internalName} (${backwardCompat})`
+          `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create collection: ${title} (${backwardCompat})`
         );
         this.registerEntity('', backwardCompat, 'collection');
         result.imported++;
@@ -207,7 +207,7 @@ export class ExploreItineraryImporter extends BaseImporter {
 
       // Write collection using strategy
       const collectionId = await this.context.strategy.writeCollection({
-        internal_name: internalName,
+        internal_name: title,
         backward_compatibility: backwardCompat,
         context_id: this.exploreContextId,
         language_id: this.defaultLanguageId,

--- a/scripts/importer/src/importers/phase-06/explore-location-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-location-importer.ts
@@ -12,7 +12,7 @@
  *
  * Mapping:
  * - locationId → backward_compatibility (mwnf3_explore:location:{locationId})
- * - label → internal_name (slugified), title (translation)
+ * - label/locationtranslated.spelling → internal_name (human-readable title)
  * - geoCoordinates → latitude, longitude
  * - zoom → map_zoom
  * - countryId → parent_id (via country collection lookup)
@@ -25,17 +25,8 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
-
-/**
- * Convert a string to a URL-safe slug
- */
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .substring(0, 100);
-}
+import { mapLanguageCode } from '../../utils/code-mappings.js';
+import { selectItemInternalName } from '../../domain/transformers/item-internal-name-transformer.js';
 
 /**
  * Legacy location structure
@@ -51,6 +42,12 @@ interface LegacyLocation {
   info: string | null;
   contact: string | null;
   description: string | null;
+}
+
+interface LegacyLocationTranslation {
+  locationId: number;
+  langId: string;
+  spelling: string | null;
 }
 
 /**
@@ -104,6 +101,7 @@ export class ExploreLocationImporter extends BaseImporter {
 
       this.logInfo(`Found Explore context: ${this.exploreContextId}`);
       this.logInfo('Importing Explore locations...');
+      this.defaultLanguageId = await this.getDefaultLanguageIdAsync();
 
       // Query locations from legacy database
       const locations = await this.context.legacyDb.query<LegacyLocation>(
@@ -112,6 +110,23 @@ export class ExploreLocationImporter extends BaseImporter {
          WHERE label IS NOT NULL AND label != ''
          ORDER BY countryId, locationId`
       );
+
+      const locationTranslations = await this.context.legacyDb.query<LegacyLocationTranslation>(
+        `SELECT locationId, langId, spelling
+         FROM mwnf3_explore.locationtranslated
+         WHERE spelling IS NOT NULL AND spelling != ''`
+      );
+
+      const translationsByLocationId = new Map<number, LegacyLocationTranslation[]>();
+      for (const translation of locationTranslations) {
+        const existingTranslations = translationsByLocationId.get(translation.locationId);
+        if (existingTranslations) {
+          existingTranslations.push(translation);
+          continue;
+        }
+
+        translationsByLocationId.set(translation.locationId, [translation]);
+      }
 
       this.logInfo(`Found ${locations.length} locations to import`);
 
@@ -132,8 +147,30 @@ export class ExploreLocationImporter extends BaseImporter {
           // Parse coordinates
           const [latitude, longitude] = parseGeoCoordinates(legacy.geoCoordinates);
 
-          // Create internal name - include locationId for uniqueness
-          const internalName = `location_${legacy.locationId}_${legacy.countryId}_${slugify(legacy.label)}`;
+          const internalNameCandidates = [
+            {
+              languageId: this.defaultLanguageId,
+              value: legacy.label,
+            },
+          ];
+
+          const translatedNames = translationsByLocationId.get(legacy.locationId) ?? [];
+          for (const translation of translatedNames) {
+            internalNameCandidates.push({
+              languageId: mapLanguageCode(translation.langId),
+              value: translation.spelling,
+            });
+          }
+
+          const selectedInternalName = selectItemInternalName(
+            internalNameCandidates,
+            this.defaultLanguageId,
+            'Explore location',
+            backwardCompat
+          );
+          if (selectedInternalName.warning) {
+            this.logWarning(selectedInternalName.warning);
+          }
 
           // Collect sample
           this.collectSample(
@@ -144,7 +181,7 @@ export class ExploreLocationImporter extends BaseImporter {
 
           if (this.isDryRun || this.isSampleOnlyMode) {
             this.logInfo(
-              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create collection: ${internalName} (${backwardCompat})`
+              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create collection: ${selectedInternalName.internalName} (${backwardCompat})`
             );
             this.registerEntity('', backwardCompat, 'collection');
             result.imported++;
@@ -154,7 +191,7 @@ export class ExploreLocationImporter extends BaseImporter {
 
           // Write collection using strategy
           const collectionId = await this.context.strategy.writeCollection({
-            internal_name: internalName,
+            internal_name: selectedInternalName.internalName,
             backward_compatibility: backwardCompat,
             context_id: this.exploreContextId,
             language_id: this.defaultLanguageId,

--- a/scripts/importer/src/importers/phase-06/explore-monument-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-monument-importer.ts
@@ -13,7 +13,7 @@
  *
  * Mapping:
  * - monumentId → backward_compatibility (mwnf3_explore:monument:{monumentId})
- * - title → internal_name (slugified)
+ * - exploremonumentext.name → internal_name (default language first, then first named translation)
  * - geoCoordinates → latitude, longitude
  * - zoom → map_zoom
  * - locationId → collection link (via collection_item pivot)
@@ -25,50 +25,11 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
-
-/**
- * Convert a string to a URL-safe slug
- */
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .substring(0, 100);
-}
-
-/**
- * Legacy monument structure
- */
-interface LegacyMonument {
-  monumentId: number;
-  locationId: number | null;
-  title: string;
-  geoCoordinates: string | null;
-  zoom: number | null;
-  special_monument: string | null;
-  related_monument: string | null;
-}
-
-/**
- * Parse legacy geoCoordinates format
- */
-function parseGeoCoordinates(coords: string | null): [number | null, number | null] {
-  if (!coords || !coords.trim()) {
-    return [null, null];
-  }
-  const cleaned = coords.replace(/\s+/g, '').trim();
-  const parts = cleaned.split(',');
-  if (parts.length !== 2) {
-    return [null, null];
-  }
-  const lat = parseFloat(parts[0]);
-  const lon = parseFloat(parts[1]);
-  if (isNaN(lat) || isNaN(lon)) {
-    return [null, null];
-  }
-  return [lat, lon];
-}
+import {
+  transformExploreMonument,
+  type ExploreLegacyMonument,
+  type ExploreMonumentNameTranslation,
+} from '../../domain/transformers/explore-monument-transformer.js';
 
 export class ExploreMonumentImporter extends BaseImporter {
   private exploreContextId: string | null = null;
@@ -99,14 +60,42 @@ export class ExploreMonumentImporter extends BaseImporter {
 
       this.logInfo(`Found Explore context: ${this.exploreContextId}`);
       this.logInfo('Importing Explore monuments...');
+      const defaultLanguageId = await this.getDefaultLanguageIdAsync();
 
       // Query monuments from legacy database
-      const monuments = await this.context.legacyDb.query<LegacyMonument>(
+      const monuments = await this.context.legacyDb.query<ExploreLegacyMonument>(
         `SELECT monumentId, locationId, title, geoCoordinates, zoom, special_monument, related_monument
          FROM mwnf3_explore.exploremonument 
-         WHERE title IS NOT NULL AND title != ''
          ORDER BY locationId, monumentId`
       );
+
+      const monumentTranslations = await this.context.legacyDb.query<
+        ExploreMonumentNameTranslation & { monumentId: number }
+      >(
+        `SELECT monumentId, langId, name
+         FROM mwnf3_explore.exploremonumentext
+         WHERE name IS NOT NULL AND name != ''
+         ORDER BY monumentId, langId`
+      );
+
+      const translationsByMonumentId = new Map<number, ExploreMonumentNameTranslation[]>();
+      for (const translation of monumentTranslations) {
+        const existingTranslations = translationsByMonumentId.get(translation.monumentId);
+        if (existingTranslations) {
+          existingTranslations.push({
+            langId: translation.langId,
+            name: translation.name,
+          });
+          continue;
+        }
+
+        translationsByMonumentId.set(translation.monumentId, [
+          {
+            langId: translation.langId,
+            name: translation.name,
+          },
+        ]);
+      }
 
       this.logInfo(`Found ${monuments.length} monuments to import`);
 
@@ -121,11 +110,17 @@ export class ExploreMonumentImporter extends BaseImporter {
             continue;
           }
 
-          // Parse coordinates
-          const [latitude, longitude] = parseGeoCoordinates(legacy.geoCoordinates);
+          const translations = translationsByMonumentId.get(legacy.monumentId);
+          if (!translations) {
+            throw new Error(
+              `Explore monument ${backwardCompat} missing translation rows required for internal_name selection`
+            );
+          }
 
-          // Create internal name (with location context if available)
-          const internalName = `explore_monument_${legacy.monumentId}_${slugify(legacy.title)}`;
+          const transformed = transformExploreMonument(legacy, translations, defaultLanguageId);
+          if (transformed.warning) {
+            this.logWarning(transformed.warning);
+          }
 
           // Collect sample
           this.collectSample(
@@ -136,7 +131,7 @@ export class ExploreMonumentImporter extends BaseImporter {
 
           if (this.isDryRun || this.isSampleOnlyMode) {
             this.logInfo(
-              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create item: ${internalName} (${backwardCompat})`
+              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create item: ${transformed.data.internal_name} (${backwardCompat})`
             );
             this.registerEntity('', backwardCompat, 'item');
             result.imported++;
@@ -146,31 +141,22 @@ export class ExploreMonumentImporter extends BaseImporter {
 
           // Write item using strategy
           const itemId = await this.context.strategy.writeItem({
-            internal_name: internalName,
-            backward_compatibility: backwardCompat,
-            type: 'monument',
+            ...transformed.data,
             collection_id: null,
             partner_id: null,
-            country_id: null,
             project_id: null,
-            parent_id: null,
-            owner_reference: null,
-            mwnf_reference: null,
-            latitude,
-            longitude,
-            map_zoom: legacy.zoom ?? null,
           });
 
           this.registerEntity(itemId, backwardCompat, 'item');
 
           // Link item to location collection if available
-          if (legacy.locationId) {
-            const collectionId = await this.getLocationCollectionId(legacy.locationId);
+          if (transformed.locationId) {
+            const collectionId = await this.getLocationCollectionId(transformed.locationId);
             if (collectionId) {
               await this.context.strategy.writeCollectionItem({
                 collection_id: collectionId,
                 item_id: itemId,
-                backward_compatibility: `${backwardCompat}:collection_link:${legacy.locationId}`,
+                backward_compatibility: `${backwardCompat}:collection_link:${transformed.locationId}`,
                 display_order: null,
               });
             }

--- a/scripts/importer/src/importers/phase-06/explore-region-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-region-importer.ts
@@ -23,14 +23,8 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
-
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .substring(0, 100);
-}
+import { mapLanguageCode } from '../../utils/code-mappings.js';
+import { selectItemInternalName } from '../../domain/transformers/item-internal-name-transformer.js';
 
 function parseGeoCoordinates(coords: string | null): [number | null, number | null] {
   if (!coords || !coords.trim()) return [null, null];
@@ -66,6 +60,7 @@ interface LegacyRegionTheme {
 export class ExploreRegionImporter extends BaseImporter {
   private exploreContextId!: string;
   private countryCollectionCache: Map<string, string | null> = new Map();
+  private defaultLanguageId: string = 'eng';
 
   getName(): string {
     return 'ExploreRegionImporter';
@@ -87,6 +82,7 @@ export class ExploreRegionImporter extends BaseImporter {
         );
       }
       this.exploreContextId = exploreContextId;
+      this.defaultLanguageId = await this.getDefaultLanguageIdAsync();
 
       this.logInfo('Importing Explore regions...');
 
@@ -134,7 +130,31 @@ export class ExploreRegionImporter extends BaseImporter {
           const parentId = await this.getCountryCollectionId(legacy.countryId);
 
           const [latitude, longitude] = parseGeoCoordinates(legacy.geoCoordinates);
-          const internalName = `region_${legacy.regionId}_${slugify(legacy.label)}`;
+
+          const internalNameCandidates = [
+            {
+              languageId: this.defaultLanguageId,
+              value: legacy.label,
+            },
+          ];
+
+          const regionTranslations = translationsByRegion.get(legacy.regionId) ?? [];
+          for (const translation of regionTranslations) {
+            internalNameCandidates.push({
+              languageId: mapLanguageCode(translation.langId),
+              value: translation.spelling,
+            });
+          }
+
+          const selectedInternalName = selectItemInternalName(
+            internalNameCandidates,
+            this.defaultLanguageId,
+            'Explore region',
+            backwardCompat
+          );
+          if (selectedInternalName.warning) {
+            this.logWarning(selectedInternalName.warning);
+          }
 
           // Build extra with territory_level and theme_ids
           const extra: Record<string, unknown> = {};
@@ -155,7 +175,7 @@ export class ExploreRegionImporter extends BaseImporter {
 
           if (this.isDryRun || this.isSampleOnlyMode) {
             this.logInfo(
-              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create collection: ${internalName} (${backwardCompat})`
+              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create collection: ${selectedInternalName.internalName} (${backwardCompat})`
             );
             this.registerEntity('', backwardCompat, 'collection');
             result.imported++;
@@ -165,7 +185,7 @@ export class ExploreRegionImporter extends BaseImporter {
 
           // Write collection
           const collectionId = await this.context.strategy.writeCollection({
-            internal_name: internalName,
+            internal_name: selectedInternalName.internalName,
             backward_compatibility: backwardCompat,
             context_id: this.exploreContextId,
             language_id: 'eng',

--- a/scripts/importer/src/importers/phase-06/explore-thematiccycle-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-thematiccycle-importer.ts
@@ -12,7 +12,7 @@
  *
  * Mapping:
  * - cycleId → backward_compatibility (mwnf3_explore:thematiccycle:{cycleId})
- * - cycleLabel → internal_name (slugified)
+ * - cycleDescription/cycleLabel → internal_name (human-readable title)
  * - geoCoordinates → latitude, longitude (parsed from "lat,lon" format)
  * - zoom → map_zoom
  * - type = 'theme'
@@ -25,17 +25,6 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
-
-/**
- * Convert a string to a URL-safe slug
- */
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .substring(0, 100);
-}
 
 /**
  * Legacy thematiccycle structure
@@ -143,8 +132,19 @@ export class ExploreThematicCycleImporter extends BaseImporter {
           // Parse coordinates
           const [latitude, longitude] = parseGeoCoordinates(legacy.geoCoordinates);
 
-          // Create internal name from cycleLabel
-          const internalName = `theme_${slugify(legacy.cycleLabel)}`;
+          let internalName = '';
+          if (legacy.cycleDescription && legacy.cycleDescription.trim() !== '') {
+            internalName = legacy.cycleDescription;
+          } else if (legacy.cycleLabel && legacy.cycleLabel.trim() !== '') {
+            internalName = legacy.cycleLabel;
+            this.logWarning(
+              `Explore thematic cycle ${backwardCompat} missing cycleDescription, using cycleLabel instead`
+            );
+          } else {
+            throw new Error(
+              `Explore thematic cycle ${backwardCompat} missing required title data for internal_name`
+            );
+          }
 
           // Collect sample
           this.collectSample(

--- a/scripts/importer/src/importers/phase-07/travels-itinerary-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-itinerary-importer.ts
@@ -5,7 +5,7 @@
  * Itineraries are routes within a trail, like "Itinerary I - The Seat of the Sultanate".
  *
  * Legacy schema:
- * - mwnf3.tr_itineraries (project_id, country, number, lang, trail_id, title, description, days)
+ * - mwnf3_travels.tr_itineraries (project_id, country, number, lang, trail_id, title, description, days)
  *   - Composite key: (project_id, country, trail_id, number) identifies unique itinerary
  *   - Multiple rows per itinerary (one per language)
  *   - trail_id references trails.number
@@ -87,7 +87,7 @@ export class TravelsItineraryImporter extends BaseImporter {
       // Query unique itineraries from legacy database (use English for names)
       const itineraries = await this.context.legacyDb.query<LegacyItinerary>(
         `SELECT project_id, country, number, lang, trail_id, title, description, days
-         FROM mwnf3.tr_itineraries 
+        FROM mwnf3_travels.tr_itineraries 
          WHERE lang = 'en'
          ORDER BY project_id, country, trail_id, number`
       );

--- a/scripts/importer/src/importers/phase-07/travels-itinerary-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-itinerary-importer.ts
@@ -15,7 +15,7 @@
  *
  * Mapping:
  * - (project_id, country, trail_id, number) → backward_compatibility
- * - title → used to create internal_name (slugified)
+ * - title → internal_name (default language first, then first named translation)
  * - type = 'itinerary'
  * - parent_id = trail collection
  *
@@ -26,17 +26,8 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
-
-/**
- * Convert a string to a URL-safe slug
- */
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .substring(0, 100);
-}
+import { mapLanguageCode } from '../../utils/code-mappings.js';
+import { selectItemInternalName } from '../../domain/transformers/item-internal-name-transformer.js';
 
 /**
  * Legacy itinerary structure
@@ -84,17 +75,29 @@ export class TravelsItineraryImporter extends BaseImporter {
 
       this.logInfo('Importing itineraries...');
 
-      // Query unique itineraries from legacy database (use English for names)
+      // Query all itinerary rows and group by project/country/trail/number
       const itineraries = await this.context.legacyDb.query<LegacyItinerary>(
         `SELECT project_id, country, number, lang, trail_id, title, description, days
         FROM mwnf3_travels.tr_itineraries 
-         WHERE lang = 'en'
-         ORDER BY project_id, country, trail_id, number`
+         ORDER BY project_id, country, trail_id, number, lang`
       );
 
-      this.logInfo(`Found ${itineraries.length} itineraries to import`);
+      const groupedItineraries = new Map<string, LegacyItinerary[]>();
+      for (const itinerary of itineraries) {
+        const key = `${itinerary.project_id}:${itinerary.country}:${itinerary.trail_id}:${itinerary.number}`;
+        const existingItineraries = groupedItineraries.get(key);
+        if (existingItineraries) {
+          existingItineraries.push(itinerary);
+          continue;
+        }
 
-      for (const legacy of itineraries) {
+        groupedItineraries.set(key, [itinerary]);
+      }
+
+      this.logInfo(`Found ${groupedItineraries.size} itineraries to import`);
+
+      for (const itineraryGroup of groupedItineraries.values()) {
+        const legacy = itineraryGroup[0]!;
         try {
           const backwardCompat = `mwnf3_travels:itinerary:${legacy.project_id}:${legacy.country}:${legacy.trail_id}:${legacy.number}`;
 
@@ -118,8 +121,23 @@ export class TravelsItineraryImporter extends BaseImporter {
             continue;
           }
 
-          // Create internal name
-          const internalName = `itin_${legacy.project_id}_${legacy.country}_${legacy.trail_id}_${legacy.number}_${slugify(legacy.title || 'unnamed')}`;
+          const internalNameCandidates = [];
+          for (const translation of itineraryGroup) {
+            internalNameCandidates.push({
+              languageId: mapLanguageCode(translation.lang),
+              value: translation.title,
+            });
+          }
+
+          const selectedInternalName = selectItemInternalName(
+            internalNameCandidates,
+            this.defaultLanguageId,
+            'Travels itinerary',
+            backwardCompat
+          );
+          if (selectedInternalName.warning) {
+            this.logWarning(selectedInternalName.warning);
+          }
 
           // Collect sample
           this.collectSample(
@@ -131,7 +149,7 @@ export class TravelsItineraryImporter extends BaseImporter {
 
           if (this.isDryRun || this.isSampleOnlyMode) {
             this.logInfo(
-              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create itinerary: ${internalName}`
+              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create itinerary: ${selectedInternalName.internalName}`
             );
             this.registerEntity('', backwardCompat, 'collection');
             result.imported++;
@@ -141,7 +159,7 @@ export class TravelsItineraryImporter extends BaseImporter {
 
           // Write collection
           const collectionId = await this.context.strategy.writeCollection({
-            internal_name: internalName,
+            internal_name: selectedInternalName.internalName,
             backward_compatibility: backwardCompat,
             context_id: this.travelsContextId,
             language_id: this.defaultLanguageId,

--- a/scripts/importer/src/importers/phase-07/travels-itinerary-picture-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-itinerary-picture-importer.ts
@@ -1,10 +1,10 @@
 /**
  * Travels Itinerary Picture Importer
  *
- * Imports pictures from mwnf3.tr_itineraries_pictures as CollectionImages.
+ * Imports pictures from mwnf3_travels.tr_itineraries_pictures as CollectionImages.
  *
  * Legacy schema:
- * - mwnf3.tr_itineraries_pictures (lang, country, project_id, number, trail_id, image_number, path, thumb, caption, photographer, copyright, lastupdate, type)
+ * - mwnf3_travels.tr_itineraries_pictures (lang, country, project_id, number, trail_id, image_number, path, thumb, caption, photographer, copyright, lastupdate, type)
  *   - PK: (lang, project_id, country, trail_id, number, image_number, type)
  *   - Types: sketch, or empty
  *
@@ -67,7 +67,7 @@ export class TravelsItineraryPictureImporter extends BaseImporter {
       // Query all itinerary pictures
       const pictures = await this.context.legacyDb.query<LegacyItineraryPicture>(
         `SELECT lang, country, project_id, number, trail_id, image_number, path, thumb, caption, photographer, copyright, lastupdate, type
-         FROM mwnf3.tr_itineraries_pictures
+        FROM mwnf3_travels.tr_itineraries_pictures
          ORDER BY project_id, country, trail_id, number, type, image_number, lang`
       );
 

--- a/scripts/importer/src/importers/phase-07/travels-itinerary-translation-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-itinerary-translation-importer.ts
@@ -4,7 +4,7 @@
  * Creates CollectionTranslation records for each itinerary in all available languages.
  *
  * Legacy schema:
- * - mwnf3.tr_itineraries (project_id, country, number, lang, trail_id, title, description, days)
+ * - mwnf3_travels.tr_itineraries (project_id, country, number, lang, trail_id, title, description, days)
  *   - One row per language
  *
  * New schema:
@@ -65,7 +65,7 @@ export class TravelsItineraryTranslationImporter extends BaseImporter {
       // Query all itinerary translations
       const translations = await this.context.legacyDb.query<LegacyItineraryTranslation>(
         `SELECT project_id, country, number, lang, trail_id, title, description, days
-         FROM mwnf3.tr_itineraries 
+        FROM mwnf3_travels.tr_itineraries 
          ORDER BY project_id, country, trail_id, number, lang`
       );
 

--- a/scripts/importer/src/importers/phase-07/travels-location-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-location-importer.ts
@@ -5,7 +5,7 @@
  * Locations are places within an itinerary, like "Cairo" or "Alexandria".
  *
  * Legacy schema:
- * - mwnf3.tr_locations (project_id, country, itinerary_id, number, lang, trail_id, title)
+ * - mwnf3_travels.tr_locations (project_id, country, itinerary_id, number, lang, trail_id, title)
  *   - Composite key: (project_id, country, trail_id, itinerary_id, number)
  *   - Multiple rows per location (one per language)
  *   - itinerary_id references tr_itineraries.number (Roman numerals like 'I', 'II')
@@ -86,7 +86,7 @@ export class TravelsLocationImporter extends BaseImporter {
       // Query unique locations from legacy database (use English for names)
       const locations = await this.context.legacyDb.query<LegacyLocation>(
         `SELECT project_id, country, itinerary_id, number, lang, trail_id, title
-         FROM mwnf3.tr_locations 
+        FROM mwnf3_travels.tr_locations 
          WHERE lang = 'en'
          ORDER BY project_id, country, trail_id, itinerary_id, number`
       );

--- a/scripts/importer/src/importers/phase-07/travels-location-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-location-importer.ts
@@ -15,7 +15,7 @@
  *
  * Mapping:
  * - (project_id, country, trail_id, itinerary_id, number) → backward_compatibility
- * - title → used to create internal_name (slugified)
+ * - title → internal_name (default language first, then first named translation)
  * - type = 'location'
  * - parent_id = itinerary collection
  *
@@ -26,17 +26,8 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
-
-/**
- * Convert a string to a URL-safe slug
- */
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .substring(0, 100);
-}
+import { mapLanguageCode } from '../../utils/code-mappings.js';
+import { selectItemInternalName } from '../../domain/transformers/item-internal-name-transformer.js';
 
 /**
  * Legacy location structure
@@ -83,17 +74,29 @@ export class TravelsLocationImporter extends BaseImporter {
 
       this.logInfo('Importing locations...');
 
-      // Query unique locations from legacy database (use English for names)
+      // Query all location rows and group by project/country/trail/itinerary/number
       const locations = await this.context.legacyDb.query<LegacyLocation>(
         `SELECT project_id, country, itinerary_id, number, lang, trail_id, title
         FROM mwnf3_travels.tr_locations 
-         WHERE lang = 'en'
-         ORDER BY project_id, country, trail_id, itinerary_id, number`
+         ORDER BY project_id, country, trail_id, itinerary_id, number, lang`
       );
 
-      this.logInfo(`Found ${locations.length} locations to import`);
+      const groupedLocations = new Map<string, LegacyLocation[]>();
+      for (const location of locations) {
+        const key = `${location.project_id}:${location.country}:${location.trail_id}:${location.itinerary_id}:${location.number}`;
+        const existingLocations = groupedLocations.get(key);
+        if (existingLocations) {
+          existingLocations.push(location);
+          continue;
+        }
 
-      for (const legacy of locations) {
+        groupedLocations.set(key, [location]);
+      }
+
+      this.logInfo(`Found ${groupedLocations.size} locations to import`);
+
+      for (const locationGroup of groupedLocations.values()) {
+        const legacy = locationGroup[0]!;
         try {
           const backwardCompat = `mwnf3_travels:location:${legacy.project_id}:${legacy.country}:${legacy.trail_id}:${legacy.itinerary_id}:${legacy.number}`;
 
@@ -117,8 +120,23 @@ export class TravelsLocationImporter extends BaseImporter {
             continue;
           }
 
-          // Create internal name
-          const internalName = `loc_${legacy.project_id}_${legacy.country}_${legacy.trail_id}_${legacy.itinerary_id}_${legacy.number}_${slugify(legacy.title || 'unnamed')}`;
+          const internalNameCandidates = [];
+          for (const translation of locationGroup) {
+            internalNameCandidates.push({
+              languageId: mapLanguageCode(translation.lang),
+              value: translation.title,
+            });
+          }
+
+          const selectedInternalName = selectItemInternalName(
+            internalNameCandidates,
+            this.defaultLanguageId,
+            'Travels location',
+            backwardCompat
+          );
+          if (selectedInternalName.warning) {
+            this.logWarning(selectedInternalName.warning);
+          }
 
           // Collect sample
           this.collectSample(
@@ -130,7 +148,7 @@ export class TravelsLocationImporter extends BaseImporter {
 
           if (this.isDryRun || this.isSampleOnlyMode) {
             this.logInfo(
-              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create location: ${internalName}`
+              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create location: ${selectedInternalName.internalName}`
             );
             this.registerEntity('', backwardCompat, 'collection');
             result.imported++;
@@ -140,7 +158,7 @@ export class TravelsLocationImporter extends BaseImporter {
 
           // Write collection
           const collectionId = await this.context.strategy.writeCollection({
-            internal_name: internalName,
+            internal_name: selectedInternalName.internalName,
             backward_compatibility: backwardCompat,
             context_id: this.travelsContextId,
             language_id: this.defaultLanguageId,

--- a/scripts/importer/src/importers/phase-07/travels-location-picture-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-location-picture-importer.ts
@@ -1,10 +1,10 @@
 /**
  * Travels Location Picture Importer
  *
- * Imports pictures from mwnf3.tr_locations_pictures as CollectionImages.
+ * Imports pictures from mwnf3_travels.tr_locations_pictures as CollectionImages.
  *
  * Legacy schema:
- * - mwnf3.tr_locations_pictures (lang, country, project_id, itinerary_id, number, trail_id, image_number, path, thumb, caption, photographer, copyright, lastupdate, type)
+ * - mwnf3_travels.tr_locations_pictures (lang, country, project_id, itinerary_id, number, trail_id, image_number, path, thumb, caption, photographer, copyright, lastupdate, type)
  *   - PK: (lang, project_id, country, trail_id, itinerary_id, number, image_number, type)
  *   - Type: usually empty string
  *
@@ -69,7 +69,7 @@ export class TravelsLocationPictureImporter extends BaseImporter {
       // Query all location pictures
       const pictures = await this.context.legacyDb.query<LegacyLocationPicture>(
         `SELECT lang, country, project_id, itinerary_id, number, trail_id, image_number, path, thumb, caption, photographer, copyright, lastupdate, type
-         FROM mwnf3.tr_locations_pictures
+        FROM mwnf3_travels.tr_locations_pictures
          ORDER BY project_id, country, trail_id, itinerary_id, number, type, image_number, lang`
       );
 

--- a/scripts/importer/src/importers/phase-07/travels-location-translation-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-location-translation-importer.ts
@@ -4,7 +4,7 @@
  * Creates CollectionTranslation records for each location in all available languages.
  *
  * Legacy schema:
- * - mwnf3.tr_locations (project_id, country, itinerary_id, number, lang, trail_id, title)
+ * - mwnf3_travels.tr_locations (project_id, country, itinerary_id, number, lang, trail_id, title)
  *   - One row per language
  *
  * New schema:
@@ -64,7 +64,7 @@ export class TravelsLocationTranslationImporter extends BaseImporter {
       // Query all location translations
       const translations = await this.context.legacyDb.query<LegacyLocationTranslation>(
         `SELECT project_id, country, itinerary_id, number, lang, trail_id, title
-         FROM mwnf3.tr_locations 
+        FROM mwnf3_travels.tr_locations 
          ORDER BY project_id, country, trail_id, itinerary_id, number, lang`
       );
 

--- a/scripts/importer/src/importers/phase-07/travels-monument-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-monument-importer.ts
@@ -17,7 +17,7 @@
  *
  * Mapping:
  * - (project_id, country, trail_id, itinerary_id, location_id, number) → backward_compatibility
- * - title → used to create internal_name (slugified)
+ * - title → internal_name (default language first, then first named translation)
  * - type = 'monument'
  * - Linked to parent location collection via collection_item pivot
  *
@@ -28,17 +28,7 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
-
-/**
- * Convert a string to a URL-safe slug
- */
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .substring(0, 100);
-}
+import { transformTravelsMonument } from '../../domain/transformers/travels-monument-transformer.js';
 
 /**
  * Legacy travel monument structure
@@ -94,6 +84,7 @@ export class TravelsMonumentImporter extends BaseImporter {
       }
 
       this.logInfo('Importing travel monuments...');
+      const defaultLanguageId = await this.getDefaultLanguageIdAsync();
 
       // Query all travel monuments from legacy database
       const monuments = await this.context.legacyDb.query<LegacyTravelMonument>(
@@ -132,19 +123,15 @@ export class TravelsMonumentImporter extends BaseImporter {
             continue;
           }
 
-          // Find English title for internal name (or first available)
-          const englishTranslation = group.translations.find((t) => t.lang === 'en');
-          const primaryTranslation = englishTranslation || group.translations[0];
-
-          if (!primaryTranslation) {
-            this.logWarning(`No translations found for monument: ${backwardCompat}`);
-            result.skipped++;
-            this.showSkipped();
-            continue;
+          const transformed = transformTravelsMonument(group, defaultLanguageId);
+          if (transformed.warning) {
+            this.logWarning(transformed.warning);
           }
 
-          // Create internal name
-          const internalName = `tr_mon_${group.project_id}_${group.country}_${group.trail_id}_${group.itinerary_id}_${group.location_id}_${group.number}_${slugify(primaryTranslation.title || 'unnamed')}`;
+          const primaryTranslation = group.translations[0];
+          if (!primaryTranslation) {
+            throw new Error(`Travels monument ${backwardCompat} has no translation rows`);
+          }
 
           // Collect sample
           this.collectSample(
@@ -156,7 +143,7 @@ export class TravelsMonumentImporter extends BaseImporter {
 
           if (this.isDryRun || this.isSampleOnlyMode) {
             this.logInfo(
-              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create monument: ${internalName}`
+              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create monument: ${transformed.data.internal_name}`
             );
             this.registerEntity('', backwardCompat, 'item');
             result.imported++;
@@ -164,29 +151,12 @@ export class TravelsMonumentImporter extends BaseImporter {
             continue;
           }
 
-          // Get country ID
-          const countryId = await this.getEntityUuidAsync(group.country, 'country');
-          if (!countryId) {
-            this.logWarning(
-              `Country not found for code '${group.country}' in monument ${backwardCompat}, importing without country`
-            );
-          }
-
           // Write Item
           const itemId = await this.context.strategy.writeItem({
-            internal_name: internalName,
-            backward_compatibility: backwardCompat,
-            type: 'monument',
+            ...transformed.data,
             partner_id: null, // Travel monuments don't have a specific partner
             collection_id: locationId, // Primary collection is the location
-            parent_id: null,
-            country_id: countryId,
             project_id: null, // No project association
-            owner_reference: null,
-            mwnf_reference: null,
-            latitude: null,
-            longitude: null,
-            map_zoom: null,
           });
 
           this.registerEntity(itemId, backwardCompat, 'item');

--- a/scripts/importer/src/importers/phase-07/travels-monument-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-monument-importer.ts
@@ -6,7 +6,7 @@
  * entities from the main mwnf3.monuments table and have their own content.
  *
  * Legacy schema:
- * - mwnf3.tr_monuments (project_id, country, itinerary_id, location_id, number, lang, trail_id, title)
+ * - mwnf3_travels.tr_monuments (project_id, country, itinerary_id, location_id, number, lang, trail_id, title)
  *   - Composite key: (project_id, country, trail_id, itinerary_id, location_id, number)
  *   - Multiple rows per monument (one per language)
  *   - These are travel-specific monuments, separate from mwnf3.monuments
@@ -98,7 +98,7 @@ export class TravelsMonumentImporter extends BaseImporter {
       // Query all travel monuments from legacy database
       const monuments = await this.context.legacyDb.query<LegacyTravelMonument>(
         `SELECT project_id, country, itinerary_id, location_id, number, lang, trail_id, title
-         FROM mwnf3.tr_monuments 
+        FROM mwnf3_travels.tr_monuments 
          ORDER BY project_id, country, trail_id, itinerary_id, location_id, number, lang`
       );
 

--- a/scripts/importer/src/importers/phase-07/travels-monument-picture-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-monument-picture-importer.ts
@@ -1,11 +1,11 @@
 /**
  * Travels Monument Picture Importer
  *
- * Imports pictures from mwnf3.tr_monuments_pictures as ItemImages.
+ * Imports pictures from mwnf3_travels.tr_monuments_pictures as ItemImages.
  * This is the largest travel picture table (~7000 records).
  *
  * Legacy schema:
- * - mwnf3.tr_monuments_pictures (country, project_id, lang, itinerary_id, location_id, number, trail_id, image_number, path, thumb, caption, photographer, copyright, lastupdate, type)
+ * - mwnf3_travels.tr_monuments_pictures (country, project_id, lang, itinerary_id, location_id, number, trail_id, image_number, path, thumb, caption, photographer, copyright, lastupdate, type)
  *   - PK: (lang, project_id, country, trail_id, itinerary_id, location_id, number, image_number, type)
  *   - Type: usually empty string
  *
@@ -72,7 +72,7 @@ export class TravelsMonumentPictureImporter extends BaseImporter {
       // Query all monument pictures
       const pictures = await this.context.legacyDb.query<LegacyMonumentPicture>(
         `SELECT country, project_id, lang, itinerary_id, location_id, number, trail_id, image_number, path, thumb, caption, photographer, copyright, lastupdate, type
-         FROM mwnf3.tr_monuments_pictures
+        FROM mwnf3_travels.tr_monuments_pictures
          ORDER BY project_id, country, trail_id, itinerary_id, location_id, number, type, image_number, lang`
       );
 

--- a/scripts/importer/src/importers/phase-07/travels-monument-translation-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-monument-translation-importer.ts
@@ -4,7 +4,7 @@
  * Creates ItemTranslation records for each travel monument in all available languages.
  *
  * Legacy schema:
- * - mwnf3.tr_monuments (project_id, country, itinerary_id, location_id, number, lang, trail_id, title)
+ * - mwnf3_travels.tr_monuments (project_id, country, itinerary_id, location_id, number, lang, trail_id, title)
  *   - One row per language
  *   - Note: Unlike explore locations, tr_monuments only has title (no description, how_to_reach, etc.)
  *
@@ -68,7 +68,7 @@ export class TravelsMonumentTranslationImporter extends BaseImporter {
       // Note: tr_monuments only has title column, no description or visitor info fields
       const translations = await this.context.legacyDb.query<LegacyTravelMonumentTranslation>(
         `SELECT project_id, country, itinerary_id, location_id, number, lang, trail_id, title
-         FROM mwnf3.tr_monuments 
+        FROM mwnf3_travels.tr_monuments 
          ORDER BY project_id, country, trail_id, itinerary_id, location_id, number, lang`
       );
 

--- a/scripts/importer/src/importers/phase-07/travels-trail-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-trail-importer.ts
@@ -14,7 +14,7 @@
  *
  * Mapping:
  * - (project_id, country, number) → backward_compatibility (mwnf3_travels:trail:{project_id}:{country}:{number})
- * - title → used to create internal_name (slugified)
+ * - title → internal_name (default language first, then first named translation)
  * - type = 'exhibition trail'
  * - parent_id = travels root collection
  * - country_id = looked up from country code
@@ -27,17 +27,8 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
-
-/**
- * Convert a string to a URL-safe slug
- */
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .substring(0, 100);
-}
+import { mapLanguageCode } from '../../utils/code-mappings.js';
+import { selectItemInternalName } from '../../domain/transformers/item-internal-name-transformer.js';
 
 /**
  * Legacy trail structure (one row per language)
@@ -102,19 +93,30 @@ export class TravelsTrailImporter extends BaseImporter {
       this.logInfo(`Found Travels root: ${this.travelsRootId}`);
       this.logInfo('Importing trails...');
 
-      // Query unique trails from legacy database (use English for names, or first available)
-      // Group by project_id, country, number to get unique trails
+      // Query all trail rows and group by project_id/country/number for translation-aware naming
       const trails = await this.context.legacyDb.query<LegacyTrail>(
         `SELECT project_id, country, lang, number, title, subtitle, description, 
                 curated_by, local_coordinator, photo_by, museum_id, region_territory
          FROM mwnf3_travels.trails 
-         WHERE lang = 'en'
-         ORDER BY project_id, country, number`
+         ORDER BY project_id, country, number, lang`
       );
 
-      this.logInfo(`Found ${trails.length} trails to import`);
+      const groupedTrails = new Map<string, LegacyTrail[]>();
+      for (const trail of trails) {
+        const key = `${trail.project_id}:${trail.country}:${trail.number}`;
+        const existingTrails = groupedTrails.get(key);
+        if (existingTrails) {
+          existingTrails.push(trail);
+          continue;
+        }
 
-      for (const legacy of trails) {
+        groupedTrails.set(key, [trail]);
+      }
+
+      this.logInfo(`Found ${groupedTrails.size} trails to import`);
+
+      for (const trailGroup of groupedTrails.values()) {
+        const legacy = trailGroup[0]!;
         try {
           const backwardCompat = `mwnf3_travels:trail:${legacy.project_id}:${legacy.country}:${legacy.number}`;
 
@@ -133,8 +135,23 @@ export class TravelsTrailImporter extends BaseImporter {
             );
           }
 
-          // Create internal name from project_id, country, and title
-          const internalName = `trail_${legacy.project_id}_${legacy.country}_${legacy.number}_${slugify(legacy.title || 'unnamed')}`;
+          const internalNameCandidates = [];
+          for (const translation of trailGroup) {
+            internalNameCandidates.push({
+              languageId: mapLanguageCode(translation.lang),
+              value: translation.title,
+            });
+          }
+
+          const selectedInternalName = selectItemInternalName(
+            internalNameCandidates,
+            this.defaultLanguageId,
+            'Travels trail',
+            backwardCompat
+          );
+          if (selectedInternalName.warning) {
+            this.logWarning(selectedInternalName.warning);
+          }
 
           // Collect sample
           this.collectSample(
@@ -146,7 +163,7 @@ export class TravelsTrailImporter extends BaseImporter {
 
           if (this.isDryRun || this.isSampleOnlyMode) {
             this.logInfo(
-              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create trail: ${internalName}`
+              `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create trail: ${selectedInternalName.internalName}`
             );
             this.registerEntity('', backwardCompat, 'collection');
             result.imported++;
@@ -156,7 +173,7 @@ export class TravelsTrailImporter extends BaseImporter {
 
           // Write collection
           const collectionId = await this.context.strategy.writeCollection({
-            internal_name: internalName,
+            internal_name: selectedInternalName.internalName,
             backward_compatibility: backwardCompat,
             context_id: this.travelsContextId,
             language_id: this.defaultLanguageId,

--- a/scripts/importer/src/importers/phase-07/travels-trail-picture-importer.ts
+++ b/scripts/importer/src/importers/phase-07/travels-trail-picture-importer.ts
@@ -1,10 +1,10 @@
 /**
  * Travels Trail Picture Importer
  *
- * Imports pictures from mwnf3.tr_trails_pictures as CollectionImages.
+ * Imports pictures from mwnf3_travels.tr_trails_pictures as CollectionImages.
  *
  * Legacy schema:
- * - mwnf3.tr_trails_pictures (lang, country, project_id, trail_id, image_number, path, thumb, caption, photographer, copyright, lastupdate, type)
+ * - mwnf3_travels.tr_trails_pictures (lang, country, project_id, trail_id, image_number, path, thumb, caption, photographer, copyright, lastupdate, type)
  *   - PK: (project_id, country, trail_id, image_number, type, lang)
  *   - Types: cover, map, title, or empty
  *
@@ -66,7 +66,7 @@ export class TravelsTrailPictureImporter extends BaseImporter {
       // Query all trail pictures
       const pictures = await this.context.legacyDb.query<LegacyTrailPicture>(
         `SELECT lang, country, project_id, trail_id, image_number, path, thumb, caption, photographer, copyright, lastupdate, type
-         FROM mwnf3.tr_trails_pictures
+        FROM mwnf3_travels.tr_trails_pictures
          ORDER BY project_id, country, trail_id, type, image_number, lang`
       );
 

--- a/scripts/importer/tests/unit/explore-location-importer.test.ts
+++ b/scripts/importer/tests/unit/explore-location-importer.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExploreLocationImporter } from '../../src/importers/phase-06/explore-location-importer.js';
+import { UnifiedTracker } from '../../src/core/tracker.js';
+import type { ImportContext, ILegacyDatabase, ILogger } from '../../src/core/base-importer.js';
+import type { IWriteStrategy } from '../../src/core/strategy.js';
+
+describe('ExploreLocationImporter', () => {
+  let tracker: UnifiedTracker;
+  let legacyDb: ILegacyDatabase;
+  let strategy: IWriteStrategy;
+  let context: ImportContext;
+  let queryMock: ReturnType<typeof vi.fn>;
+  let writeCollectionMock: ReturnType<typeof vi.fn>;
+  let writeCollectionTranslationMock: ReturnType<typeof vi.fn>;
+
+  const logger: ILogger = {
+    info: vi.fn(),
+    warning: vi.fn(),
+    skip: vi.fn(),
+    error: vi.fn(),
+    exception: vi.fn(),
+    showProgress: vi.fn(),
+    showSkipped: vi.fn(),
+    showError: vi.fn(),
+    showSummary: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    tracker = new UnifiedTracker();
+    tracker.set('mwnf3_explore:context', 'explore-context-uuid', 'context');
+    tracker.set('mwnf3_explore:country:eg', 'country-collection-uuid', 'collection');
+    tracker.setMetadata('default_language_id', 'eng');
+
+    queryMock = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM mwnf3_explore.locations')) {
+        return [
+          {
+            locationId: 21,
+            countryId: 'eg',
+            label: 'Alexandria',
+            geoCoordinates: '31.2,29.9',
+            zoom: 9,
+            path: null,
+            how_to_reach: null,
+            info: null,
+            contact: null,
+            description: 'A city on the Mediterranean coast.',
+          },
+        ];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.locationtranslated')) {
+        return [
+          {
+            locationId: 21,
+            langId: 'fr',
+            spelling: 'Alexandrie',
+          },
+        ];
+      }
+
+      return [];
+    });
+
+    legacyDb = {
+      query: queryMock as ILegacyDatabase['query'],
+      execute: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+
+    writeCollectionMock = vi.fn().mockResolvedValue('location-collection-uuid');
+    writeCollectionTranslationMock = vi.fn().mockResolvedValue(undefined);
+
+    strategy = {
+      exists: vi.fn().mockResolvedValue(false),
+      findByBackwardCompatibility: vi.fn().mockResolvedValue(null),
+      writeCollection: writeCollectionMock,
+      writeCollectionTranslation: writeCollectionTranslationMock,
+    } as unknown as IWriteStrategy;
+
+    context = {
+      legacyDb,
+      strategy,
+      tracker,
+      logger,
+      dryRun: false,
+    };
+  });
+
+  it('uses the human-readable label as internal_name instead of a technical slug', async () => {
+    const importer = new ExploreLocationImporter(context);
+    const result = await importer.import();
+
+    expect(writeCollectionMock).toHaveBeenCalledWith({
+      internal_name: 'Alexandria',
+      backward_compatibility: 'mwnf3_explore:location:21',
+      context_id: 'explore-context-uuid',
+      language_id: 'eng',
+      parent_id: 'country-collection-uuid',
+      type: 'location',
+      latitude: 31.2,
+      longitude: 29.9,
+      map_zoom: 9,
+      country_id: null,
+    });
+    expect(writeCollectionTranslationMock).toHaveBeenCalledWith({
+      collection_id: 'location-collection-uuid',
+      language_id: 'eng',
+      context_id: 'explore-context-uuid',
+      backward_compatibility: 'mwnf3_explore:location:21:translation:eng',
+      title: 'Alexandria',
+      description: 'A city on the Mediterranean coast.',
+    });
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(1);
+  });
+});

--- a/scripts/importer/tests/unit/explore-monument-transformer.test.ts
+++ b/scripts/importer/tests/unit/explore-monument-transformer.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformExploreMonument } from '../../src/domain/transformers/explore-monument-transformer.js';
+
+describe('transformExploreMonument', () => {
+  it('uses the english translation name as internal_name instead of a slugged legacy title', () => {
+    const result = transformExploreMonument(
+      {
+        monumentId: 15,
+        locationId: 9,
+        title: 'Legacy Base Title',
+        geoCoordinates: '31.1, 35.2',
+        zoom: 16,
+        special_monument: null,
+        related_monument: null,
+      },
+      [
+        { langId: 'fr', name: 'Titre francais' },
+        { langId: 'en', name: 'English Monument Name' },
+      ],
+      'eng'
+    );
+
+    expect(result.data.internal_name).toBe('English Monument Name');
+    expect(result.data.latitude).toBe(31.1);
+    expect(result.data.longitude).toBe(35.2);
+    expect(result.locationId).toBe(9);
+    expect(result.warning).toBeNull();
+  });
+});

--- a/scripts/importer/tests/unit/item-internal-name-transformer.test.ts
+++ b/scripts/importer/tests/unit/item-internal-name-transformer.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectItemInternalName } from '../../src/domain/transformers/item-internal-name-transformer.js';
+
+describe('selectItemInternalName', () => {
+  it('uses the default language translation when it has a name', () => {
+    const result = selectItemInternalName(
+      [
+        { languageId: 'fra', value: 'Nom francais' },
+        { languageId: 'eng', value: 'English Name' },
+      ],
+      'eng',
+      'Travels monument',
+      'mwnf3_travels:monument:IAM:pt:1:V:1:a'
+    );
+
+    expect(result.internalName).toBe('English Name');
+    expect(result.warning).toBeNull();
+  });
+
+  it('falls back to the first named translation with an explicit warning', () => {
+    const result = selectItemInternalName(
+      [
+        { languageId: 'eng', value: null },
+        { languageId: 'fra', value: 'Nom francais' },
+        { languageId: 'ita', value: 'Nome italiano' },
+      ],
+      'eng',
+      'Explore monument',
+      'mwnf3_explore:monument:123'
+    );
+
+    expect(result.internalName).toBe('Nom francais');
+    expect(result.warning).toBe(
+      'Explore monument mwnf3_explore:monument:123 has no translation with a name in default language eng, using fra instead'
+    );
+  });
+
+  it('throws when no translation provides a usable name', () => {
+    expect(() =>
+      selectItemInternalName(
+        [
+          { languageId: 'eng', value: null },
+          { languageId: 'fra', value: '   ' },
+        ],
+        'eng',
+        'Object',
+        'mwnf3:objects:EPM:eg:cairo:001'
+      )
+    ).toThrow(
+      'Object mwnf3:objects:EPM:eg:cairo:001 missing required name field in all translations'
+    );
+  });
+});

--- a/scripts/importer/tests/unit/sh-item-internal-name-transformers.test.ts
+++ b/scripts/importer/tests/unit/sh-item-internal-name-transformers.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformShObject } from '../../src/domain/transformers/sh-object-transformer.js';
+import { transformShMonument } from '../../src/domain/transformers/sh-monument-transformer.js';
+import { transformShMonumentDetail } from '../../src/domain/transformers/sh-monument-detail-transformer.js';
+
+describe('SH item internal_name selection', () => {
+  it('throws for SH objects when no translation has a usable name', () => {
+    expect(() =>
+      transformShObject(
+        {
+          project_id: 'SH1',
+          country: 'eg',
+          number: '1',
+          partners_id: null,
+          working_number: null,
+          inventory_id: null,
+          start_date: null,
+          end_date: null,
+          display_status: null,
+          pd_country: null,
+          translations: [
+            { project_id: 'SH1', country: 'eg', number: '1', lang: 'en', name: null },
+            { project_id: 'SH1', country: 'eg', number: '1', lang: 'fr', name: '   ' },
+          ],
+        },
+        'eng'
+      )
+    ).toThrow('SH Object mwnf3_sharing_history:sh_objects:sh1:eg:1 missing required name field in all translations');
+  });
+
+  it('throws for SH monuments when no translation has a usable name', () => {
+    expect(() =>
+      transformShMonument(
+        {
+          project_id: 'SH1',
+          country: 'eg',
+          number: '1',
+          partners_id: null,
+          working_number: null,
+          start_date: null,
+          end_date: null,
+          display_status: null,
+          pd_country: null,
+          translations: [
+            { project_id: 'SH1', country: 'eg', number: '1', lang: 'en', name: null },
+            { project_id: 'SH1', country: 'eg', number: '1', lang: 'fr', name: '   ' },
+          ],
+        },
+        'eng'
+      )
+    ).toThrow('SH Monument mwnf3_sharing_history:sh_monuments:sh1:eg:1 missing required name field in all translations');
+  });
+
+  it('throws for SH monument details when no translation has a usable name', () => {
+    expect(() =>
+      transformShMonumentDetail(
+        {
+          project_id: 'SH1',
+          country: 'eg',
+          number: '1',
+          detail_id: '2',
+          translations: [
+            {
+              project_id: 'SH1',
+              country: 'eg',
+              number: '1',
+              detail_id: '2',
+              lang: 'en',
+              name: null,
+            },
+            {
+              project_id: 'SH1',
+              country: 'eg',
+              number: '1',
+              detail_id: '2',
+              lang: 'fr',
+              name: '   ',
+            },
+          ],
+        },
+        'eng'
+      )
+    ).toThrow(
+      'SH Monument Detail mwnf3_sharing_history:sh_monument_details:sh1:eg:1:2 missing required name field in all translations'
+    );
+  });
+});

--- a/scripts/importer/tests/unit/travels-monument-transformer.test.ts
+++ b/scripts/importer/tests/unit/travels-monument-transformer.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformTravelsMonument } from '../../src/domain/transformers/travels-monument-transformer.js';
+
+describe('transformTravelsMonument', () => {
+  it('uses the english title as internal_name instead of a technical slug', () => {
+    const result = transformTravelsMonument(
+      {
+        project_id: 'IAM',
+        country: 'pt',
+        trail_id: 1,
+        itinerary_id: 'V',
+        location_id: '1',
+        number: 'a',
+        translations: [
+          {
+            project_id: 'IAM',
+            country: 'pt',
+            trail_id: 1,
+            itinerary_id: 'V',
+            location_id: '1',
+            number: 'a',
+            lang: 'en',
+            title: 'Islamic Beja',
+          },
+          {
+            project_id: 'IAM',
+            country: 'pt',
+            trail_id: 1,
+            itinerary_id: 'V',
+            location_id: '1',
+            number: 'a',
+            lang: 'fr',
+            title: 'Beja islamique',
+          },
+        ],
+      },
+      'eng'
+    );
+
+    expect(result.data.internal_name).toBe('Islamic Beja');
+    expect(result.data.country_id).toBe('prt');
+    expect(result.warning).toBeNull();
+  });
+});

--- a/scripts/importer/tests/unit/travels-phase-07-schema.test.ts
+++ b/scripts/importer/tests/unit/travels-phase-07-schema.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const phase07Files = [
+  'travels-itinerary-importer.ts',
+  'travels-itinerary-translation-importer.ts',
+  'travels-location-importer.ts',
+  'travels-location-translation-importer.ts',
+  'travels-monument-importer.ts',
+  'travels-monument-translation-importer.ts',
+  'travels-itinerary-picture-importer.ts',
+  'travels-location-picture-importer.ts',
+  'travels-monument-picture-importer.ts',
+  'travels-trail-picture-importer.ts',
+];
+
+describe('Phase 07 Travels schema usage', () => {
+  it('queries legacy travel tables from mwnf3_travels and not mwnf3', () => {
+    for (const fileName of phase07Files) {
+      const filePath = path.resolve(
+        import.meta.dirname,
+        '../../src/importers/phase-07',
+        fileName
+      );
+      const source = readFileSync(filePath, 'utf8');
+
+      expect(source).not.toContain('FROM mwnf3.tr_');
+      expect(source).toContain('FROM mwnf3_travels.');
+    }
+  });
+});

--- a/scripts/importer/tests/unit/travels-trail-importer.test.ts
+++ b/scripts/importer/tests/unit/travels-trail-importer.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TravelsTrailImporter } from '../../src/importers/phase-07/travels-trail-importer.js';
+import { UnifiedTracker } from '../../src/core/tracker.js';
+import type { ImportContext, ILegacyDatabase, ILogger } from '../../src/core/base-importer.js';
+import type { IWriteStrategy } from '../../src/core/strategy.js';
+
+describe('TravelsTrailImporter', () => {
+  let tracker: UnifiedTracker;
+  let legacyDb: ILegacyDatabase;
+  let strategy: IWriteStrategy;
+  let context: ImportContext;
+  let queryMock: ReturnType<typeof vi.fn>;
+  let writeCollectionMock: ReturnType<typeof vi.fn>;
+
+  const logger: ILogger = {
+    info: vi.fn(),
+    warning: vi.fn(),
+    skip: vi.fn(),
+    error: vi.fn(),
+    exception: vi.fn(),
+    showProgress: vi.fn(),
+    showSkipped: vi.fn(),
+    showError: vi.fn(),
+    showSummary: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    tracker = new UnifiedTracker();
+    tracker.set('mwnf3_travels:context', 'travels-context-uuid', 'context');
+    tracker.set('mwnf3_travels:root', 'travels-root-uuid', 'collection');
+    tracker.set('pt', 'prt', 'country');
+    tracker.setMetadata('default_language_id', 'eng');
+
+    queryMock = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM mwnf3_travels.trails')) {
+        return [
+          {
+            project_id: 'IAM',
+            country: 'pt',
+            lang: 'fr',
+            number: 1,
+            title: 'Sentier francais',
+            subtitle: null,
+            description: null,
+            curated_by: null,
+            local_coordinator: null,
+            photo_by: null,
+            museum_id: null,
+            region_territory: null,
+          },
+        ];
+      }
+
+      return [];
+    });
+
+    legacyDb = {
+      query: queryMock as ILegacyDatabase['query'],
+      execute: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+
+    writeCollectionMock = vi.fn().mockResolvedValue('trail-collection-uuid');
+
+    strategy = {
+      exists: vi.fn().mockResolvedValue(false),
+      findByBackwardCompatibility: vi.fn().mockResolvedValue(null),
+      writeCollection: writeCollectionMock,
+    } as unknown as IWriteStrategy;
+
+    context = {
+      legacyDb,
+      strategy,
+      tracker,
+      logger,
+      dryRun: false,
+    };
+  });
+
+  it('uses the first named translation when english is missing and logs the fallback', async () => {
+    const importer = new TravelsTrailImporter(context);
+    const result = await importer.import();
+
+    expect(writeCollectionMock).toHaveBeenCalledWith({
+      internal_name: 'Sentier francais',
+      backward_compatibility: 'mwnf3_travels:trail:IAM:pt:1',
+      context_id: 'travels-context-uuid',
+      language_id: 'eng',
+      parent_id: 'travels-root-uuid',
+      type: 'exhibition trail',
+      latitude: null,
+      longitude: null,
+      map_zoom: null,
+      country_id: 'prt',
+    });
+    expect(logger.warning).toHaveBeenCalledWith(
+      'Travels trail mwnf3_travels:trail:IAM:pt:1 has no translation with a name in default language eng, using fra instead',
+      undefined
+    );
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(1);
+  });
+});


### PR DESCRIPTION
This branch standardizes how importer-created `internal_name` values are derived for both items and collections, and removes the remaining synthetic fallback behavior in Sharing History item transformers.

It does three things:
1. Standardizes item `internal_name` selection behind shared logic in item-internal-name-transformer.ts, then applies it to mwnf3, Explore, and Travels item importers and transformers.
2. Removes SH synthetic item-name fallbacks in sh-object-transformer.ts, sh-monument-transformer.ts, and sh-monument-detail-transformer.ts, so missing names now fail explicitly instead of inventing placeholder internal names.
3. Standardizes Explore and Travels collection `internal_name` values so user-facing collections use human-readable titles instead of technical slugs or IDs in importers such as explore-location-importer.ts and travels-trail-importer.ts.

**Commits**
1. `5f8d4f8b` Standardize importer item internal names
2. `6f1f5075` Remove SH synthetic item-name fallbacks
3. `7f429780` Standardize collection internal names

**Behavioral impact**
Items and relevant collections now select `internal_name` from translated human-readable names using the explicit rule:
1. default language first
2. first other named translation if default is unavailable
3. explicit warning on fallback
4. explicit failure if no usable name exists

This fixes cases like Travels monuments receiving technical values such as `tr_mon_IAM_pt_1_V_1_a_islamic_beja` instead of `Islamic Beja`.

**Test coverage**
Targeted regression coverage was added in:
item-internal-name-transformer.test.ts
explore-monument-transformer.test.ts
travels-monument-transformer.test.ts
sh-item-internal-name-transformers.test.ts
explore-location-importer.test.ts
travels-trail-importer.test.ts
