### PR TITLE
Fix importer parsing for explore 'author'

### DIFF
--- a/scripts/importer/package-lock.json
+++ b/scripts/importer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "importer",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "importer",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dependencies": {
         "@types/turndown": "^5.0.6",
         "axios": "^1.15.0",

--- a/scripts/importer/package.json
+++ b/scripts/importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "importer",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "type": "module",
   "description": "Unified legacy database import utility for Inventory Management System",

--- a/scripts/importer/src/helpers/author-helper.ts
+++ b/scripts/importer/src/helpers/author-helper.ts
@@ -17,6 +17,7 @@ import type { IWriteStrategy } from '../core/strategy.js';
 import type { ITracker } from '../core/tracker.js';
 import type { ILogger } from '../core/base-importer.js';
 import type { AuthorData } from '../core/types.js';
+import { sanitizeAllStrings } from '../utils/html-to-markdown.js';
 
 export class AuthorHelper {
   private strategy: IWriteStrategy;
@@ -25,6 +26,10 @@ export class AuthorHelper {
   constructor(strategy: IWriteStrategy, _tracker: ITracker, logger: ILogger) {
     this.strategy = strategy;
     this.logger = logger;
+  }
+
+  private normalizeName(name: string): string {
+    return sanitizeAllStrings({ name }).name.trim();
   }
 
   /**
@@ -40,17 +45,21 @@ export class AuthorHelper {
     }
 
     const trimmedName = name.trim();
+    const normalizedName = this.normalizeName(trimmedName);
+    if (normalizedName === '') {
+      return null;
+    }
 
     // Look up by name — may find an author already created by AuthorImporter
-    const existing = await this.strategy.findAuthorByName(trimmedName);
+    const existing = await this.strategy.findAuthorByName(normalizedName);
     if (existing) {
       return existing;
     }
 
     // Create new author without backward_compatibility (no legacy ID available)
     const authorData: AuthorData = {
-      name: trimmedName,
-      internal_name: trimmedName,
+      name: normalizedName,
+      internal_name: normalizedName,
       backward_compatibility: '',
     };
 
@@ -62,7 +71,7 @@ export class AuthorHelper {
         `Author write failed for '${trimmedName}': ${message}, retrying name lookup`
       );
       // Retry: another thread/record may have created the same author concurrently
-      const retryResult = await this.strategy.findAuthorByName(trimmedName);
+      const retryResult = await this.strategy.findAuthorByName(normalizedName);
       if (!retryResult) {
         this.logger.warning(`Author retry lookup also failed for '${trimmedName}' — entity lost`);
       }

--- a/scripts/importer/src/helpers/explore-prepared-by-parser.ts
+++ b/scripts/importer/src/helpers/explore-prepared-by-parser.ts
@@ -1,0 +1,131 @@
+export interface ParsedExplorePreparedBy {
+  authorName: string | null;
+  textCopyEditorName: string | null;
+  translatorName: string | null;
+  translationCopyEditorName: string | null;
+  preserveRawInExtra: boolean;
+}
+
+const STRUCTURED_PATTERN =
+  /<\s*br\s*\/?\s*>|author\s*:|copy-?editor|copyeditor|translat(?:or|ion)\s*:|sulla base di materiale fornito da|©|museum with no frontiers|museo senza frontiere/i;
+const LINE_BREAK_PATTERN = /<\s*br\s*\/?\s*>/gi;
+const INLINE_ROLE_PATTERN = /\s+(?=(Author|Copy-?editor|Copyeditor|Translat(?:or|ion))\s*:)/gi;
+const AUTHOR_PATTERN = /^author\s*:\s*(.+)$/i;
+const COPY_EDITOR_PATTERN = /^copy-?editor(?:\s*\(([^)]+)\))?\s*:\s*(.+)$/i;
+const TRANSLATOR_PATTERN = /^translat(?:or|ion)\s*:\s*(.+)$/i;
+const ATTRIBUTION_PATTERN = /sulla base di materiale fornito da\s*:\s*(.+)?$/i;
+const COPYRIGHT_PATTERN = /(©|museum with no frontiers|mwnf|museo senza frontiere)/i;
+
+function normalizePreparedBy(value: string): string {
+  return value
+    .replace(/\r/g, '')
+    .replace(LINE_BREAK_PATTERN, '\n')
+    .replace(INLINE_ROLE_PATTERN, '\n')
+    .replace(/\n{2,}/g, '\n')
+    .trim();
+}
+
+function stripCopyright(value: string): string {
+  return value.replace(/\s*©.*$/i, '').trim();
+}
+
+function cleanNameCandidate(value: string, splitOnComma: boolean): string | null {
+  const withoutCopyright = stripCopyright(value);
+  const firstSegment = withoutCopyright.split(';')[0]?.trim() ?? '';
+  const primarySegment = splitOnComma ? (firstSegment.split(',')[0]?.trim() ?? '') : firstSegment;
+  const normalized = primarySegment.replace(/\s+/g, ' ').trim();
+  const cleaned = normalized.replace(/[;:,.]+$/g, '').trim();
+
+  return cleaned !== '' ? cleaned : null;
+}
+
+function isEnglishCopyEditor(roleHint: string | undefined): boolean {
+  return roleHint ? /\benglish\b/i.test(roleHint) : false;
+}
+
+export function parseExplorePreparedBy(
+  rawPreparedBy: string | null | undefined
+): ParsedExplorePreparedBy | null {
+  if (!rawPreparedBy) {
+    return null;
+  }
+
+  const trimmed = rawPreparedBy.trim();
+  if (trimmed === '' || !STRUCTURED_PATTERN.test(trimmed)) {
+    return null;
+  }
+
+  const parsed: ParsedExplorePreparedBy = {
+    authorName: null,
+    textCopyEditorName: null,
+    translatorName: null,
+    translationCopyEditorName: null,
+    preserveRawInExtra: true,
+  };
+
+  const lines = normalizePreparedBy(trimmed)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '');
+
+  for (const line of lines) {
+    const authorMatch = line.match(AUTHOR_PATTERN);
+    if (authorMatch?.[1] && !parsed.authorName) {
+      parsed.authorName = cleanNameCandidate(authorMatch[1], false);
+      continue;
+    }
+
+    const copyEditorMatch = line.match(COPY_EDITOR_PATTERN);
+    if (copyEditorMatch?.[2]) {
+      const candidate = cleanNameCandidate(copyEditorMatch[2], false);
+      if (!candidate) {
+        continue;
+      }
+
+      if (isEnglishCopyEditor(copyEditorMatch[1])) {
+        parsed.translationCopyEditorName ??= candidate;
+      } else {
+        parsed.textCopyEditorName ??= candidate;
+      }
+      continue;
+    }
+
+    const translatorMatch = line.match(TRANSLATOR_PATTERN);
+    if (translatorMatch?.[1] && !parsed.translatorName) {
+      parsed.translatorName = cleanNameCandidate(translatorMatch[1], false);
+      continue;
+    }
+
+    const attributionMatch = line.match(ATTRIBUTION_PATTERN);
+    if (attributionMatch && !parsed.authorName) {
+      const inlineCandidate = attributionMatch[1]
+        ? cleanNameCandidate(attributionMatch[1], true)
+        : null;
+
+      if (inlineCandidate) {
+        parsed.authorName = inlineCandidate;
+      }
+      continue;
+    }
+
+    if (COPYRIGHT_PATTERN.test(line)) {
+      const candidate = cleanNameCandidate(line, true);
+      if (!parsed.authorName && candidate) {
+        parsed.authorName = candidate;
+      }
+      continue;
+    }
+
+    if (!parsed.authorName) {
+      parsed.authorName = cleanNameCandidate(line, false);
+    }
+  }
+
+  const hasResolvedRole =
+    parsed.authorName ||
+    parsed.textCopyEditorName ||
+    parsed.translatorName ||
+    parsed.translationCopyEditorName;
+
+  return hasResolvedRole ? parsed : null;
+}

--- a/scripts/importer/src/importers/phase-06/explore-monument-translation-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-monument-translation-importer.ts
@@ -24,6 +24,7 @@
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
 import { AuthorHelper } from '../../helpers/author-helper.js';
+import { parseExplorePreparedBy } from '../../helpers/explore-prepared-by-parser.js';
 
 interface LegacyMonumentText {
   monumentId: number;
@@ -158,14 +159,39 @@ export class ExploreMonumentTranslationImporter extends BaseImporter {
             continue;
           }
 
-          // Resolve author
+          const parsedPreparedBy = parseExplorePreparedBy(text.prepared_by);
+          const authorName = parsedPreparedBy?.authorName ?? text.prepared_by?.trim() ?? null;
+
+          // Resolve author roles
           let authorId: string | null = null;
-          if (text.prepared_by && text.prepared_by.trim()) {
-            authorId = await this.authorHelper.findOrCreate(text.prepared_by.trim());
+          if (authorName) {
+            authorId = await this.authorHelper.findOrCreate(authorName);
+          }
+
+          let textCopyEditorId: string | null = null;
+          if (parsedPreparedBy?.textCopyEditorName) {
+            textCopyEditorId = await this.authorHelper.findOrCreate(
+              parsedPreparedBy.textCopyEditorName
+            );
+          }
+
+          let translatorId: string | null = null;
+          if (parsedPreparedBy?.translatorName) {
+            translatorId = await this.authorHelper.findOrCreate(parsedPreparedBy.translatorName);
+          }
+
+          let translationCopyEditorId: string | null = null;
+          if (parsedPreparedBy?.translationCopyEditorName) {
+            translationCopyEditorId = await this.authorHelper.findOrCreate(
+              parsedPreparedBy.translationCopyEditorName
+            );
           }
 
           // Build extra JSON
           const extra: Record<string, unknown> = {};
+          if (parsedPreparedBy?.preserveRawInExtra && text.prepared_by) {
+            extra.prepared_by = text.prepared_by;
+          }
           if (text.how_to_reach) extra.how_to_reach = text.how_to_reach;
           if (text.info) extra.info = text.info;
           if (text.contact) extra.contact = text.contact;
@@ -225,6 +251,9 @@ export class ExploreMonumentTranslationImporter extends BaseImporter {
             dates: text.date ?? null,
             type: text.styles ?? null,
             author_id: authorId,
+            text_copy_editor_id: textCopyEditorId,
+            translator_id: translatorId,
+            translation_copy_editor_id: translationCopyEditorId,
             extra: extraJson,
           });
 

--- a/scripts/importer/tests/unit/author-helper.test.ts
+++ b/scripts/importer/tests/unit/author-helper.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ILogger } from '../../src/core/base-importer.js';
+import type { IWriteStrategy } from '../../src/core/strategy.js';
+import type { ITracker } from '../../src/core/tracker.js';
+import { AuthorHelper } from '../../src/helpers/author-helper.js';
+import { sanitizeAllStrings } from '../../src/utils/html-to-markdown.js';
+
+describe('AuthorHelper', () => {
+  it('normalizes HTML-like names before lookup and duplicate retry', async () => {
+    const rawName =
+      'arch. Francesco Petrucci<br/>Copy-editor (Italian): Saverio Capozzi<br/>© Museum With No Frontiers (MWNF)';
+    const normalizedName = sanitizeAllStrings({ name: rawName }).name.trim();
+
+    const strategy = {
+      findAuthorByName: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce('author-uuid'),
+      writeAuthor: vi.fn().mockRejectedValue(new Error('Duplicate entry')),
+    } as unknown as IWriteStrategy;
+
+    const logger = {
+      warning: vi.fn(),
+    } as unknown as ILogger;
+
+    const tracker = {} as ITracker;
+
+    const helper = new AuthorHelper(strategy, tracker, logger);
+
+    const result = await helper.findOrCreate(rawName);
+
+    expect(result).toBe('author-uuid');
+    expect(strategy.findAuthorByName).toHaveBeenNthCalledWith(1, normalizedName);
+    expect(strategy.writeAuthor).toHaveBeenCalledWith({
+      name: normalizedName,
+      internal_name: normalizedName,
+      backward_compatibility: '',
+    });
+    expect(strategy.findAuthorByName).toHaveBeenNthCalledWith(2, normalizedName);
+  });
+});

--- a/scripts/importer/tests/unit/explore-prepared-by-parser.test.ts
+++ b/scripts/importer/tests/unit/explore-prepared-by-parser.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseExplorePreparedBy } from '../../src/helpers/explore-prepared-by-parser.js';
+
+describe('parseExplorePreparedBy', () => {
+  it('extracts author and editor roles from the recurring Francesco Petrucci block', () => {
+    const parsed = parseExplorePreparedBy(
+      'arch. Francesco Petrucci<br/>\nCopy-editor (Italian): Saverio Capozzi<br/>\nTranslator: Lavinia Amenduni<br/>\nCopy-editor (English): Danny de la Vega<br/>\n© Museum With No Frontiers (MWNF)'
+    );
+
+    expect(parsed).toEqual({
+      authorName: 'arch. Francesco Petrucci',
+      textCopyEditorName: 'Saverio Capozzi',
+      translatorName: 'Lavinia Amenduni',
+      translationCopyEditorName: 'Danny de la Vega',
+      preserveRawInExtra: true,
+    });
+  });
+
+  it('extracts the primary author from attribution-based prepared_by blocks', () => {
+    const parsed = parseExplorePreparedBy(
+      'Museo Senza Frontiere, Saverio Capozzi, sulla base di materiale fornito da:<br/>\narch. Francesco Petrucci; © Museum With No Frontiers (MWNF).'
+    );
+
+    expect(parsed).toEqual({
+      authorName: 'arch. Francesco Petrucci',
+      textCopyEditorName: null,
+      translatorName: null,
+      translationCopyEditorName: null,
+      preserveRawInExtra: true,
+    });
+  });
+
+  it('extracts labeled author and copyeditor pairs', () => {
+    const parsed = parseExplorePreparedBy(
+      '<br/>\nAuthor: Fiza Ishaq<br/>\nCopyeditor: Amber "AJ" Stephens'
+    );
+
+    expect(parsed).toEqual({
+      authorName: 'Fiza Ishaq',
+      textCopyEditorName: 'Amber "AJ" Stephens',
+      translatorName: null,
+      translationCopyEditorName: null,
+      preserveRawInExtra: true,
+    });
+  });
+
+  it('returns null for plain single-name values', () => {
+    expect(parseExplorePreparedBy('John Doe')).toBeNull();
+  });
+});


### PR DESCRIPTION
Implemented the narrow fix set in the importer.

The global bug is fixed in author-helper.ts: free-text author lookup and duplicate retry now use the same sanitized name that `writeAuthor` persists, so the repeated HTML-like author blobs no longer end up as “entity lost” on duplicate insert.

The Explore-specific enhancement is in explore-prepared-by-parser.ts and wired into explore-monument-translation-importer.ts. It only activates for the narrow semi-structured `prepared_by` shapes we found in the scan. It now extracts:
- primary author from the Francesco Petrucci role blocks
- text copy editor, translator, and translation copy editor when explicitly labeled
- the primary author from the recurring “sulla base di materiale fornito da” attribution blocks

When that parser activates, the original raw `prepared_by` string is also preserved in `extra.prepared_by`, so the copyright / attribution text is not lost even when only part of the blob maps cleanly to role FKs.