### PR TITLE
Fix Livewire table performance and sort validation vulnerabilities

### DIFF
--- a/app/Livewire/Tables/CollectionTranslationsTable.php
+++ b/app/Livewire/Tables/CollectionTranslationsTable.php
@@ -113,9 +113,9 @@ class CollectionTranslationsTable extends Component
 
         // Filter by context if specified
         if ($this->contextFilter === 'default') {
-            $defaultContext = Context::where('is_default', true)->first();
-            if ($defaultContext) {
-                $query->where('context_id', $defaultContext->id);
+            $defaultContextId = Context::where('is_default', true)->value('id');
+            if ($defaultContextId) {
+                $query->where('context_id', $defaultContextId);
             }
         } elseif ($this->contextFilter !== '' && $this->contextFilter !== 'all') {
             $query->where('context_id', $this->contextFilter);
@@ -123,9 +123,9 @@ class CollectionTranslationsTable extends Component
 
         // Filter by language if specified
         if ($this->languageFilter === 'default') {
-            $defaultLanguage = Language::where('is_default', true)->first();
-            if ($defaultLanguage) {
-                $query->where('language_id', $defaultLanguage->id);
+            $defaultLanguageId = Language::where('is_default', true)->value('id');
+            if ($defaultLanguageId) {
+                $query->where('language_id', $defaultLanguageId);
             }
         } elseif ($this->languageFilter !== '' && $this->languageFilter !== 'all') {
             $query->where('language_id', $this->languageFilter);
@@ -144,8 +144,8 @@ class CollectionTranslationsTable extends Component
     public function render()
     {
         $c = config('app_entities.collection_translations.colors', []);
-        $contexts = Context::orderBy('internal_name')->get();
-        $languages = Language::orderBy('internal_name')->get();
+        $contexts = Context::select('id', 'internal_name')->orderBy('internal_name')->get();
+        $languages = Language::select('id', 'internal_name')->orderBy('internal_name')->get();
 
         return view('livewire.tables.collection-translations-table', [
             'collectionTranslations' => $this->collectionTranslations,

--- a/app/Livewire/Tables/CollectionsTable.php
+++ b/app/Livewire/Tables/CollectionsTable.php
@@ -148,7 +148,11 @@ class CollectionsTable extends Component
             }
         }
 
-        return $query->orderBy($this->sortBy, $this->sortDirection)->paginate($this->perPage)->withQueryString();
+        $validSortFields = ['internal_name', 'display_order', 'created_at', 'updated_at'];
+        $sortField = in_array($this->sortBy, $validSortFields) ? $this->sortBy : 'created_at';
+        $sortDirection = in_array(strtolower($this->sortDirection), ['asc', 'desc']) ? $this->sortDirection : 'desc';
+
+        return $query->orderBy($sortField, $sortDirection)->paginate($this->perPage)->withQueryString();
     }
 
     public function render()

--- a/app/Livewire/Tables/CountriesTable.php
+++ b/app/Livewire/Tables/CountriesTable.php
@@ -90,7 +90,11 @@ class CountriesTable extends Component
             $query->where('internal_name', 'LIKE', "%{$search}%");
         }
 
-        return $query->orderBy($this->sortBy, $this->sortDirection)->paginate($this->perPage)->withQueryString();
+        $validSortFields = ['id', 'internal_name', 'created_at', 'updated_at'];
+        $sortField = in_array($this->sortBy, $validSortFields) ? $this->sortBy : 'created_at';
+        $sortDirection = in_array(strtolower($this->sortDirection), ['asc', 'desc']) ? $this->sortDirection : 'desc';
+
+        return $query->orderBy($sortField, $sortDirection)->paginate($this->perPage)->withQueryString();
     }
 
     public function render()

--- a/app/Livewire/Tables/ItemItemLinksTable.php
+++ b/app/Livewire/Tables/ItemItemLinksTable.php
@@ -79,6 +79,11 @@ class ItemItemLinksTable extends Component
 
     public function sortBy(string $field): void
     {
+        $validFields = ['created_at', 'updated_at'];
+        if (! in_array($field, $validFields)) {
+            return;
+        }
+
         if ($this->sortBy === $field) {
             $this->sortDirection = $this->sortDirection === 'asc' ? 'desc' : 'asc';
         } else {
@@ -109,9 +114,13 @@ class ItemItemLinksTable extends Component
             $query->where('context_id', $this->contextFilter);
         }
 
-        $query->orderBy($this->sortBy, $this->sortDirection);
+        $validSortFields = ['created_at', 'updated_at'];
+        $sortField = in_array($this->sortBy, $validSortFields) ? $this->sortBy : 'created_at';
+        $sortDirection = in_array(strtolower($this->sortDirection), ['asc', 'desc']) ? $this->sortDirection : 'desc';
 
-        return $query->paginate($this->perPage);
+        $query->orderBy($sortField, $sortDirection);
+
+        return $query->paginate($this->perPage)->withQueryString();
     }
 
     public function deleteLink(ItemItemLink $link): void
@@ -123,7 +132,7 @@ class ItemItemLinksTable extends Component
     {
         return view('livewire.tables.item-item-links-table', [
             'links' => $this->getItemItemLinksProperty(),
-            'contexts' => Context::orderBy('internal_name')->get(),
+            'contexts' => Context::select('id', 'internal_name')->orderBy('internal_name')->get(),
         ]);
     }
 }

--- a/app/Livewire/Tables/ItemTranslationsTable.php
+++ b/app/Livewire/Tables/ItemTranslationsTable.php
@@ -114,9 +114,9 @@ class ItemTranslationsTable extends Component
 
         // Filter by context if specified
         if ($this->contextFilter === 'default') {
-            $defaultContext = Context::where('is_default', true)->first();
-            if ($defaultContext) {
-                $query->where('context_id', $defaultContext->id);
+            $defaultContextId = Context::where('is_default', true)->value('id');
+            if ($defaultContextId) {
+                $query->where('context_id', $defaultContextId);
             }
         } elseif ($this->contextFilter !== '' && $this->contextFilter !== 'all') {
             $query->where('context_id', $this->contextFilter);
@@ -124,9 +124,9 @@ class ItemTranslationsTable extends Component
 
         // Filter by language if specified
         if ($this->languageFilter === 'default') {
-            $defaultLanguage = Language::where('is_default', true)->first();
-            if ($defaultLanguage) {
-                $query->where('language_id', $defaultLanguage->id);
+            $defaultLanguageId = Language::where('is_default', true)->value('id');
+            if ($defaultLanguageId) {
+                $query->where('language_id', $defaultLanguageId);
             }
         } elseif ($this->languageFilter !== '' && $this->languageFilter !== 'all') {
             $query->where('language_id', $this->languageFilter);
@@ -145,8 +145,8 @@ class ItemTranslationsTable extends Component
     public function render()
     {
         $c = config('app_entities.item_translations.colors', []);
-        $contexts = Context::orderBy('internal_name')->get();
-        $languages = Language::orderBy('internal_name')->get();
+        $contexts = Context::select('id', 'internal_name')->orderBy('internal_name')->get();
+        $languages = Language::select('id', 'internal_name')->orderBy('internal_name')->get();
 
         return view('livewire.tables.item-translations-table', [
             'itemTranslations' => $this->itemTranslations,

--- a/app/Livewire/Tables/ItemsTable.php
+++ b/app/Livewire/Tables/ItemsTable.php
@@ -201,7 +201,11 @@ class ItemsTable extends Component
             }
         }
 
-        return $query->orderBy($this->sortBy, $this->sortDirection)->paginate($this->perPage)->withQueryString();
+        $validSortFields = ['internal_name', 'created_at', 'updated_at'];
+        $sortField = in_array($this->sortBy, $validSortFields) ? $this->sortBy : 'created_at';
+        $sortDirection = in_array(strtolower($this->sortDirection), ['asc', 'desc']) ? $this->sortDirection : 'desc';
+
+        return $query->orderBy($sortField, $sortDirection)->paginate($this->perPage)->withQueryString();
     }
 
     public function getAvailableTagsProperty()

--- a/app/Livewire/Tables/ItemsTable.php
+++ b/app/Livewire/Tables/ItemsTable.php
@@ -206,7 +206,9 @@ class ItemsTable extends Component
 
     public function getAvailableTagsProperty()
     {
-        return Tag::orderBy('internal_name')->get();
+        return Tag::select('id', 'internal_name', 'description')
+            ->orderBy('internal_name')
+            ->get();
     }
 
     public function render()

--- a/app/Livewire/Tables/LanguagesTable.php
+++ b/app/Livewire/Tables/LanguagesTable.php
@@ -90,7 +90,11 @@ class LanguagesTable extends Component
             $query->where('internal_name', 'LIKE', "%{$search}%");
         }
 
-        return $query->orderBy($this->sortBy, $this->sortDirection)->paginate($this->perPage)->withQueryString();
+        $validSortFields = ['id', 'internal_name', 'created_at', 'updated_at'];
+        $sortField = in_array($this->sortBy, $validSortFields) ? $this->sortBy : 'created_at';
+        $sortDirection = in_array(strtolower($this->sortDirection), ['asc', 'desc']) ? $this->sortDirection : 'desc';
+
+        return $query->orderBy($sortField, $sortDirection)->paginate($this->perPage)->withQueryString();
     }
 
     public function render()

--- a/app/Livewire/Tables/PartnerTranslationsTable.php
+++ b/app/Livewire/Tables/PartnerTranslationsTable.php
@@ -114,9 +114,9 @@ class PartnerTranslationsTable extends Component
 
         // Filter by context if specified
         if ($this->contextFilter === 'default') {
-            $defaultContext = Context::where('is_default', true)->first();
-            if ($defaultContext) {
-                $query->where('context_id', $defaultContext->id);
+            $defaultContextId = Context::where('is_default', true)->value('id');
+            if ($defaultContextId) {
+                $query->where('context_id', $defaultContextId);
             }
         } elseif ($this->contextFilter !== '' && $this->contextFilter !== 'all') {
             $query->where('context_id', $this->contextFilter);
@@ -124,9 +124,9 @@ class PartnerTranslationsTable extends Component
 
         // Filter by language if specified
         if ($this->languageFilter === 'default') {
-            $defaultLanguage = Language::where('is_default', true)->first();
-            if ($defaultLanguage) {
-                $query->where('language_id', $defaultLanguage->id);
+            $defaultLanguageId = Language::where('is_default', true)->value('id');
+            if ($defaultLanguageId) {
+                $query->where('language_id', $defaultLanguageId);
             }
         } elseif ($this->languageFilter !== '' && $this->languageFilter !== 'all') {
             $query->where('language_id', $this->languageFilter);
@@ -145,8 +145,8 @@ class PartnerTranslationsTable extends Component
     public function render()
     {
         $c = config('app_entities.partner_translations.colors', []);
-        $contexts = Context::orderBy('internal_name')->get();
-        $languages = Language::orderBy('internal_name')->get();
+        $contexts = Context::select('id', 'internal_name')->orderBy('internal_name')->get();
+        $languages = Language::select('id', 'internal_name')->orderBy('internal_name')->get();
 
         return view('livewire.tables.partner-translations-table', [
             'partnerTranslations' => $this->partnerTranslations,

--- a/app/Livewire/Tables/PartnersTable.php
+++ b/app/Livewire/Tables/PartnersTable.php
@@ -98,12 +98,11 @@ class PartnersTable extends Component
             $query->where('internal_name', 'LIKE', "%{$search}%");
         }
 
-        return $query->orderBy($this->sortBy, $this->sortDirection)->paginate($this->perPage)->withQueryString();
-    }
+        $validSortFields = ['internal_name', 'created_at', 'updated_at'];
+        $sortField = in_array($this->sortBy, $validSortFields) ? $this->sortBy : 'created_at';
+        $sortDirection = in_array(strtolower($this->sortDirection), ['asc', 'desc']) ? $this->sortDirection : 'desc';
 
-    public function render()
-    {
-        $c = config('app_entities.partners.colors', []);
+        return $query->orderBy($sortField, $sortDirection)->paginate($this->perPage)->withQueryString();
 
         return view('livewire.tables.partners-table', [
             'partners' => $this->partners,

--- a/app/Livewire/Tables/PartnersTable.php
+++ b/app/Livewire/Tables/PartnersTable.php
@@ -103,6 +103,11 @@ class PartnersTable extends Component
         $sortDirection = in_array(strtolower($this->sortDirection), ['asc', 'desc']) ? $this->sortDirection : 'desc';
 
         return $query->orderBy($sortField, $sortDirection)->paginate($this->perPage)->withQueryString();
+    }
+
+    public function render()
+    {
+        $c = config('app_entities.partners.colors', []);
 
         return view('livewire.tables.partners-table', [
             'partners' => $this->partners,

--- a/database/migrations/2026_04_20_000001_add_performance_indexes_to_items_and_item_tag.php
+++ b/database/migrations/2026_04_20_000001_add_performance_indexes_to_items_and_item_tag.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->index('internal_name');
+            $table->index('type');
+            $table->index('created_at');
+            $table->index('updated_at');
+            $table->index(['parent_id', 'type', 'created_at']);
+        });
+
+        Schema::table('item_tag', function (Blueprint $table) {
+            $table->index(['tag_id', 'item_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->dropIndex(['internal_name']);
+            $table->dropIndex(['type']);
+            $table->dropIndex(['created_at']);
+            $table->dropIndex(['updated_at']);
+            $table->dropIndex(['parent_id', 'type', 'created_at']);
+        });
+
+        Schema::table('item_tag', function (Blueprint $table) {
+            $table->dropIndex(['tag_id', 'item_id']);
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "inventory-app",
-    "version": "6.12.8",
+    "version": "6.12.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "inventory-app",
-            "version": "6.12.8",
+            "version": "6.12.9",
             "dependencies": {
                 "glob": "^13.0.6"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "inventory-app",
-    "version": "6.12.8",
+    "version": "6.12.9",
     "private": true,
     "type": "module",
     "scripts": {

--- a/resources/views/components/form/multiselect.blade.php
+++ b/resources/views/components/form/multiselect.blade.php
@@ -17,13 +17,23 @@
     $chipText = "text-{$chipColor}-800";
     $chipHover = "hover:text-{$chipColor}-900";
     $chipHoverBg = "hover:bg-{$chipColor}-50";
+
+    // Project options to minimal arrays to avoid serializing full Eloquent models
+    $fields = array_filter(['id', $displayField, $descriptionField]);
+    $jsOptions = collect($options)->map(function ($opt) use ($fields) {
+        $row = [];
+        foreach ($fields as $f) {
+            $row[$f] = is_object($opt) ? ($opt->{$f} ?? '') : ($opt[$f] ?? '');
+        }
+        return $row;
+    })->values();
 @endphp
 
 <div 
     x-data="{ 
         open: false, 
         search: '', 
-        options: @js($options),
+        options: @js($jsOptions),
         selectedIds: @entangle($wireModel).live,
         get filteredOptions() {
             if (this.search === '') return this.options;

--- a/resources/views/livewire/searchable-select.blade.php
+++ b/resources/views/livewire/searchable-select.blade.php
@@ -7,9 +7,9 @@
         <input 
             type="text"
             wire:model.live.debounce.300ms="search"
-            wire:focus="$set('open', true)"
-            @click.away="$set('open', false); $set('search', '')"
-            @keydown.escape="$set('open', false); $set('search', '')"
+            @focus="$wire.set('open', true)"
+            @click.away="$wire.set('open', false); $wire.set('search', '')"
+            @keydown.escape="$wire.set('open', false); $wire.set('search', '')"
             placeholder="{{ $selectedOption ? $selectedOption->{$displayField} : $searchPlaceholder }}"
             class="block w-full rounded-md border-gray-300 shadow-sm {{ $focusClasses }} sm:text-sm pr-10"
             autocomplete="off"

--- a/tests/Web/Livewire/CollectionsTableTest.php
+++ b/tests/Web/Livewire/CollectionsTableTest.php
@@ -158,4 +158,31 @@ class CollectionsTableTest extends TestCase
             ->assertSee('Parent')
             ->assertSee('All Collections');
     }
+
+    public function test_invalid_sort_field_falls_back_to_default(): void
+    {
+        Collection::factory()->create(['internal_name' => 'Test Collection']);
+
+        Livewire::test(CollectionsTable::class)
+            ->set('sortBy', 'nonexistent_column')
+            ->call('toggleHierarchyMode')
+            ->assertOk();
+    }
+
+    public function test_sort_by_rejects_invalid_field(): void
+    {
+        Livewire::test(CollectionsTable::class)
+            ->call('sortBy', 'nonexistent_column')
+            ->assertSet('sortBy', 'created_at');
+    }
+
+    public function test_invalid_sort_direction_falls_back_to_desc(): void
+    {
+        Collection::factory()->create(['internal_name' => 'Test Collection']);
+
+        Livewire::test(CollectionsTable::class)
+            ->set('sortDirection', 'sideways')
+            ->call('toggleHierarchyMode')
+            ->assertOk();
+    }
 }

--- a/tests/Web/Livewire/ItemItemLinksTableTest.php
+++ b/tests/Web/Livewire/ItemItemLinksTableTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Web\Livewire;
+
+use App\Livewire\Tables\ItemItemLinksTable;
+use App\Models\Item;
+use App\Models\ItemItemLink;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+use Tests\Web\Traits\AuthenticatesWebRequests;
+
+class ItemItemLinksTableTest extends TestCase
+{
+    use AuthenticatesWebRequests;
+    use RefreshDatabase;
+
+    public function test_component_can_render(): void
+    {
+        Livewire::test(ItemItemLinksTable::class)->assertOk();
+    }
+
+    public function test_component_renders_with_item_scope(): void
+    {
+        $item = Item::factory()->create();
+
+        Livewire::test(ItemItemLinksTable::class, ['item' => $item])
+            ->assertOk();
+    }
+
+    public function test_invalid_sort_field_falls_back_to_default(): void
+    {
+        $link = ItemItemLink::factory()->create();
+
+        Livewire::test(ItemItemLinksTable::class, ['item' => $link->source])
+            ->set('sortBy', 'nonexistent_column')
+            ->assertOk();
+    }
+
+    public function test_sort_by_rejects_invalid_field(): void
+    {
+        Livewire::test(ItemItemLinksTable::class)
+            ->call('sortBy', 'nonexistent_column')
+            ->assertSet('sortBy', 'created_at');
+    }
+
+    public function test_sort_by_accepts_valid_field(): void
+    {
+        Livewire::test(ItemItemLinksTable::class)
+            ->call('sortBy', 'updated_at')
+            ->assertSet('sortBy', 'updated_at')
+            ->assertSet('sortDirection', 'asc');
+    }
+
+    public function test_invalid_sort_direction_falls_back_to_desc(): void
+    {
+        $link = ItemItemLink::factory()->create();
+
+        Livewire::test(ItemItemLinksTable::class, ['item' => $link->source])
+            ->set('sortDirection', 'sideways')
+            ->assertOk();
+    }
+
+    public function test_context_filter_works(): void
+    {
+        $link = ItemItemLink::factory()->create();
+        $otherLink = ItemItemLink::factory()->create();
+
+        Livewire::test(ItemItemLinksTable::class)
+            ->set('contextFilter', $link->context_id)
+            ->assertSee($link->target->internal_name)
+            ->assertDontSee($otherLink->target->internal_name);
+    }
+
+    public function test_search_filters_by_target_name(): void
+    {
+        $source = Item::factory()->create();
+        $target1 = Item::factory()->create(['internal_name' => 'Alpha Target']);
+        $target2 = Item::factory()->create(['internal_name' => 'Beta Target']);
+        ItemItemLink::factory()->create(['source_id' => $source->id, 'target_id' => $target1->id]);
+        ItemItemLink::factory()->create(['source_id' => $source->id, 'target_id' => $target2->id]);
+
+        Livewire::test(ItemItemLinksTable::class, ['item' => $source])
+            ->set('q', 'Alpha')
+            ->assertSee('Alpha Target')
+            ->assertDontSee('Beta Target');
+    }
+}

--- a/tests/Web/Livewire/ItemsTableTest.php
+++ b/tests/Web/Livewire/ItemsTableTest.php
@@ -173,4 +173,45 @@ class ItemsTableTest extends TestCase
             ->assertSee('Parent')
             ->assertSee('All Items');
     }
+
+    public function test_invalid_sort_field_falls_back_to_default(): void
+    {
+        Item::factory()->create(['internal_name' => 'Test Item']);
+
+        Livewire::test(ItemsTable::class)
+            ->set('sortBy', 'nonexistent_column')
+            ->call('toggleHierarchyMode')
+            ->assertOk();
+    }
+
+    public function test_sort_by_rejects_invalid_field(): void
+    {
+        Livewire::test(ItemsTable::class)
+            ->call('sortBy', 'nonexistent_column')
+            ->assertSet('sortBy', 'created_at');
+    }
+
+    public function test_invalid_sort_direction_falls_back_to_desc(): void
+    {
+        Item::factory()->create(['internal_name' => 'Test Item']);
+
+        Livewire::test(ItemsTable::class)
+            ->set('sortDirection', 'sideways')
+            ->call('toggleHierarchyMode')
+            ->assertOk();
+    }
+
+    public function test_available_tags_only_contain_needed_fields(): void
+    {
+        Tag::factory()->create(['internal_name' => 'TestTag', 'description' => 'A tag']);
+
+        $component = Livewire::test(ItemsTable::class);
+        $tags = $component->get('availableTags');
+
+        $this->assertCount(1, $tags);
+        $tag = $tags->first();
+        $this->assertEquals('TestTag', $tag->internal_name);
+        $this->assertEquals('A tag', $tag->description);
+        $this->assertNotNull($tag->id);
+    }
 }


### PR DESCRIPTION
## Summary

Fix performance bottlenecks and security issues in Livewire table components without changing the architecture.

## Changes

### Performance
- **Multiselect payload bloat**: The `@js($options)` in `multiselect.blade.php` was serializing full Eloquent models (all attributes) into inline JavaScript. Now projects options to minimal `{id, displayField, descriptionField}` arrays. `ItemsTable` also selects only `id, internal_name, description` from the tags table.
- **Translation table query optimization**: Replaced `Context::where(...)->first()->id` with `->value('id')` to avoid hydrating full models just to get an ID. Dropdown data now selects only `id, internal_name`.
- **Database indexes**: Added indexes on `items(internal_name, type, created_at, updated_at)`, composite `items(parent_id, type, created_at)`, and reverse lookup `item_tag(tag_id, item_id)`.

### Bug Fixes
- **SearchableSelect Alpine v3 incompatibility**: Replaced Alpine v2 `$set()` (removed in v3) with Livewire 3 `$wire.set()` for open/close and search state management.
- **Sort field validation**: Added `in_array()` validation in the query property getters of all table components that lacked it: `ItemsTable`, `CollectionsTable`, `PartnersTable`, `LanguagesTable`, `CountriesTable`, `ItemItemLinksTable`. Previously these passed user-controlled `sortBy` query string values directly into `orderBy()`.

### Tests
- New `ItemItemLinksTableTest` (8 tests): render, sort validation, context filter, search
- Extended `ItemsTableTest` (+4 tests): invalid sort field/direction fallback, tag payload fields
- Extended `CollectionsTableTest` (+3 tests): invalid sort field/direction fallback

## Files Changed
- `app/Livewire/Tables/` — 9 table components
- `resources/views/components/form/multiselect.blade.php`
- `resources/views/livewire/searchable-select.blade.php`
- `database/migrations/2026_04_20_000001_add_performance_indexes_to_items_and_item_tag.php`
- `tests/Web/Livewire/` — 3 test files (1 new, 2 extended)

## Validation
- All 1537 backend tests pass (872 Unit+Api, 665 Web)
- Lint clean (Pint)