### PR TITLE
Fix standalone timeline image imports

### DIFF
--- a/scripts/importer/package-lock.json
+++ b/scripts/importer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "importer",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "importer",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dependencies": {
         "@types/turndown": "^5.0.6",
         "axios": "^1.15.0",

--- a/scripts/importer/package.json
+++ b/scripts/importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "importer",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "type": "module",
   "description": "Unified legacy database import utility for Inventory Management System",

--- a/scripts/importer/src/importers/phase-05/timeline-importer.ts
+++ b/scripts/importer/src/importers/phase-05/timeline-importer.ts
@@ -45,6 +45,14 @@ import type {
 } from '../../domain/types/index.js';
 import { mapCountryCode } from '../../utils/code-mappings.js';
 
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
 export class TimelineImporter extends BaseImporter {
   getName(): string {
     return 'TimelineImporter';
@@ -568,17 +576,27 @@ export class TimelineImporter extends BaseImporter {
           result.imported++;
           this.showProgress();
         } else {
-          // Standalone image → TimelineEventImage
-          // These are files like custom/sharinghistory/*.jpg
-          // They need to go through AvailableImage pipeline
-          // For now, we skip physical file copy (requires presence of files)
-          // and just create the TimelineEventImage record if the file info can be determined
+          const imgTexts = textsByImgId.get(img.hcr_img_id);
+          const altText = await this.getStandaloneImageAltTextAsync(imgTexts);
 
-          this.logInfo(
-            `Standalone image hcr_img_id=${img.hcr_img_id}, picture=${img.picture} — skipping (requires physical file import via AvailableImage pipeline)`
-          );
-          result.skipped++;
-          this.showSkipped();
+          if (this.isDryRun || this.isSampleOnlyMode) {
+            result.imported++;
+            this.showProgress();
+            continue;
+          }
+
+          await this.context.strategy.writeTimelineEventImage({
+            timeline_event_id: eventId,
+            path: img.picture,
+            original_name: this.getOriginalName(img.picture),
+            mime_type: this.getMimeType(img.picture),
+            size: 1,
+            alt_text: altText,
+            display_order: img.sort_order,
+          });
+
+          result.imported++;
+          this.showProgress();
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -589,6 +607,69 @@ export class TimelineImporter extends BaseImporter {
     }
 
     return result;
+  }
+
+  private getOriginalName(filePath: string): string {
+    const segments = filePath.split('/');
+    return segments.at(-1) || filePath;
+  }
+
+  private getMimeType(filePath: string): string {
+    const normalizedPath = filePath.toLowerCase();
+    const extension = Object.keys(IMAGE_MIME_TYPES).find((ext) => normalizedPath.endsWith(ext));
+
+    return extension ? IMAGE_MIME_TYPES[extension] : 'image/jpeg';
+  }
+
+  private async getStandaloneImageAltTextAsync(
+    imgTexts: Map<string, ShLegacyHcrImageText> | undefined
+  ): Promise<string | null> {
+    if (!imgTexts || imgTexts.size === 0) {
+      return null;
+    }
+
+    const defaultLanguageId = await this.getDefaultLanguageIdAsync();
+    let fallback: string | null = null;
+
+    for (const [legacyLang, txt] of imgTexts) {
+      const candidate = this.getStandaloneImageAltTextCandidate(txt);
+      if (!candidate) {
+        continue;
+      }
+
+      fallback ??= candidate;
+
+      const languageId = await this.getLanguageIdByLegacyCodeAsync(legacyLang);
+      if (languageId === defaultLanguageId) {
+        return candidate;
+      }
+    }
+
+    return fallback;
+  }
+
+  private getStandaloneImageAltTextCandidate(txt: ShLegacyHcrImageText): string | null {
+    const candidates = [
+      txt.name,
+      txt.sname,
+      txt.name_detail,
+      txt.detail_justification,
+      txt.museum,
+      txt.location,
+      txt.artist,
+      txt.material,
+      txt.date,
+      txt.dynasty,
+    ];
+
+    for (const candidate of candidates) {
+      const trimmed = candidate.trim();
+      if (trimmed !== '') {
+        return trimmed;
+      }
+    }
+
+    return null;
   }
 
   // ===========================================================================

--- a/scripts/importer/src/strategies/sql-strategy.ts
+++ b/scripts/importer/src/strategies/sql-strategy.ts
@@ -1104,6 +1104,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
         this.now,
       ]
     );
+    this.tracker.set(data.path.toLowerCase(), id, 'image');
     return id;
   }
 

--- a/scripts/importer/src/tools/image-sync.ts
+++ b/scripts/importer/src/tools/image-sync.ts
@@ -3,7 +3,8 @@
  *
  * Synchronizes legacy images to new storage by:
  * 1. Finding records with size=1 (legacy placeholder) in item_images,
- *    partner_images, partner_logos, collection_images, contributor_images
+ *    partner_images, partner_logos, collection_images, contributor_images,
+ *    timeline_event_images
  * 2. Copying or symlinking the actual image file from legacy storage
  * 3. Updating the database record with correct path, size, and metadata
  *
@@ -95,6 +96,7 @@ export class ImageSyncTool {
         'partner_logos',
         'collection_images',
         'contributor_images',
+        'timeline_event_images',
       ];
 
       for (const table of tables) {

--- a/scripts/importer/tests/unit/image-sync.test.ts
+++ b/scripts/importer/tests/unit/image-sync.test.ts
@@ -183,4 +183,22 @@ describe('ImageSyncTool destination clearing', () => {
     await expect(fs.access(oldFile)).resolves.toBeUndefined();
     expect(logger.messages).toContain(`[DRY-RUN] Would clear destination directory: ${newRoot}`);
   });
+
+  it('includes timeline_event_images in the sync table list', async () => {
+    const db = new FakeConnection([]) as unknown as Connection;
+    const logger = new FakeLogger();
+
+    const tool = new ImageSyncTool(
+      db,
+      createOptions({
+        dryRun: true,
+      }),
+      logger
+    );
+
+    const result = await tool.run();
+
+    expect(result.success).toBe(true);
+    expect(logger.messages).toContain('\n=== Syncing timeline_event_images ===');
+  });
 });

--- a/scripts/importer/tests/unit/timeline-importer.test.ts
+++ b/scripts/importer/tests/unit/timeline-importer.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TimelineImporter } from '../../src/importers/phase-05/timeline-importer.js';
+import { UnifiedTracker } from '../../src/core/tracker.js';
+import type { ImportContext, ILegacyDatabase, ILogger } from '../../src/core/base-importer.js';
+import type { IWriteStrategy } from '../../src/core/strategy.js';
+import type { ShLegacyHcrImage, ShLegacyHcrImageText } from '../../src/domain/types/index.js';
+
+describe('TimelineImporter', () => {
+  let tracker: UnifiedTracker;
+  let legacyDb: ILegacyDatabase;
+  let strategy: IWriteStrategy;
+  let context: ImportContext;
+  let imageRows: ShLegacyHcrImage[];
+  let imageTextRows: ShLegacyHcrImageText[];
+
+  const logger: ILogger = {
+    info: vi.fn(),
+    warning: vi.fn(),
+    skip: vi.fn(),
+    error: vi.fn(),
+    exception: vi.fn(),
+    showProgress: vi.fn(),
+    showSkipped: vi.fn(),
+    showError: vi.fn(),
+    showSummary: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    tracker = new UnifiedTracker();
+    tracker.setMetadata('default_language_id', 'eng');
+    tracker.set('en', 'eng', 'language');
+    tracker.set('fr', 'fra', 'language');
+    tracker.set('mwnf3_sharing_history:sh_hcr:101', 'timeline-event-uuid', 'timeline_event');
+
+    imageRows = [
+      {
+        hcr_img_id: 495,
+        hcr_id: 101,
+        ref_item: '',
+        item_type: 'obj',
+        picture: 'custom/sharinghistory/14.jpg',
+        sort_order: 7,
+      },
+    ];
+
+    imageTextRows = [];
+
+    legacyDb = {
+      query: vi.fn(async (sql: string) => {
+        if (sql.includes('FROM mwnf3.hcr_events')) {
+          return [];
+        }
+
+        if (sql.includes('FROM mwnf3.hcr ORDER BY')) {
+          return [];
+        }
+
+        if (sql.includes('FROM mwnf3_sharing_history.sh_hcr_events')) {
+          return [];
+        }
+
+        if (sql.includes('FROM mwnf3_sharing_history.sh_hcr ORDER BY')) {
+          return [];
+        }
+
+        if (sql.includes('FROM mwnf3_sharing_history.sh_hcr_images')) {
+          return imageRows;
+        }
+
+        if (sql.includes('FROM mwnf3_sharing_history.sh_hcr_image_texts')) {
+          return imageTextRows;
+        }
+
+        if (sql.includes('FROM mwnf3_sharing_history.rel_sh_bibliography_hcr_country')) {
+          return [];
+        }
+
+        return [];
+      }) as ILegacyDatabase['query'],
+      execute: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+
+    strategy = {
+      writeTimelineEventImage: vi.fn().mockResolvedValue('timeline-image-uuid'),
+      writeTimelineEventItem: vi.fn().mockResolvedValue(undefined),
+      exists: vi.fn().mockResolvedValue(false),
+      findByBackwardCompatibility: vi.fn().mockResolvedValue(null),
+      updateTimelineExtra: vi.fn().mockResolvedValue(undefined),
+    } as unknown as IWriteStrategy;
+
+    context = {
+      legacyDb,
+      strategy,
+      tracker,
+      logger,
+      dryRun: false,
+    };
+  });
+
+  it('writes standalone timeline event images with default-language alt text', async () => {
+    imageTextRows = [
+      {
+        hcr_img_id: 495,
+        lang: 'fr',
+        name: 'Legende francaise',
+        sname: '',
+        name_detail: '',
+        detail_justification: '',
+        date: '',
+        dynasty: '',
+        museum: '',
+        location: '',
+        artist: '',
+        material: '',
+      },
+      {
+        hcr_img_id: 495,
+        lang: 'en',
+        name: 'English caption',
+        sname: '',
+        name_detail: '',
+        detail_justification: '',
+        date: '',
+        dynasty: '',
+        museum: '',
+        location: '',
+        artist: '',
+        material: '',
+      },
+    ];
+
+    const importer = new TimelineImporter(context);
+    const result = await importer.import();
+
+    expect(strategy.writeTimelineEventImage).toHaveBeenCalledWith({
+      timeline_event_id: 'timeline-event-uuid',
+      path: 'custom/sharinghistory/14.jpg',
+      original_name: '14.jpg',
+      mime_type: 'image/jpeg',
+      size: 1,
+      alt_text: 'English caption',
+      display_order: 7,
+    });
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('falls back to the first non-empty standalone image text when default language is absent', async () => {
+    imageTextRows = [
+      {
+        hcr_img_id: 495,
+        lang: 'fr',
+        name: '',
+        sname: '',
+        name_detail: '',
+        detail_justification: '',
+        date: '',
+        dynasty: '',
+        museum: 'Musee du test',
+        location: '',
+        artist: '',
+        material: '',
+      },
+    ];
+
+    const importer = new TimelineImporter(context);
+    await importer.import();
+
+    expect(strategy.writeTimelineEventImage).toHaveBeenCalledWith(
+      expect.objectContaining({ alt_text: 'Musee du test' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- import standalone Sharing History HCR timeline images instead of skipping them
- derive basic `alt_text` from image text rows, preferring the default language when available
- include `timeline_event_images` in the importer image-sync pipeline and track written timeline images like other placeholder image records
- add focused unit coverage for the new timeline importer behavior and image-sync table coverage
- keep the importer package version bump on this branch

## Validation
- `npm test -- tests/unit/timeline-importer.test.ts tests/unit/image-sync.test.ts` in `scripts/importer/`
- `npm run type-check` in `scripts/importer/`
- `npx eslint src/importers/phase-05/timeline-importer.ts src/strategies/sql-strategy.ts src/tools/image-sync.ts tests/unit/timeline-importer.test.ts tests/unit/image-sync.test.ts` in `scripts/importer/`