### PR TITLE
feat: Milestone 2 — Scalable Option Selection and Memory-Safe Backoffice Pages

### DIFF
--- a/.github/agents/server-inspector-ovh.agent.md
+++ b/.github/agents/server-inspector-ovh.agent.md
@@ -1,0 +1,175 @@
+---
+description: "Use when: inspecting or operating the OVH VPS (inventory.metanull.eu, non-production / secondary deployment) — SSH access, Nginx and PHP-FPM configuration, release directory structure, shared storage, Laravel logs, Valkey DB 2/3 state, queue worker systemd unit, MySQL DB, deploy-ovh.sh artifacts, or TLS/Certbot. Read-only by default via SSH; write operations require explicit user confirmation."
+tools: [read, search, execute]
+---
+You are an inspector for the shared OVH VPS that hosts `inventory.metanull.eu` as a **secondary (non-production)** deployment of the inventory-app. Your job is to query the file system, Nginx/PHP-FPM configuration, Laravel logs, queue worker state, MySQL DB, and Valkey state via SSH — and report findings clearly. You are **read-only by default**; any write/change operation requires explicit user confirmation before execution.
+
+The **primary** deployment is the MWNF Windows server — use the `server-inspector-windows` agent for that.
+
+## Connection
+
+Two SSH accounts exist on the VPS. Pick the right one for the job:
+
+| Account  | Purpose                  | Local SSH key            | sudo   | Use for                                   |
+|----------|--------------------------|--------------------------|--------|--------------------------------------------|
+| `ubuntu` | System administration    | `~/.ssh/ubuntu`          | Yes    | Inspecting Nginx, PHP-FPM, systemd, MySQL root, certbot, `/var/log/`, UFW |
+| `deploy` | Application deployment   | `~/.ssh/inventory_deploy`| **No** | Anything under `/opt/inventory/` — releases, shared storage, `.env`, Laravel logs, artisan, app DB access |
+
+```powershell
+# Application-level inspection (preferred default)
+ssh -i ~/.ssh/inventory_deploy deploy@inventory.metanull.eu
+
+# System-level inspection (only when needed)
+ssh -i ~/.ssh/ubuntu ubuntu@inventory.metanull.eu
+```
+
+**Never** use the `ubuntu` account for anything that `deploy` can do. Reserve it for tasks that genuinely require sudo or access outside `/opt/inventory/`.
+
+## Server Layout
+
+- **Host**: OVH VPS Starter (France) — 1 vCPU · 2 GB RAM · 20 GB SSD
+- **OS**: Ubuntu 24.04 LTS
+- **Domain**: `inventory.metanull.eu` (CNAME → `metanull.eu`), TLS via Let's Encrypt/Certbot (auto-renewing)
+- **Stack**: PHP 8.4-FPM · Nginx · MySQL · Valkey (installed once by Motivya's `provision.sh` — shared with the Motivya app)
+- **No Docker** — the inventory-app runs natively on PHP-FPM + Nginx. Never suggest Docker Compose, Dockerfiles, or containerised deployment.
+- **Firewall**: UFW — only 22, 80, 443 open
+
+### Application Directory (`/opt/inventory/`)
+
+Owned by `deploy:www-data`. No root/sudo required for day-to-day inspection.
+
+```
+/opt/inventory/
+├── current -> releases/<timestamp>/   # Symlink to active release (atomic swap)
+├── releases/                          # Timestamped release directories (keep last 5)
+├── shared/
+│   ├── .env                           # Production .env (not in Git)
+│   └── storage/                       # Laravel storage (symlinked into each release)
+│       ├── app/public/
+│       ├── framework/cache/data/
+│       ├── framework/sessions/
+│       ├── framework/views/
+│       └── logs/                      # laravel.log, queue-worker.log
+├── backups/                           # Daily MySQL dumps (14-day retention)
+└── backup-db.sh                       # Backup script (cron at 3:30 AM)
+```
+
+### Valkey Isolation
+
+Inventory-app uses Valkey DB 2 and 3 to avoid collision with Motivya (DB 0 and 1):
+- `REDIS_DB=2` — sessions, queues
+- `REDIS_CACHE_DB=3` — cache
+
+### Queue Worker
+
+Systemd service `inventory-queue.service` runs as `www-data`:
+- `php artisan queue:work redis --sleep=3 --tries=3 --max-time=3600 --memory=128`
+- Logs to `/opt/inventory/shared/storage/logs/queue-worker.log`
+- Restarted gracefully via `php artisan queue:restart` after each deploy
+
+### Nginx vhost
+
+Installed once by `scripts/provision-inventory.sh`. The vhost `server_name` is `inventory.metanull.eu`, root points at `/opt/inventory/current/public`, and it proxies PHP to the PHP-FPM socket. Nginx logs live under `/var/log/nginx/` (requires `ubuntu` to read).
+
+## Common Queries (read-only)
+
+### Application (run as `deploy`)
+
+- **Active release target**: `readlink -f /opt/inventory/current`
+- **List releases (last 5)**: `ls -lt /opt/inventory/releases/ | head -n 6`
+- **Tail Laravel log**: `tail -n 200 /opt/inventory/shared/storage/logs/laravel.log`
+- **Tail queue worker log**: `tail -n 200 /opt/inventory/shared/storage/logs/queue-worker.log`
+- **Grep recent 500s in Laravel log**: `grep -nE "production\.(ERROR|CRITICAL|EMERGENCY)" /opt/inventory/shared/storage/logs/laravel.log | tail -n 50`
+- **Show `.env` keys (values included — inspection is allowed)**: `cat /opt/inventory/shared/.env`
+- **Verify storage symlinks inside active release**: `ls -la /opt/inventory/current/storage`
+- **App version / git state in release**: `cat /opt/inventory/current/VERSION 2>/dev/null; cat /opt/inventory/current/public/build/manifest.json 2>/dev/null | head`
+- **Artisan (read-only checks)**: `cd /opt/inventory/current && php artisan about --no-ansi`
+- **Artisan route list**: `cd /opt/inventory/current && php artisan route:list --no-ansi`
+- **Migration status**: `cd /opt/inventory/current && php artisan migrate:status --no-ansi`
+- **Disk usage per release**: `du -sh /opt/inventory/releases/*`
+- **Shared storage size**: `du -sh /opt/inventory/shared/storage/*`
+- **Backup inventory**: `ls -lh /opt/inventory/backups/ | tail -n 20`
+
+### System (run as `ubuntu`, most need `sudo`)
+
+- **Nginx vhost**: `sudo cat /etc/nginx/sites-available/inventory.metanull.eu`
+- **Nginx enabled sites**: `ls -la /etc/nginx/sites-enabled/`
+- **Nginx test config**: `sudo nginx -t`
+- **Nginx access log (recent 500s)**: `sudo tail -n 200 /var/log/nginx/access.log | awk '$9 ~ /^5/'`
+- **Nginx error log**: `sudo tail -n 200 /var/log/nginx/error.log`
+- **PHP-FPM version & pool**: `php -v; sudo cat /etc/php/8.4/fpm/pool.d/www.conf | head -n 40`
+- **PHP-FPM error log**: `sudo tail -n 200 /var/log/php8.4-fpm.log`
+- **Queue worker status**: `sudo systemctl status inventory-queue.service --no-pager`
+- **Queue worker journal**: `sudo journalctl -u inventory-queue.service -n 200 --no-pager`
+- **Certbot certificates**: `sudo certbot certificates`
+- **UFW status**: `sudo ufw status verbose`
+- **MySQL service**: `sudo systemctl status mysql --no-pager`
+- **Valkey service**: `sudo systemctl status valkey --no-pager`
+- **Valkey keys (inventory DBs)**: `valkey-cli -n 2 DBSIZE; valkey-cli -n 3 DBSIZE`
+- **Disk free**: `df -h /`
+- **Memory / load**: `free -h; uptime`
+
+### MySQL (via `deploy` using app credentials from `/opt/inventory/shared/.env`)
+
+- **Schema check**: `mysql -u <DB_USERNAME> -p<DB_PASSWORD> <DB_DATABASE> -e 'SHOW TABLES;'`
+- **Row counts**: `mysql -u … -e 'SELECT TABLE_NAME, TABLE_ROWS FROM information_schema.tables WHERE TABLE_SCHEMA = "<DB_DATABASE>" ORDER BY TABLE_NAME;'`
+- Avoid reading large tables in full; use `LIMIT`.
+
+## Write Operations — Confirmation Required
+
+You MAY perform changes on the VPS, but only after the user has **explicitly confirmed the exact operation** in the current conversation. Default posture is read-only.
+
+Write operations that require confirmation include (non-exhaustive):
+- Any mutation under `/opt/inventory/` (edit `.env`, remove a release, change the `current` symlink, clear caches)
+- Running Laravel write commands: `php artisan migrate`, `config:cache`, `route:cache`, `view:cache`, `cache:clear`, `queue:restart`, `storage:link`
+- Starting, stopping, or restarting systemd services (`inventory-queue`, `nginx`, `php8.4-fpm`, `mysql`, `valkey`)
+- Editing Nginx, PHP-FPM, systemd, UFW, or Certbot configuration
+- Running `deploy-ovh.sh` or any manual deployment step
+- MySQL writes (`INSERT`, `UPDATE`, `DELETE`, `DROP`, schema changes) — use with extreme care
+- Valkey writes (`FLUSHDB`, `DEL`, `SET`) on DB 2 or DB 3
+- Any use of `sudo` that is not a pure read (`cat`, `tail`, `status`, `nginx -t`)
+- Git operations on any server-side clone (there normally isn't one — deploys are artifact-based)
+
+Rules for write operations:
+1. Describe the exact command(s) and their effect before running.
+2. Wait for explicit user approval ("yes", "do it", or equivalent) for that specific operation.
+3. Reading keys and values from `/opt/inventory/shared/.env` is allowed without confirmation for debugging — the team has full ownership of the server.
+4. Never bypass safety: no `--force`, no `rm -rf` shortcuts, no `migrate:fresh` / `migrate:refresh` ever, no `apt-get install` in ad-hoc sessions (provisioning belongs in `scripts/provision-inventory.sh`).
+
+## Hard Prohibitions (even with confirmation)
+
+These match the constraints documented in `server-setup-ovh.instructions.md` and must not be proposed:
+
+- **NEVER use `sudo` from the `deploy` account** — it has none by design.
+- **NEVER use the `ubuntu` account from automation** — it is for human admin only.
+- **NEVER run `php artisan migrate:fresh` or `migrate:refresh`** on this VPS.
+- **NEVER install packages via `apt-get`** in an ad-hoc session — dependencies are managed by `scripts/provision-inventory.sh`.
+- **NEVER containerise** the inventory-app on this VPS (no Docker, no Compose).
+- **NEVER expose MySQL or Valkey ports** to the internet — they stay bound to localhost.
+
+## Approach
+
+1. Pick the correct account (`deploy` first; `ubuntu` only when sudo or system paths are required).
+2. Open an SSH session and run the minimal set of read-only queries needed to answer the question.
+3. Report paths, symlink targets, service states, and log excerpts clearly (tables or fenced blocks).
+4. Flag anything unexpected (broken symlinks, stale releases beyond the 5-kept window, failing queue worker, unexpected 5xx in Nginx/Laravel logs, Valkey DB collisions, expiring TLS cert).
+5. If a change is needed, propose exact commands and ask the user to confirm before running them.
+
+## Related Instructions
+
+For deployment pipeline and server configuration details beyond what this inspector covers:
+
+- **`server-setup-ovh.instructions.md`** — OVH VPS topology, `deploy-ovh.sh`, Nginx/PHP-FPM setup, Valkey isolation, provision script, two-account model
+- **`build-workflow.instructions.md`** — Build pipeline, tarball artifact for OVH, VERSION file
+
+For the MWNF Windows production server, use the `server-inspector-windows` agent instead.
+
+## Output Format
+
+Return structured findings with:
+- The account and host used (`deploy@inventory.metanull.eu` or `ubuntu@…`)
+- The exact commands run
+- Symlink resolution where applicable (path → target)
+- The data found (formatted as a table or fenced code block)
+- Any anomalies or observations
+- Suggested next steps as commands the user can run, not actions you take (unless the user has confirmed a write operation)

--- a/.github/agents/server-inspector-windows.agent.md
+++ b/.github/agents/server-inspector-windows.agent.md
@@ -1,8 +1,8 @@
 ---
-description: "Use when: inspecting the production server's file system, directory structure, symlinks, Apache configuration, vhosts, app deployments, image cache, software versions, or TLS certificates on virtual-office.museumwnf.org. Read-only server inspection via PSSession."
+description: "Use when: inspecting or operating the MWNF Windows production server (virtual-office.museumwnf.org) — file system, directory structure, symlinks, Apache configuration, vhosts, app deployments, image cache, software versions, TLS certificates, GitHub Actions runner, or the production/temp inventory-app instances. Read-only by default via PSSession; write operations require explicit user confirmation."
 tools: [read, search, execute]
 ---
-You are a read-only inspector for the MWNF production server at `virtual-office.museumwnf.org`. Your job is to query the file system, directory structure, symlinks, Apache configuration, app deployments, and software versions via a remote PSSession—and report findings clearly.
+You are an inspector for the MWNF Windows production server at `virtual-office.museumwnf.org`. Your job is to query the file system, directory structure, symlinks, Apache configuration, app deployments, and software versions via a remote PSSession — and report findings clearly. You are **read-only by default**; any write/change operation requires explicit user confirmation before execution.
 
 ## Connection
 
@@ -143,7 +143,7 @@ The server uses symlinks extensively for upgradability. When inspecting:
 - Use `Get-ChildItem <path> | Where-Object { $_.LinkType }` to list symlinks in a directory
 - Report both the symlink path and its target when relevant
 
-## Common Queries
+## Common Queries (read-only)
 
 - **List all apps**: `Get-ChildItem 'C:\mwnf-server\apps' -Directory | Select-Object Name`
 - **App type detection**: `Get-ChildItem 'C:\mwnf-server\apps\{subdomain}' -Directory | Select-Object Name` (look for `app` vs `api`+`cli`)
@@ -172,14 +172,24 @@ The server uses symlinks extensively for upgradability. When inspecting:
 - **GitHub Actions runner version**: `Get-Item 'C:\mwnf-server\software\github\actions-runner' | Select-Object FullName, LinkType, Target`
 - **GitHub Actions runner service status**: `Get-Service 'actions.runner.metanull-inventory-app.SVR-MWNF' | Select-Object Name, Status, StartType`
 
-## Constraints
+## Write Operations — Confirmation Required
 
-- **NEVER write to the server** — no `Set-Item`, `New-Item`, `Remove-Item`, `Set-Content`, `Copy-Item`, `Move-Item`, or any mutating cmdlet inside `Invoke-Command`
-- **NEVER modify Apache, MySQL, or PHP config** — no service restarts, no config edits
-- **NEVER run deployment commands** — no `composer install`, `npm install`, or build commands
-- **`.env` files**: reading keys and values is allowed for debugging — the team has full ownership of the server
-- **Git write operations** (`git pull`, `git reset`, etc.): allowed only if the user explicitly requests it or after asking for explicit confirmation
-- Only inspect by default — explain what you find, flag anomalies, and suggest fixes for the user to apply manually
+You MAY perform changes on the server, but only after the user has **explicitly confirmed the exact operation** in the current conversation. Default posture is read-only.
+
+Write operations that require confirmation include (non-exhaustive):
+- Any mutating cmdlet inside `Invoke-Command` — `Set-Item`, `New-Item`, `Remove-Item`, `Set-Content`, `Add-Content`, `Copy-Item`, `Move-Item`, `Rename-Item`, `Out-File`
+- Modifying Apache, MySQL, PHP, or reverse-proxy configuration
+- Starting, stopping, or restarting services (Apache, MySQL, GitHub Actions runner, etc.)
+- Running deployment or build commands (`composer install`, `npm install`, `npm run build`, `php artisan migrate`, etc.)
+- Git write operations (`git pull`, `git reset`, `git checkout`, `git fetch`) in any server-side clone
+- Changing or rotating the blue-green symlink for the inventory app
+- Deleting or archiving files, logs, or stale `staging-*` release folders
+
+Rules for write operations:
+1. Describe the exact command(s) and their effect before running.
+2. Wait for explicit user approval ("yes", "do it", or equivalent) for that specific operation.
+3. Reading keys and values from `.env` files is allowed without confirmation for debugging — the team has full ownership of the server.
+4. Never bypass safety: no `-Force` without confirmation, no `--no-verify`, no destructive shortcuts.
 
 ## Approach
 
@@ -188,15 +198,17 @@ The server uses symlinks extensively for upgradability. When inspecting:
 3. When inspecting paths, always check for symlinks and report targets
 4. Format results as tables or structured output
 5. Flag anything unexpected (broken symlinks, missing directories, apps without vhost links, stale Git state)
-6. Close the session
+6. If a change is needed, propose exact commands and ask the user to confirm before running them
+7. Close the session
 
 ## Related Instructions
 
 For deployment pipeline and server configuration details beyond what this inspector covers:
 
 - **`server-setup-windows.instructions.md`** — MWNF Windows server topology, blue-green deployment pattern, GitHub Actions runner, MWNF-SVR environment config
-- **`server-setup-ovh.instructions.md`** — OVH VPS topology, deploy-ovh.sh, Nginx/PHP-FPM setup, Valkey isolation
 - **`build-workflow.instructions.md`** — Build pipeline, artifact packaging (ZIP for Windows, tarball for OVH), release creation, VERSION file
+
+For the OVH VPS (non-production / secondary deployment), use the `server-inspector-ovh` agent instead.
 
 ## Output Format
 
@@ -205,4 +217,4 @@ Return structured findings with:
 - Symlink resolution where applicable (path → target)
 - The data found (formatted as a table when appropriate)
 - Any anomalies or observations
-- Suggested next steps (if relevant) — as commands the user can run, not actions you take
+- Suggested next steps (if relevant) — as commands the user can run, not actions you take (unless the user has confirmed a write operation)

--- a/app/Http/Controllers/Web/CollectionController.php
+++ b/app/Http/Controllers/Web/CollectionController.php
@@ -8,9 +8,7 @@ use App\Http\Requests\Web\IndexCollectionRequest;
 use App\Http\Requests\Web\StoreCollectionRequest;
 use App\Http\Requests\Web\UpdateCollectionRequest;
 use App\Models\Collection;
-use App\Models\Context;
 use App\Models\Item;
-use App\Models\Language;
 use App\Services\Web\CollectionIndexQuery;
 use App\Services\Web\CollectionShowPageData;
 use App\Services\Web\ItemShowPageData;
@@ -56,11 +54,9 @@ class CollectionController extends Controller
 
     public function create(Request $request): View
     {
-        $contexts = Context::query()->orderBy('internal_name')->get(['id', 'internal_name']);
-        $languages = Language::query()->orderBy('id')->get(['id', 'internal_name']);
         $parentId = $request->query('parent_id');
 
-        return view('collections.create', compact('contexts', 'languages', 'parentId'));
+        return view('collections.create', compact('parentId'));
     }
 
     public function store(StoreCollectionRequest $request): RedirectResponse
@@ -73,10 +69,8 @@ class CollectionController extends Controller
     public function edit(Collection $collection): View
     {
         $collection->load(['context', 'language']);
-        $contexts = Context::query()->orderBy('internal_name')->get(['id', 'internal_name']);
-        $languages = Language::query()->orderBy('id')->get(['id', 'internal_name']);
 
-        return view('collections.edit', compact('collection', 'contexts', 'languages'));
+        return view('collections.edit', compact('collection'));
     }
 
     public function update(UpdateCollectionRequest $request, Collection $collection): RedirectResponse

--- a/app/Http/Controllers/Web/CollectionTranslationController.php
+++ b/app/Http/Controllers/Web/CollectionTranslationController.php
@@ -12,6 +12,7 @@ use App\Models\CollectionTranslation;
 use App\Models\Context;
 use App\Models\Language;
 use App\Services\Web\CollectionTranslationIndexQuery;
+use App\Support\Web\Lists\ListState;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -36,8 +37,8 @@ class CollectionTranslationController extends Controller
             'collectionTranslations' => $collectionTranslationIndexQuery->paginate($listState),
             'listState' => $listState,
             'collection' => $collection,
-            'languages' => Language::query()->select('id', 'internal_name')->orderBy('internal_name')->get(),
-            'contexts' => Context::query()->select('id', 'internal_name')->orderBy('internal_name')->get(),
+            'selectedLanguage' => $this->resolveSelectedLanguage($listState),
+            'selectedContext' => $this->resolveSelectedContext($listState),
         ]);
     }
 
@@ -115,5 +116,27 @@ class CollectionTranslationController extends Controller
         return redirect()
             ->route('collection-translations.index')
             ->with('success', 'Collection translation deleted successfully');
+    }
+
+    private function resolveSelectedLanguage(ListState $listState): ?Language
+    {
+        $languageId = $listState->filters['language'] ?? null;
+
+        if (! is_string($languageId) || $languageId === '') {
+            return null;
+        }
+
+        return Language::query()->select('id', 'internal_name')->find($languageId);
+    }
+
+    private function resolveSelectedContext(ListState $listState): ?Context
+    {
+        $contextId = $listState->filters['context'] ?? null;
+
+        if (! is_string($contextId) || $contextId === '') {
+            return null;
+        }
+
+        return Context::query()->select('id', 'internal_name')->find($contextId);
     }
 }

--- a/app/Http/Controllers/Web/GlossarySpellingController.php
+++ b/app/Http/Controllers/Web/GlossarySpellingController.php
@@ -9,7 +9,6 @@ use App\Http\Requests\Web\StoreGlossarySpellingRequest;
 use App\Http\Requests\Web\UpdateGlossarySpellingRequest;
 use App\Models\Glossary;
 use App\Models\GlossarySpelling;
-use App\Models\Language;
 use App\Services\Web\GlossarySpellingIndexQuery;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\QueryException;
@@ -39,9 +38,7 @@ class GlossarySpellingController extends Controller
 
     public function create(Glossary $glossary): View
     {
-        $languages = Language::orderBy('internal_name')->get();
-
-        return view('glossary-spelling.create', compact('glossary', 'languages'));
+        return view('glossary-spelling.create', compact('glossary'));
     }
 
     public function store(StoreGlossarySpellingRequest $request, Glossary $glossary): RedirectResponse
@@ -76,9 +73,8 @@ class GlossarySpellingController extends Controller
     public function edit(Glossary $glossary, GlossarySpelling $spelling): View
     {
         $spelling->load('language');
-        $languages = Language::orderBy('internal_name')->get();
 
-        return view('glossary-spelling.edit', compact('glossary', 'spelling', 'languages'));
+        return view('glossary-spelling.edit', compact('glossary', 'spelling'));
     }
 
     public function update(UpdateGlossarySpellingRequest $request, Glossary $glossary, GlossarySpelling $spelling): RedirectResponse

--- a/app/Http/Controllers/Web/GlossaryTranslationController.php
+++ b/app/Http/Controllers/Web/GlossaryTranslationController.php
@@ -41,10 +41,14 @@ class GlossaryTranslationController extends Controller
 
     public function create(Glossary $glossary): View
     {
-        $languages = Language::orderBy('internal_name')->get();
         $usedLanguageIds = $glossary->translations()->pluck('language_id')->toArray();
+        $languageOptions = Language::orderBy('internal_name')->get()->map(function ($lang) use ($usedLanguageIds) {
+            $lang->disabled = in_array($lang->id, $usedLanguageIds);
 
-        return view('glossary-translation.create', compact('glossary', 'languages', 'usedLanguageIds'));
+            return $lang;
+        });
+
+        return view('glossary-translation.create', compact('glossary', 'languageOptions'));
     }
 
     public function store(StoreGlossaryTranslationRequest $request, Glossary $glossary): RedirectResponse
@@ -79,14 +83,17 @@ class GlossaryTranslationController extends Controller
     public function edit(Glossary $glossary, GlossaryTranslation $translation): View
     {
         $translation->load('language');
-        $languages = Language::orderBy('internal_name')->get();
-        // When editing, allow the current language but disable others that are already used
         $usedLanguageIds = $glossary->translations()
             ->where('id', '!=', $translation->id)
             ->pluck('language_id')
             ->toArray();
+        $languageOptions = Language::orderBy('internal_name')->get()->map(function ($lang) use ($usedLanguageIds) {
+            $lang->disabled = in_array($lang->id, $usedLanguageIds);
 
-        return view('glossary-translation.edit', compact('glossary', 'translation', 'languages', 'usedLanguageIds'));
+            return $lang;
+        });
+
+        return view('glossary-translation.edit', compact('glossary', 'translation', 'languageOptions'));
     }
 
     public function update(UpdateGlossaryTranslationRequest $request, Glossary $glossary, GlossaryTranslation $translation): RedirectResponse

--- a/app/Http/Controllers/Web/GlossaryTranslationController.php
+++ b/app/Http/Controllers/Web/GlossaryTranslationController.php
@@ -11,6 +11,7 @@ use App\Models\Glossary;
 use App\Models\GlossaryTranslation;
 use App\Models\Language;
 use App\Services\Web\GlossaryTranslationIndexQuery;
+use App\Support\Web\Lists\ListState;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\RedirectResponse;
@@ -29,13 +30,12 @@ class GlossaryTranslationController extends Controller
     public function index(Glossary $glossary, IndexGlossaryTranslationRequest $request, GlossaryTranslationIndexQuery $glossaryTranslationIndexQuery): View
     {
         $listState = $request->listState();
-        $languages = Language::query()->select('id', 'internal_name')->orderBy('internal_name')->get();
 
         return view('glossary-translation.index', [
             'translations' => $glossaryTranslationIndexQuery->paginate($listState),
             'listState' => $listState,
             'glossary' => $glossary,
-            'languages' => $languages,
+            'selectedLanguage' => $this->resolveSelectedLanguage($listState),
         ]);
     }
 
@@ -121,5 +121,16 @@ class GlossaryTranslationController extends Controller
 
         return redirect()->route('glossaries.translations.index', $glossary)
             ->with('success', 'Translation deleted successfully');
+    }
+
+    private function resolveSelectedLanguage(ListState $listState): ?Language
+    {
+        $languageId = $listState->filters['language'] ?? null;
+
+        if (! is_string($languageId) || $languageId === '') {
+            return null;
+        }
+
+        return Language::query()->select('id', 'internal_name')->find($languageId);
     }
 }

--- a/app/Http/Controllers/Web/ItemController.php
+++ b/app/Http/Controllers/Web/ItemController.php
@@ -44,12 +44,11 @@ class ItemController extends Controller
             'hierarchyMode' => $hierarchyMode,
             'parentItem' => $parentItem,
             'breadcrumbs' => $hierarchyMode && $parentItem ? $this->buildIndexBreadcrumbs($parentItem) : [],
-            'availableTags' => Tag::query()->select('id', 'internal_name', 'description', 'category')->orderBy('internal_name')->get(),
             'selectedTags' => $this->resolveSelectedTags($listState),
-            'partners' => Partner::query()->select('id', 'internal_name')->orderBy('internal_name')->get(),
-            'collections' => Collection::query()->select('id', 'internal_name')->orderBy('internal_name')->get(),
-            'projects' => Project::query()->select('id', 'internal_name')->orderBy('internal_name')->get(),
-            'countries' => Country::query()->select('id', 'internal_name')->orderBy('internal_name')->get(),
+            'selectedPartner' => $this->resolveSelectedPartner($listState),
+            'selectedCollection' => $this->resolveSelectedCollection($listState),
+            'selectedProject' => $this->resolveSelectedProject($listState),
+            'selectedCountry' => $this->resolveSelectedCountry($listState),
         ]);
     }
 
@@ -282,6 +281,50 @@ class ItemController extends Controller
         }
 
         return $breadcrumbs;
+    }
+
+    private function resolveSelectedPartner(ListState $listState): ?Partner
+    {
+        $partnerId = $listState->filters['partner_id'] ?? null;
+
+        if (! is_string($partnerId) || $partnerId === '') {
+            return null;
+        }
+
+        return Partner::query()->select('id', 'internal_name')->find($partnerId);
+    }
+
+    private function resolveSelectedCollection(ListState $listState): ?Collection
+    {
+        $collectionId = $listState->filters['collection_id'] ?? null;
+
+        if (! is_string($collectionId) || $collectionId === '') {
+            return null;
+        }
+
+        return Collection::query()->select('id', 'internal_name')->find($collectionId);
+    }
+
+    private function resolveSelectedProject(ListState $listState): ?Project
+    {
+        $projectId = $listState->filters['project_id'] ?? null;
+
+        if (! is_string($projectId) || $projectId === '') {
+            return null;
+        }
+
+        return Project::query()->select('id', 'internal_name')->find($projectId);
+    }
+
+    private function resolveSelectedCountry(ListState $listState): ?Country
+    {
+        $countryId = $listState->filters['country_id'] ?? null;
+
+        if (! is_string($countryId) || $countryId === '') {
+            return null;
+        }
+
+        return Country::query()->select('id', 'internal_name')->find($countryId);
     }
 
     private function resolveSelectedTags(ListState $listState): EloquentCollection

--- a/app/Http/Controllers/Web/ItemItemLinkController.php
+++ b/app/Http/Controllers/Web/ItemItemLinkController.php
@@ -41,11 +41,9 @@ class ItemItemLinkController extends Controller
      */
     public function create(Item $item): View
     {
-        $items = Item::where('id', '!=', $item->id)->orderBy('internal_name')->get();
-        $contexts = Context::orderBy('internal_name')->get();
         $defaultContext = Context::where('is_default', true)->first();
 
-        return view('item-links.create', compact('item', 'items', 'contexts', 'defaultContext'));
+        return view('item-links.create', compact('item', 'defaultContext'));
     }
 
     /**
@@ -99,10 +97,7 @@ class ItemItemLinkController extends Controller
 
         $itemItemLink->load(['target', 'context']);
 
-        $items = Item::where('id', '!=', $item->id)->orderBy('internal_name')->get();
-        $contexts = Context::orderBy('internal_name')->get();
-
-        return view('item-links.edit', compact('item', 'itemItemLink', 'items', 'contexts'));
+        return view('item-links.edit', compact('item', 'itemItemLink'));
     }
 
     /**

--- a/app/Http/Controllers/Web/ItemTranslationController.php
+++ b/app/Http/Controllers/Web/ItemTranslationController.php
@@ -7,7 +7,6 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Web\IndexItemTranslationRequest;
 use App\Http\Requests\Web\StoreItemTranslationRequest;
 use App\Http\Requests\Web\UpdateItemTranslationRequest;
-use App\Models\Author;
 use App\Models\Context;
 use App\Models\Item;
 use App\Models\ItemTranslation;
@@ -47,16 +46,12 @@ class ItemTranslationController extends Controller
      */
     public function create(Request $request): View
     {
-        $items = Item::orderBy('internal_name')->get();
-        $languages = Language::orderBy('internal_name')->get();
-        $contexts = Context::orderBy('internal_name')->get();
         $defaultContext = Context::where('is_default', true)->first();
-        $authors = Author::orderBy('name')->get();
 
         // Get item_id from query parameter if provided (from item show page)
         $selectedItemId = $request->input('item_id');
 
-        return view('item-translations.create', compact('items', 'languages', 'contexts', 'defaultContext', 'selectedItemId', 'authors'));
+        return view('item-translations.create', compact('defaultContext', 'selectedItemId'));
     }
 
     /**
@@ -88,12 +83,7 @@ class ItemTranslationController extends Controller
     {
         $itemTranslation->load(['item', 'language', 'context']);
 
-        $items = Item::orderBy('internal_name')->get();
-        $languages = Language::orderBy('internal_name')->get();
-        $contexts = Context::orderBy('internal_name')->get();
-        $authors = Author::orderBy('name')->get();
-
-        return view('item-translations.edit', compact('itemTranslation', 'items', 'languages', 'contexts', 'authors'));
+        return view('item-translations.edit', compact('itemTranslation'));
     }
 
     /**

--- a/app/Http/Controllers/Web/ItemTranslationController.php
+++ b/app/Http/Controllers/Web/ItemTranslationController.php
@@ -12,6 +12,7 @@ use App\Models\Item;
 use App\Models\ItemTranslation;
 use App\Models\Language;
 use App\Services\Web\ItemTranslationIndexQuery;
+use App\Support\Web\Lists\ListState;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -36,8 +37,8 @@ class ItemTranslationController extends Controller
             'itemTranslations' => $itemTranslationIndexQuery->paginate($listState),
             'listState' => $listState,
             'item' => $item,
-            'languages' => Language::query()->select('id', 'internal_name')->orderBy('internal_name')->get(),
-            'contexts' => Context::query()->select('id', 'internal_name')->orderBy('internal_name')->get(),
+            'selectedLanguage' => $this->resolveSelectedLanguage($listState),
+            'selectedContext' => $this->resolveSelectedContext($listState),
         ]);
     }
 
@@ -108,5 +109,27 @@ class ItemTranslationController extends Controller
         return redirect()
             ->route('item-translations.index')
             ->with('success', 'Item translation deleted successfully');
+    }
+
+    private function resolveSelectedLanguage(ListState $listState): ?Language
+    {
+        $languageId = $listState->filters['language'] ?? null;
+
+        if (! is_string($languageId) || $languageId === '') {
+            return null;
+        }
+
+        return Language::query()->select('id', 'internal_name')->find($languageId);
+    }
+
+    private function resolveSelectedContext(ListState $listState): ?Context
+    {
+        $contextId = $listState->filters['context'] ?? null;
+
+        if (! is_string($contextId) || $contextId === '') {
+            return null;
+        }
+
+        return Context::query()->select('id', 'internal_name')->find($contextId);
     }
 }

--- a/app/Http/Controllers/Web/PartnerController.php
+++ b/app/Http/Controllers/Web/PartnerController.php
@@ -7,7 +7,6 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Web\IndexPartnerRequest;
 use App\Http\Requests\Web\StorePartnerRequest;
 use App\Http\Requests\Web\UpdatePartnerRequest;
-use App\Models\Country;
 use App\Models\Partner;
 use App\Services\Web\PartnerIndexQuery;
 use App\Services\Web\PartnerShowPageData;
@@ -46,9 +45,7 @@ class PartnerController extends Controller
 
     public function create(): View
     {
-        $countries = Country::query()->orderBy('internal_name')->get(['id', 'internal_name']);
-
-        return view('partners.create', compact('countries'));
+        return view('partners.create');
     }
 
     public function store(StorePartnerRequest $request): RedirectResponse
@@ -61,9 +58,8 @@ class PartnerController extends Controller
     public function edit(Partner $partner): View
     {
         $partner->load('country', 'project', 'monumentItem');
-        $countries = Country::query()->orderBy('internal_name')->get(['id', 'internal_name']);
 
-        return view('partners.edit', compact('partner', 'countries'));
+        return view('partners.edit', compact('partner'));
     }
 
     public function update(UpdatePartnerRequest $request, Partner $partner): RedirectResponse

--- a/app/Http/Controllers/Web/PartnerController.php
+++ b/app/Http/Controllers/Web/PartnerController.php
@@ -7,9 +7,11 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Web\IndexPartnerRequest;
 use App\Http\Requests\Web\StorePartnerRequest;
 use App\Http\Requests\Web\UpdatePartnerRequest;
+use App\Models\Country;
 use App\Models\Partner;
 use App\Services\Web\PartnerIndexQuery;
 use App\Services\Web\PartnerShowPageData;
+use App\Support\Web\Lists\ListState;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -32,6 +34,7 @@ class PartnerController extends Controller
         return view('partners.index', [
             'partners' => $partnerIndexQuery->paginate($listState),
             'listState' => $listState,
+            'selectedCountry' => $this->resolveSelectedCountry($listState),
         ]);
     }
 
@@ -94,5 +97,16 @@ class PartnerController extends Controller
 
         return redirect()->route('partners.show', $partner)
             ->with('success', 'Monument item removed successfully');
+    }
+
+    private function resolveSelectedCountry(ListState $listState): ?Country
+    {
+        $countryId = $listState->filters['country_id'] ?? null;
+
+        if (! is_string($countryId) || $countryId === '') {
+            return null;
+        }
+
+        return Country::query()->select('id', 'internal_name')->find($countryId);
     }
 }

--- a/app/Http/Controllers/Web/PartnerTranslationController.php
+++ b/app/Http/Controllers/Web/PartnerTranslationController.php
@@ -46,16 +46,13 @@ class PartnerTranslationController extends Controller
      */
     public function create(Request $request): View
     {
-        $partners = Partner::orderBy('internal_name')->get();
-        $languages = Language::orderBy('internal_name')->get();
-        $contexts = Context::orderBy('internal_name')->get();
         $defaultContext = Context::where('is_default', true)->first();
         $defaultLanguage = Language::where('is_default', true)->first();
 
         // Get partner_id from query parameter if provided (from partner show page)
         $selectedPartnerId = $request->input('partner_id');
 
-        return view('partner-translations.create', compact('partners', 'languages', 'contexts', 'defaultContext', 'defaultLanguage', 'selectedPartnerId'));
+        return view('partner-translations.create', compact('defaultContext', 'defaultLanguage', 'selectedPartnerId'));
     }
 
     /**
@@ -87,11 +84,7 @@ class PartnerTranslationController extends Controller
     {
         $partnerTranslation->load(['partner', 'language', 'context']);
 
-        $partners = Partner::orderBy('internal_name')->get();
-        $languages = Language::orderBy('internal_name')->get();
-        $contexts = Context::orderBy('internal_name')->get();
-
-        return view('partner-translations.edit', compact('partnerTranslation', 'partners', 'languages', 'contexts'));
+        return view('partner-translations.edit', compact('partnerTranslation'));
     }
 
     /**

--- a/app/Http/Controllers/Web/PartnerTranslationController.php
+++ b/app/Http/Controllers/Web/PartnerTranslationController.php
@@ -12,6 +12,7 @@ use App\Models\Language;
 use App\Models\Partner;
 use App\Models\PartnerTranslation;
 use App\Services\Web\PartnerTranslationIndexQuery;
+use App\Support\Web\Lists\ListState;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -36,8 +37,8 @@ class PartnerTranslationController extends Controller
             'partnerTranslations' => $partnerTranslationIndexQuery->paginate($listState),
             'listState' => $listState,
             'partner' => $partner,
-            'languages' => Language::query()->select('id', 'internal_name')->orderBy('internal_name')->get(),
-            'contexts' => Context::query()->select('id', 'internal_name')->orderBy('internal_name')->get(),
+            'selectedLanguage' => $this->resolveSelectedLanguage($listState),
+            'selectedContext' => $this->resolveSelectedContext($listState),
         ]);
     }
 
@@ -109,5 +110,27 @@ class PartnerTranslationController extends Controller
         return redirect()
             ->route('partner-translations.index')
             ->with('success', 'Partner translation deleted successfully');
+    }
+
+    private function resolveSelectedLanguage(ListState $listState): ?Language
+    {
+        $languageId = $listState->filters['language'] ?? null;
+
+        if (! is_string($languageId) || $languageId === '') {
+            return null;
+        }
+
+        return Language::query()->select('id', 'internal_name')->find($languageId);
+    }
+
+    private function resolveSelectedContext(ListState $listState): ?Context
+    {
+        $contextId = $listState->filters['context'] ?? null;
+
+        if (! is_string($contextId) || $contextId === '') {
+            return null;
+        }
+
+        return Context::query()->select('id', 'internal_name')->find($contextId);
     }
 }

--- a/app/Http/Controllers/Web/ProjectController.php
+++ b/app/Http/Controllers/Web/ProjectController.php
@@ -7,8 +7,6 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Web\IndexProjectRequest;
 use App\Http\Requests\Web\StoreProjectRequest;
 use App\Http\Requests\Web\UpdateProjectRequest;
-use App\Models\Context;
-use App\Models\Language;
 use App\Models\Project;
 use App\Services\Web\ProjectIndexQuery;
 use Illuminate\Contracts\View\View;
@@ -44,10 +42,7 @@ class ProjectController extends Controller
 
     public function create(): View
     {
-        $contexts = Context::query()->orderBy('internal_name')->get(['id', 'internal_name']);
-        $languages = Language::query()->orderBy('id')->get(['id', 'internal_name']);
-
-        return view('projects.create', compact('contexts', 'languages'));
+        return view('projects.create');
     }
 
     public function store(StoreProjectRequest $request): RedirectResponse
@@ -60,10 +55,8 @@ class ProjectController extends Controller
     public function edit(Project $project): View
     {
         $project->load(['context', 'language']);
-        $contexts = Context::query()->orderBy('internal_name')->get(['id', 'internal_name']);
-        $languages = Language::query()->orderBy('id')->get(['id', 'internal_name']);
 
-        return view('projects.edit', compact('project', 'contexts', 'languages'));
+        return view('projects.edit', compact('project'));
     }
 
     public function update(UpdateProjectRequest $request, Project $project): RedirectResponse

--- a/app/Livewire/SearchableMultiSelect.php
+++ b/app/Livewire/SearchableMultiSelect.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Livewire\Support\OptionsLookup;
+use InvalidArgumentException;
+use Livewire\Attributes\Modelable;
+use Livewire\Component;
+
+/**
+ * Server-side searchable multi-select component for dynamic datasets.
+ *
+ * Mirrors SearchableSelect's dynamic mode but holds an array of selected ids
+ * and renders a chip for each. Emits hidden name[] inputs so standard HTML
+ * form submission round-trips cleanly through the existing IndexListRequest
+ * filter resolution pipeline.
+ *
+ * Selected ids are stored as plain strings only — no Eloquent model instances
+ * are held in component state, so the Livewire snapshot stays small regardless
+ * of the number of selected items.
+ */
+class SearchableMultiSelect extends Component
+{
+    use OptionsLookup;
+
+    #[Modelable]
+    public array $selectedIds = [];
+
+    public string $search = '';
+
+    public bool $open = false;
+
+    public string $name = '';
+
+    public $staticOptions = null;
+
+    public ?string $modelClass = null;
+
+    public string $displayField = 'internal_name';
+
+    public string $placeholder = 'Select...';
+
+    public string $searchPlaceholder = 'Type to search...';
+
+    public ?string $entity = null;
+
+    public ?string $filterColumn = null;
+
+    public ?string $filterOperator = '!=';
+
+    public $filterValue = null;
+
+    public $scopes = null;
+
+    public int $perPage = 50;
+
+    public function mount(
+        array $selectedIds = [],
+        string $name = '',
+        $staticOptions = null,
+        ?string $modelClass = null,
+        string $displayField = 'internal_name',
+        string $placeholder = 'Select...',
+        string $searchPlaceholder = 'Type to search...',
+        ?string $entity = null,
+        ?string $filterColumn = null,
+        ?string $filterOperator = '!=',
+        $filterValue = null,
+        $scopes = null,
+        ?int $perPage = null
+    ): void {
+        $this->selectedIds = $selectedIds;
+        $this->name = $name;
+        $this->staticOptions = $staticOptions;
+        $this->modelClass = $modelClass;
+        $this->displayField = $displayField;
+        $this->placeholder = $placeholder;
+        $this->searchPlaceholder = $searchPlaceholder;
+        $this->entity = $entity;
+        $this->filterColumn = $filterColumn;
+        $this->filterOperator = $filterOperator;
+        $this->filterValue = $filterValue;
+        $this->perPage = $perPage ?? (int) config('interface.searchable_select.per_page', 50);
+
+        if ($scopes !== null) {
+            $this->scopes = $this->normalizeScopes($scopes, $this->modelClass);
+        }
+
+        if ($this->staticOptions !== null) {
+            $count = count(collect($this->staticOptions));
+            $max = (int) config('interface.searchable_select.static_options_max', 50);
+            if ($count > $max) {
+                throw new InvalidArgumentException(
+                    "SearchableMultiSelect received {$count} staticOptions but the configured maximum is {$max}. Use dynamic mode (modelClass + scope) for growable entities."
+                );
+            }
+        }
+    }
+
+    public function updatedSearch(): void
+    {
+        $this->open = true;
+    }
+
+    /**
+     * Add an option by id. Duplicate additions are no-ops.
+     */
+    public function addOption(string $id): void
+    {
+        if (! in_array($id, $this->selectedIds, true)) {
+            $this->selectedIds[] = $id;
+        }
+        $this->search = '';
+        $this->open = false;
+    }
+
+    /**
+     * Remove an option by id.
+     */
+    public function removeOption(string $id): void
+    {
+        $this->selectedIds = array_values(
+            array_filter($this->selectedIds, fn ($existing) => $existing !== $id)
+        );
+    }
+
+    /**
+     * Clear all selected ids and reset the search field.
+     */
+    public function clear(): void
+    {
+        $this->selectedIds = [];
+        $this->search = '';
+    }
+
+    /**
+     * Candidate options for the dropdown (excludes already-selected ids).
+     */
+    public function getOptionsProperty()
+    {
+        if ($this->staticOptions !== null) {
+            return $this->resolveStaticOptions()->filter(function ($option) {
+                $value = is_object($option) ? ($option->id ?? null) : ($option['id'] ?? null);
+
+                return ! in_array((string) $value, $this->selectedIds, true);
+            });
+        }
+
+        if ($this->modelClass) {
+            return $this->resolveOptionsQuery()
+                ->whereNotIn('id', $this->selectedIds)
+                ->get();
+        }
+
+        return collect();
+    }
+
+    /**
+     * Currently selected options — queried by id so we never store model instances
+     * in component state.
+     */
+    public function getSelectedOptionsProperty()
+    {
+        if (empty($this->selectedIds)) {
+            return collect();
+        }
+
+        if ($this->staticOptions !== null) {
+            return collect($this->staticOptions)->filter(function ($option) {
+                $value = is_object($option) ? ($option->id ?? null) : ($option['id'] ?? null);
+
+                return in_array((string) $value, $this->selectedIds, true);
+            });
+        }
+
+        if ($this->modelClass) {
+            return $this->modelClass::whereIn('id', $this->selectedIds)->get();
+        }
+
+        return collect();
+    }
+
+    public function render()
+    {
+        $colors = $this->entity ? config("app_entities.{$this->entity}.colors", []) : null;
+        $focusClasses = $colors
+            ? "focus:border-{$colors['base']} focus:ring-{$colors['base']}"
+            : 'focus:border-indigo-500 focus:ring-indigo-500';
+
+        return view('livewire.searchable-multi-select', [
+            'options' => $this->options,
+            'selectedOptions' => $this->selectedOptions,
+            'focusClasses' => $focusClasses,
+        ]);
+    }
+}

--- a/app/Livewire/SearchableSelect.php
+++ b/app/Livewire/SearchableSelect.php
@@ -2,18 +2,15 @@
 
 namespace App\Livewire;
 
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Str;
+use App\Livewire\Support\OptionsLookup;
 use InvalidArgumentException;
 use Livewire\Attributes\Modelable;
 use Livewire\Component;
 
-/**
- * Server-side searchable select component for both static and dynamic datasets
- * Handles both static options arrays and dynamic DB queries with Livewire
- */
 class SearchableSelect extends Component
 {
+    use OptionsLookup;
+
     #[Modelable]
     public $selectedId = '';
 
@@ -123,54 +120,12 @@ class SearchableSelect extends Component
     {
         // Static options mode: filter provided options
         if ($this->staticOptions !== null) {
-            $options = collect($this->staticOptions);
-
-            $search = trim($this->search);
-            if ($search !== '') {
-                $options = $options->filter(function ($option) use ($search) {
-                    $displayValue = is_object($option)
-                        ? ($option->{$this->displayField} ?? '')
-                        : ($option[$this->displayField] ?? '');
-
-                    return stripos($displayValue, $search) !== false;
-                });
-            }
-
-            return $options;
+            return $this->resolveStaticOptions();
         }
 
         // Dynamic DB query mode
         if ($this->modelClass) {
-            $query = $this->modelClass::query();
-
-            // Apply filter if provided
-            if ($this->filterColumn && $this->filterValue !== null) {
-                $this->applyFilter($query);
-            }
-
-            // Apply named scopes
-            if ($this->scopes) {
-                foreach ($this->scopes as $scopeEntry) {
-                    $query->{$scopeEntry['scope']}(...$scopeEntry['args']);
-                }
-            }
-
-            // Prefix-first search: prefix matches are ordered before infix matches
-            $search = trim($this->search);
-            if ($search !== '') {
-                $grammar = $query->getModel()->getConnection()->getQueryGrammar();
-                $wrappedColumn = $grammar->wrap($this->displayField);
-                $query->where($this->displayField, 'LIKE', "%{$search}%")
-                    ->orderByRaw(
-                        "CASE WHEN {$wrappedColumn} LIKE ? THEN 0 ELSE 1 END",
-                        ["{$search}%"]
-                    )
-                    ->orderBy($this->displayField);
-            } else {
-                $query->orderBy($this->displayField);
-            }
-
-            return $query->limit($this->perPage)->get();
+            return $this->resolveOptionsQuery()->get();
         }
 
         return collect();
@@ -201,81 +156,6 @@ class SearchableSelect extends Component
         }
 
         return null;
-    }
-
-    protected function applyFilter(Builder $query): void
-    {
-        match (strtoupper($this->filterOperator)) {
-            'IN' => $query->whereIn($this->filterColumn, (array) $this->filterValue),
-            'NOT IN' => $query->whereNotIn($this->filterColumn, (array) $this->filterValue),
-            default => $query->where($this->filterColumn, $this->filterOperator, $this->filterValue),
-        };
-    }
-
-    /**
-     * Normalise the $scopes mount parameter into the canonical
-     * array<int, array{scope: string, args: array}> shape.
-     *
-     * Accepted input shapes:
-     *   string                                    → single scope, no args
-     *   array<int, string>                        → multiple scopes, no args
-     *   array<int, array{scope: string, args: array}> → fully specified
-     *
-     * @throws InvalidArgumentException for non-alphanumeric names, unknown scopes, or non-serializable args
-     */
-    private function normalizeScopes(mixed $scopes, ?string $modelClass): array
-    {
-        if (is_string($scopes)) {
-            $scopes = [$scopes];
-        }
-
-        if (! is_array($scopes)) {
-            throw new InvalidArgumentException('The scopes parameter must be a string or an array.');
-        }
-
-        $normalized = [];
-
-        foreach ($scopes as $scope) {
-            if (is_string($scope)) {
-                $this->validateScopeName($scope, $modelClass);
-                $normalized[] = ['scope' => $scope, 'args' => []];
-            } elseif (is_array($scope) && array_key_exists('scope', $scope)) {
-                $this->validateScopeName($scope['scope'], $modelClass);
-                $args = $scope['args'] ?? [];
-                $this->validateScopeArgs($args);
-                $normalized[] = ['scope' => $scope['scope'], 'args' => array_values((array) $args)];
-            } else {
-                throw new InvalidArgumentException('Each scope must be a string or an array with a "scope" key.');
-            }
-        }
-
-        return $normalized;
-    }
-
-    private function validateScopeName(string $name, ?string $modelClass): void
-    {
-        if (! preg_match('/^[a-zA-Z0-9]+$/', $name)) {
-            throw new InvalidArgumentException(
-                "Scope name '{$name}' contains non-alphanumeric characters. Only alphanumeric scope names are allowed."
-            );
-        }
-
-        if ($modelClass !== null && ! method_exists($modelClass, 'scope'.Str::studly($name))) {
-            throw new InvalidArgumentException(
-                "Scope '{$name}' does not exist on model {$modelClass}."
-            );
-        }
-    }
-
-    private function validateScopeArgs(mixed $args): void
-    {
-        foreach ((array) $args as $arg) {
-            if (! is_scalar($arg) && ! is_null($arg) && ! is_array($arg)) {
-                throw new InvalidArgumentException(
-                    'Scope arguments must be scalars, arrays, or null. Objects (including Eloquent models) are not allowed in component state.'
-                );
-            }
-        }
     }
 
     public function render()

--- a/app/Livewire/SearchableSelect.php
+++ b/app/Livewire/SearchableSelect.php
@@ -3,6 +3,8 @@
 namespace App\Livewire;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Livewire\Attributes\Modelable;
 use Livewire\Component;
 
@@ -44,6 +46,10 @@ class SearchableSelect extends Component
 
     public $filterValue = null; // Optional: value(s) to filter (e.g., '123' or ['123', '456'])
 
+    public $scopes = null; // Optional: named Eloquent scope(s) applied to dynamic queries
+
+    public int $perPage = 50; // Maximum options returned by a dynamic query
+
     protected $queryString = [
         'search' => ['except' => ''],
     ];
@@ -61,7 +67,9 @@ class SearchableSelect extends Component
         bool $required = false,
         ?string $filterColumn = null,
         ?string $filterOperator = '!=',
-        $filterValue = null
+        $filterValue = null,
+        $scopes = null,
+        ?int $perPage = null
     ): void {
         $this->selectedId = old($name, $selectedId);
         $this->name = $name;
@@ -76,6 +84,21 @@ class SearchableSelect extends Component
         $this->filterColumn = $filterColumn;
         $this->filterOperator = $filterOperator;
         $this->filterValue = $filterValue;
+        $this->perPage = $perPage ?? (int) config('interface.searchable_select.per_page', 50);
+
+        if ($scopes !== null) {
+            $this->scopes = $this->normalizeScopes($scopes, $this->modelClass);
+        }
+
+        if ($this->staticOptions !== null) {
+            $count = count(collect($this->staticOptions));
+            $max = (int) config('interface.searchable_select.static_options_max', 50);
+            if ($count > $max) {
+                throw new InvalidArgumentException(
+                    "SearchableSelect received {$count} staticOptions but the configured maximum is {$max}. Use dynamic mode (modelClass + scope) for growable entities."
+                );
+            }
+        }
     }
 
     public function updatedSearch(): void
@@ -125,13 +148,29 @@ class SearchableSelect extends Component
                 $this->applyFilter($query);
             }
 
-            // Apply search
-            $search = trim($this->search);
-            if ($search !== '') {
-                $query->where($this->displayField, 'LIKE', "%{$search}%");
+            // Apply named scopes
+            if ($this->scopes) {
+                foreach ($this->scopes as $scopeEntry) {
+                    $query->{$scopeEntry['scope']}(...$scopeEntry['args']);
+                }
             }
 
-            return $query->orderBy($this->displayField)->limit(50)->get();
+            // Prefix-first search: prefix matches are ordered before infix matches
+            $search = trim($this->search);
+            if ($search !== '') {
+                $grammar = $query->getModel()->getConnection()->getQueryGrammar();
+                $wrappedColumn = $grammar->wrap($this->displayField);
+                $query->where($this->displayField, 'LIKE', "%{$search}%")
+                    ->orderByRaw(
+                        "CASE WHEN {$wrappedColumn} LIKE ? THEN 0 ELSE 1 END",
+                        ["{$search}%"]
+                    )
+                    ->orderBy($this->displayField);
+            } else {
+                $query->orderBy($this->displayField);
+            }
+
+            return $query->limit($this->perPage)->get();
         }
 
         return collect();
@@ -171,6 +210,72 @@ class SearchableSelect extends Component
             'NOT IN' => $query->whereNotIn($this->filterColumn, (array) $this->filterValue),
             default => $query->where($this->filterColumn, $this->filterOperator, $this->filterValue),
         };
+    }
+
+    /**
+     * Normalise the $scopes mount parameter into the canonical
+     * array<int, array{scope: string, args: array}> shape.
+     *
+     * Accepted input shapes:
+     *   string                                    → single scope, no args
+     *   array<int, string>                        → multiple scopes, no args
+     *   array<int, array{scope: string, args: array}> → fully specified
+     *
+     * @throws InvalidArgumentException for non-alphanumeric names, unknown scopes, or non-serializable args
+     */
+    private function normalizeScopes(mixed $scopes, ?string $modelClass): array
+    {
+        if (is_string($scopes)) {
+            $scopes = [$scopes];
+        }
+
+        if (! is_array($scopes)) {
+            throw new InvalidArgumentException('The scopes parameter must be a string or an array.');
+        }
+
+        $normalized = [];
+
+        foreach ($scopes as $scope) {
+            if (is_string($scope)) {
+                $this->validateScopeName($scope, $modelClass);
+                $normalized[] = ['scope' => $scope, 'args' => []];
+            } elseif (is_array($scope) && array_key_exists('scope', $scope)) {
+                $this->validateScopeName($scope['scope'], $modelClass);
+                $args = $scope['args'] ?? [];
+                $this->validateScopeArgs($args);
+                $normalized[] = ['scope' => $scope['scope'], 'args' => array_values((array) $args)];
+            } else {
+                throw new InvalidArgumentException('Each scope must be a string or an array with a "scope" key.');
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function validateScopeName(string $name, ?string $modelClass): void
+    {
+        if (! preg_match('/^[a-zA-Z0-9]+$/', $name)) {
+            throw new InvalidArgumentException(
+                "Scope name '{$name}' contains non-alphanumeric characters. Only alphanumeric scope names are allowed."
+            );
+        }
+
+        if ($modelClass !== null && ! method_exists($modelClass, 'scope'.Str::studly($name))) {
+            throw new InvalidArgumentException(
+                "Scope '{$name}' does not exist on model {$modelClass}."
+            );
+        }
+    }
+
+    private function validateScopeArgs(mixed $args): void
+    {
+        foreach ((array) $args as $arg) {
+            if (! is_scalar($arg) && ! is_null($arg) && ! is_array($arg)) {
+                throw new InvalidArgumentException(
+                    'Scope arguments must be scalars, arrays, or null. Objects (including Eloquent models) are not allowed in component state.'
+                );
+            }
+        }
     }
 
     public function render()

--- a/app/Livewire/Support/OptionsLookup.php
+++ b/app/Livewire/Support/OptionsLookup.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App\Livewire\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+/**
+ * Shared query-composition trait for Livewire option-picker components.
+ *
+ * Consumed by SearchableSelect and SearchableMultiSelect to ensure both
+ * components query candidates identically (prefix-first search, scope
+ * composition, ceiling guard, filter application).
+ *
+ * The trait is pure query composition — it does not use any Livewire
+ * lifecycle method, and must not introduce constructor-bound dependencies.
+ * It reads configuration and state from the consuming component's public
+ * properties ($modelClass, $displayField, $perPage, $scopes, $search,
+ * $staticOptions, $filterColumn, $filterOperator, $filterValue).
+ */
+trait OptionsLookup
+{
+    /**
+     * Build and return the Eloquent query builder for dynamic mode.
+     *
+     * Applies the optional filter column, named scopes, and prefix-first
+     * LIKE search, then limits the result set to $perPage rows. The caller
+     * is responsible for calling ->get() on the returned builder.
+     */
+    public function resolveOptionsQuery(): Builder
+    {
+        $query = $this->modelClass::query();
+
+        if ($this->filterColumn && $this->filterValue !== null) {
+            $this->applyFilter($query);
+        }
+
+        $query = $this->applyScopes($query);
+
+        $search = trim($this->search);
+        $query = $this->applySearch($query, $search);
+
+        return $query->limit($this->perPage);
+    }
+
+    /**
+     * Apply named Eloquent scopes to the given query.
+     *
+     * Iterates over the normalised $scopes array (array<int, array{scope: string, args: array}>)
+     * and calls each scope method on the query, forwarding any args.
+     */
+    public function applyScopes(Builder $query): Builder
+    {
+        if ($this->scopes) {
+            foreach ($this->scopes as $scopeEntry) {
+                $query->{$scopeEntry['scope']}(...$scopeEntry['args']);
+            }
+        }
+
+        return $query;
+    }
+
+    /**
+     * Apply prefix-first LIKE search ordering to the query.
+     *
+     * When $search is non-empty:
+     *   - WHERE displayField LIKE %search%
+     *   - ORDER BY prefix-match first (CASE WHEN ... LIKE 'search%' THEN 0 ELSE 1 END)
+     *   - Secondary ORDER BY displayField ASC
+     * When $search is empty:
+     *   - ORDER BY displayField ASC only
+     */
+    public function applySearch(Builder $query, string $search): Builder
+    {
+        if ($search !== '') {
+            $grammar = $query->getModel()->getConnection()->getQueryGrammar();
+            $wrappedColumn = $grammar->wrap($this->displayField);
+            $query->where($this->displayField, 'LIKE', "%{$search}%")
+                ->orderByRaw(
+                    "CASE WHEN {$wrappedColumn} LIKE ? THEN 0 ELSE 1 END",
+                    ["{$search}%"]
+                )
+                ->orderBy($this->displayField);
+        } else {
+            $query->orderBy($this->displayField);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Filter and return the static options collection based on the current search term.
+     *
+     * Performs a case-insensitive substring match against displayField.
+     * No database queries are issued.
+     */
+    public function resolveStaticOptions(): Collection
+    {
+        $options = collect($this->staticOptions);
+
+        $search = trim($this->search);
+        if ($search !== '') {
+            $options = $options->filter(function ($option) use ($search) {
+                $displayValue = is_object($option)
+                    ? ($option->{$this->displayField} ?? '')
+                    : ($option[$this->displayField] ?? '');
+
+                return stripos($displayValue, $search) !== false;
+            });
+        }
+
+        return $options;
+    }
+
+    /**
+     * Apply the filter column/operator/value constraint to the query.
+     *
+     * Supports IN, NOT IN, and any standard comparison operator.
+     */
+    protected function applyFilter(Builder $query): void
+    {
+        match (strtoupper($this->filterOperator)) {
+            'IN' => $query->whereIn($this->filterColumn, (array) $this->filterValue),
+            'NOT IN' => $query->whereNotIn($this->filterColumn, (array) $this->filterValue),
+            default => $query->where($this->filterColumn, $this->filterOperator, $this->filterValue),
+        };
+    }
+
+    /**
+     * Normalise the $scopes mount parameter into the canonical
+     * array<int, array{scope: string, args: array}> shape.
+     *
+     * Accepted input shapes:
+     *   string                                         → single scope, no args
+     *   array<int, string>                             → multiple scopes, no args
+     *   array<int, array{scope: string, args: array}>  → fully specified
+     *
+     * @throws InvalidArgumentException for non-alphanumeric names, unknown scopes, or non-serializable args
+     */
+    protected function normalizeScopes(mixed $scopes, ?string $modelClass): array
+    {
+        if (is_string($scopes)) {
+            $scopes = [$scopes];
+        }
+
+        if (! is_array($scopes)) {
+            throw new InvalidArgumentException('The scopes parameter must be a string or an array.');
+        }
+
+        $normalized = [];
+
+        foreach ($scopes as $scope) {
+            if (is_string($scope)) {
+                $this->validateScopeName($scope, $modelClass);
+                $normalized[] = ['scope' => $scope, 'args' => []];
+            } elseif (is_array($scope) && array_key_exists('scope', $scope)) {
+                $this->validateScopeName($scope['scope'], $modelClass);
+                $args = $scope['args'] ?? [];
+                $this->validateScopeArgs($args);
+                $normalized[] = ['scope' => $scope['scope'], 'args' => array_values((array) $args)];
+            } else {
+                throw new InvalidArgumentException('Each scope must be a string or an array with a "scope" key.');
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function validateScopeName(string $name, ?string $modelClass): void
+    {
+        if (! preg_match('/^[a-zA-Z0-9]+$/', $name)) {
+            throw new InvalidArgumentException(
+                "Scope name '{$name}' contains non-alphanumeric characters. Only alphanumeric scope names are allowed."
+            );
+        }
+
+        if ($modelClass !== null && ! method_exists($modelClass, 'scope'.Str::studly($name))) {
+            throw new InvalidArgumentException(
+                "Scope '{$name}' does not exist on model {$modelClass}."
+            );
+        }
+    }
+
+    private function validateScopeArgs(mixed $args): void
+    {
+        foreach ((array) $args as $arg) {
+            if (! is_scalar($arg) && ! is_null($arg) && ! is_array($arg)) {
+                throw new InvalidArgumentException(
+                    'Scope arguments must be scalars, arrays, or null. Objects (including Eloquent models) are not allowed in component state.'
+                );
+            }
+        }
+    }
+}

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -370,4 +370,78 @@ class Collection extends Model
     {
         $this->attachedItems()->detach($itemIds);
     }
+
+    /**
+     * Scope to exclude collections with the given IDs.
+     *
+     * @param  array<int, string>  $ids
+     */
+    public function scopeExcludingIds(Builder $query, array $ids): Builder
+    {
+        return empty($ids) ? $query : $query->whereNotIn('id', $ids);
+    }
+
+    /**
+     * Scope to exclude the given collection and all its transitive descendants.
+     * Prevents circular hierarchies when selecting a parent collection.
+     * Hard-caps traversal at 10 levels.
+     *
+     * @param  string  $collectionId  UUID of the collection whose descendants to exclude
+     */
+    public function scopeExcludingDescendantsOf(Builder $query, string $collectionId): Builder
+    {
+        $maxDepth = 10;
+        $excludeIds = [$collectionId];
+        $currentLevel = [$collectionId];
+
+        for ($depth = 0; $depth < $maxDepth; $depth++) {
+            $nextLevel = static::whereIn('parent_id', $currentLevel)->pluck('id')->all();
+            if (empty($nextLevel)) {
+                break;
+            }
+            $excludeIds = array_merge($excludeIds, $nextLevel);
+            $currentLevel = $nextLevel;
+
+            if ($depth + 1 >= $maxDepth) {
+                $hasMore = static::whereIn('parent_id', $currentLevel)->exists();
+                if ($hasMore) {
+                    throw new \RuntimeException('Collection hierarchy depth exceeds maximum of '.$maxDepth.' levels.');
+                }
+            }
+        }
+
+        return $query->whereNotIn('id', $excludeIds);
+    }
+
+    /**
+     * Scope to exclude the given collection and all its transitive ancestors.
+     * Prevents an ancestor from being set as a child of the collection.
+     * Hard-caps traversal at 10 levels.
+     *
+     * @param  string  $collectionId  UUID of the collection whose ancestors to exclude
+     */
+    public function scopeExcludingAncestorsOf(Builder $query, string $collectionId): Builder
+    {
+        $maxDepth = 10;
+        $excludeIds = [$collectionId];
+        $currentId = $collectionId;
+
+        for ($depth = 0; $depth < $maxDepth; $depth++) {
+            $parentId = static::where('id', $currentId)->value('parent_id');
+            if ($parentId === null) {
+                break;
+            }
+            $excludeIds[] = $parentId;
+            $currentId = $parentId;
+
+            if ($depth + 1 >= $maxDepth) {
+                $hasMore = static::where('id', $currentId)->whereNotNull('parent_id')->exists();
+                if ($hasMore) {
+                    throw new \RuntimeException('Collection hierarchy depth exceeds maximum of '.$maxDepth.' levels.');
+                }
+            }
+        }
+
+        return $query->whereNotIn('id', $excludeIds);
+    }
 }

--- a/app/Models/Context.php
+++ b/app/Models/Context.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -82,5 +83,15 @@ class Context extends Model
             // Set all rows' 'default' column to false (or 0)
             self::query()->update(['is_default' => false]);
         });
+    }
+
+    /**
+     * Scope to exclude contexts with the given IDs.
+     *
+     * @param  array<int, string>  $ids
+     */
+    public function scopeExcludingIds(Builder $query, array $ids): Builder
+    {
+        return empty($ids) ? $query : $query->whereNotIn('id', $ids);
     }
 }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -442,4 +442,78 @@ class Item extends Model
     {
         $this->attributes['mwnf_reference'] = $value === '' ? null : $value;
     }
+
+    /**
+     * Scope to exclude items with the given IDs.
+     *
+     * @param  array<int, string>  $ids
+     */
+    public function scopeExcludingIds(Builder $query, array $ids): Builder
+    {
+        return empty($ids) ? $query : $query->whereNotIn('id', $ids);
+    }
+
+    /**
+     * Scope to exclude the given item and all its transitive descendants.
+     * Prevents a descendant from being set as the item's own parent.
+     * Hard-caps traversal at 10 levels.
+     *
+     * @param  string  $itemId  UUID of the item whose descendants to exclude
+     */
+    public function scopeExcludingDescendantsOf(Builder $query, string $itemId): Builder
+    {
+        $maxDepth = 10;
+        $excludeIds = [$itemId];
+        $currentLevel = [$itemId];
+
+        for ($depth = 0; $depth < $maxDepth; $depth++) {
+            $nextLevel = static::whereIn('parent_id', $currentLevel)->pluck('id')->all();
+            if (empty($nextLevel)) {
+                break;
+            }
+            $excludeIds = array_merge($excludeIds, $nextLevel);
+            $currentLevel = $nextLevel;
+
+            if ($depth + 1 >= $maxDepth) {
+                $hasMore = static::whereIn('parent_id', $currentLevel)->exists();
+                if ($hasMore) {
+                    throw new \RuntimeException('Item hierarchy depth exceeds maximum of '.$maxDepth.' levels.');
+                }
+            }
+        }
+
+        return $query->whereNotIn('id', $excludeIds);
+    }
+
+    /**
+     * Scope to exclude the given item and all its transitive ancestors.
+     * Prevents an ancestor from being set as a child of the item.
+     * Hard-caps traversal at 10 levels.
+     *
+     * @param  string  $itemId  UUID of the item whose ancestors to exclude
+     */
+    public function scopeExcludingAncestorsOf(Builder $query, string $itemId): Builder
+    {
+        $maxDepth = 10;
+        $excludeIds = [$itemId];
+        $currentId = $itemId;
+
+        for ($depth = 0; $depth < $maxDepth; $depth++) {
+            $parentId = static::where('id', $currentId)->value('parent_id');
+            if ($parentId === null) {
+                break;
+            }
+            $excludeIds[] = $parentId;
+            $currentId = $parentId;
+
+            if ($depth + 1 >= $maxDepth) {
+                $hasMore = static::where('id', $currentId)->whereNotNull('parent_id')->exists();
+                if ($hasMore) {
+                    throw new \RuntimeException('Item hierarchy depth exceeds maximum of '.$maxDepth.' levels.');
+                }
+            }
+        }
+
+        return $query->whereNotIn('id', $excludeIds);
+    }
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -85,6 +85,16 @@ class Tag extends Model
     }
 
     /**
+     * Scope to exclude tags already attached to the given item.
+     *
+     * @param  string  $itemId  UUID of the item to check attachment against
+     */
+    public function scopeNotAttachedTo(Builder $query, string $itemId): Builder
+    {
+        return $query->whereDoesntHave('items', fn (Builder $q) => $q->whereKey($itemId));
+    }
+
+    /**
      * Get the columns that should automatically receive a unique identifier.
      *
      * @return array<int, string>

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,7 +12,9 @@ use App\Listeners\DispatchSyncSpellingToCollectionTranslations;
 use App\Listeners\DispatchSyncSpellingToItemTranslations;
 use App\Listeners\DispatchSyncSpellingToTimelineEventTranslations;
 use App\Listeners\DispatchSyncTimelineEventTranslationSpellings;
+use App\Services\Settings;
 use App\Support\Documentation\RuleTransformers\IncludeRuleTransformer;
+use App\View\Composers\SettingsComposer;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
@@ -28,7 +30,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(Settings::class);
     }
 
     /**
@@ -43,6 +45,12 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(SpellingSaved::class, DispatchSyncSpellingToItemTranslations::class);
         Event::listen(SpellingSaved::class, DispatchSyncSpellingToCollectionTranslations::class);
         Event::listen(SpellingSaved::class, DispatchSyncSpellingToTimelineEventTranslations::class);
+
+        // Inject settings (e.g. self_registration_enabled) into shared layouts
+        View::composer(
+            ['components.app-nav', 'auth.login', 'navigation-menu', 'welcome'],
+            SettingsComposer::class
+        );
 
         // Share entity color config helper across views
         View::share('entityColor', function (string $entity): array {

--- a/app/Services/Settings.php
+++ b/app/Services/Settings.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Setting;
+
+class Settings
+{
+    private ?bool $selfRegistrationEnabled = null;
+
+    public function selfRegistrationEnabled(): bool
+    {
+        if ($this->selfRegistrationEnabled === null) {
+            $this->selfRegistrationEnabled = (bool) Setting::get('self_registration_enabled', false);
+        }
+
+        return $this->selfRegistrationEnabled;
+    }
+}

--- a/app/Services/Web/CollectionShowPageData.php
+++ b/app/Services/Web/CollectionShowPageData.php
@@ -3,7 +3,6 @@
 namespace App\Services\Web;
 
 use App\Models\Collection;
-use App\Models\Item;
 
 class CollectionShowPageData
 {
@@ -35,20 +34,12 @@ class CollectionShowPageData
                 ],
                 'items' => [
                     'items' => $collection->attachedItems->values(),
-                    'attachableItems' => Item::query()
-                        ->whereNotIn('id', $collection->attachedItems->pluck('id'))
-                        ->orderBy('internal_name')
-                        ->get(),
                 ],
                 'translations' => [
                     'groups' => $this->translationSectionData->build($collection->translations),
                 ],
                 'parent' => [
                     'collection' => $collection->parent,
-                    'options' => Collection::query()
-                        ->whereKeyNot($collection->id)
-                        ->orderBy('internal_name')
-                        ->get(),
                 ],
                 'system' => [
                     'id' => $collection->id,

--- a/app/Services/Web/ItemShowPageData.php
+++ b/app/Services/Web/ItemShowPageData.php
@@ -3,10 +3,7 @@
 namespace App\Services\Web;
 
 use App\Enums\ItemType;
-use App\Models\Context;
 use App\Models\Item;
-use App\Models\Tag;
-use App\Support\Web\TagPresentation;
 use Illuminate\Support\Collection;
 
 class ItemShowPageData
@@ -36,11 +33,6 @@ class ItemShowPageData
             'incomingLinks.context',
         ]);
 
-        $relatableItems = Item::query()
-            ->whereKeyNot($item->id)
-            ->orderBy('internal_name')
-            ->get();
-
         $pictureChildren = $item->children
             ->filter(fn (Item $child): bool => $child->type === ItemType::PICTURE)
             ->values();
@@ -62,32 +54,15 @@ class ItemShowPageData
                 ],
                 'parent' => [
                     'item' => $item->parent,
-                    'options' => $relatableItems,
                 ],
                 'children' => [
                     'items' => $structuralChildren,
-                    'options' => $relatableItems
-                        ->whereNotIn('id', $item->children->pluck('id'))
-                        ->values(),
                 ],
                 'tags' => [
                     'items' => $item->tags->values(),
-                    'availableTags' => Tag::query()
-                        ->whereDoesntHave('items', fn ($query) => $query->where('items.id', $item->id))
-                        ->orderBy('internal_name')
-                        ->get()
-                        ->map(function (Tag $tag): Tag {
-                            $tag->setAttribute('display_label', TagPresentation::label($tag));
-
-                            return $tag;
-                        })
-                        ->sortBy('display_label')
-                        ->values(),
                 ],
                 'links' => [
                     'formatted' => $this->buildFormattedLinks($item),
-                    'contextOptions' => Context::query()->orderBy('internal_name')->get(),
-                    'targetOptions' => $relatableItems,
                 ],
                 'system' => [
                     'id' => $item->id,

--- a/app/Services/Web/PartnerIndexQuery.php
+++ b/app/Services/Web/PartnerIndexQuery.php
@@ -27,6 +27,7 @@ final class PartnerIndexQuery
             ->with($this->mapEagerLoads());
 
         $this->applySearch($query, $state->search);
+        $this->applyFilters($query, $state);
         $this->applySort($query, $state);
 
         return $query
@@ -37,6 +38,15 @@ final class PartnerIndexQuery
     private function applySearch(Builder $query, ?string $search): void
     {
         $this->definition->applySearch($query, $search);
+    }
+
+    private function applyFilters(Builder $query, ListState $state): void
+    {
+        $filters = $state->filters;
+
+        if (isset($filters['country_id'])) {
+            $query->where('partners.country_id', $filters['country_id']);
+        }
     }
 
     private function applySort(Builder $query, ListState $state): void

--- a/app/Services/Web/PartnerShowPageData.php
+++ b/app/Services/Web/PartnerShowPageData.php
@@ -2,7 +2,6 @@
 
 namespace App\Services\Web;
 
-use App\Models\Item;
 use App\Models\Partner;
 
 class PartnerShowPageData
@@ -33,10 +32,6 @@ class PartnerShowPageData
                 ],
                 'monument' => [
                     'item' => $partner->monumentItem,
-                    'options' => Item::query()
-                        ->monuments()
-                        ->orderBy('internal_name')
-                        ->get(),
                 ],
                 'system' => [
                     'id' => $partner->id,

--- a/app/Support/Web/Lists/PartnerListDefinition.php
+++ b/app/Support/Web/Lists/PartnerListDefinition.php
@@ -6,12 +6,14 @@ final class PartnerListDefinition extends ListDefinition
 {
     public function filterParameters(): array
     {
-        return [];
+        return ['country_id'];
     }
 
     public function filterRules(): array
     {
-        return [];
+        return [
+            'country_id' => ['sometimes', 'nullable', 'string', 'size:3', 'exists:countries,id'],
+        ];
     }
 
     public function sorts(): array
@@ -31,5 +33,23 @@ final class PartnerListDefinition extends ListDefinition
     public function eagerLoads(): array
     {
         return ['country'];
+    }
+
+    public function normalizeFilters(array $input): array
+    {
+        return array_filter([
+            'country_id' => $this->normalizeNullableString($input['country_id'] ?? null),
+        ], static fn (mixed $value): bool => $value !== null && $value !== []);
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
     }
 }

--- a/app/View/Composers/SettingsComposer.php
+++ b/app/View/Composers/SettingsComposer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\View\Composers;
+
+use App\Services\Settings;
+use Illuminate\View\View;
+
+class SettingsComposer
+{
+    public function __construct(private readonly Settings $settings)
+    {
+        //
+    }
+
+    public function compose(View $view): void
+    {
+        $view->with('selfRegistrationEnabled', $this->settings->selfRegistrationEnabled());
+    }
+}

--- a/config/app_entities.php
+++ b/config/app_entities.php
@@ -30,6 +30,7 @@ return [
             'base' => 'teal-500',
             'bg' => 'bg-teal-50',
             'text' => 'text-teal-600',
+            'border' => 'border-teal-200',
         ],
         'yellow' => [
             'button' => 'bg-yellow-600 hover:bg-yellow-700 text-white',
@@ -41,6 +42,7 @@ return [
             'base' => 'yellow-500',
             'bg' => 'bg-yellow-50',
             'text' => 'text-yellow-600',
+            'border' => 'border-yellow-200',
         ],
         'indigo' => [
             'button' => 'bg-indigo-600 hover:bg-indigo-700 text-white',
@@ -52,6 +54,7 @@ return [
             'base' => 'indigo-500',
             'bg' => 'bg-indigo-50',
             'text' => 'text-indigo-600',
+            'border' => 'border-indigo-200',
         ],
         'fuchsia' => [
             'button' => 'bg-fuchsia-600 hover:bg-fuchsia-700 text-white',
@@ -63,6 +66,7 @@ return [
             'base' => 'fuchsia-500',
             'bg' => 'bg-fuchsia-50',
             'text' => 'text-fuchsia-600',
+            'border' => 'border-fuchsia-200',
         ],
         'emerald' => [
             'button' => 'bg-emerald-600 hover:bg-emerald-700 text-white',
@@ -74,6 +78,7 @@ return [
             'base' => 'emerald-500',
             'bg' => 'bg-emerald-50',
             'text' => 'text-emerald-600',
+            'border' => 'border-emerald-200',
         ],
     ],
 ];

--- a/config/interface.php
+++ b/config/interface.php
@@ -37,4 +37,24 @@ return [
         'max_per_page' => env('WEB_MAX_PER_PAGE', 100),
         'per_page_options' => [10, 20, 25, 50, 100],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | SearchableSelect Component Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Controls the behaviour of the App\Livewire\SearchableSelect component.
+    |
+    | static_options_max — Maximum number of items accepted via staticOptions.
+    |   Exceeding this ceiling causes mount() to throw InvalidArgumentException,
+    |   forcing the caller to switch to dynamic mode (modelClass + scope).
+    |
+    | per_page — Default number of options returned by a dynamic DB query.
+    |   Callers may override per request via the perPage prop.
+    |
+    */
+    'searchable_select' => [
+        'static_options_max' => env('SEARCHABLE_SELECT_STATIC_OPTIONS_MAX', 50),
+        'per_page' => env('SEARCHABLE_SELECT_PER_PAGE', 50),
+    ],
 ];

--- a/docs/frontend-blade/livewire/index.md
+++ b/docs/frontend-blade/livewire/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Livewire
 nav_order: 2
 parent: Blade/Livewire Frontend
-has_children: false
+has_children: true
 ---
 
 # Livewire Component Patterns

--- a/docs/frontend-blade/livewire/searchable-multi-select.md
+++ b/docs/frontend-blade/livewire/searchable-multi-select.md
@@ -1,0 +1,100 @@
+---
+layout: default
+title: Searchable Multi-Select
+nav_order: 2
+parent: Livewire
+grand_parent: Blade/Livewire Frontend
+---
+
+# Searchable Multi-Select
+
+The `SearchableMultiSelect` Livewire component is the multi-value counterpart of `SearchableSelect`. It renders a chip for each selected option and a live-search combobox for picking additional candidates.
+
+## When to Use
+
+| Scenario                                                            | Component               |
+| ------------------------------------------------------------------- | ----------------------- |
+| Single-value relationship picker (parent item, default language, …) | `SearchableSelect`      |
+| Multi-value filter on an index page (tags, countries, …)            | `SearchableMultiSelect` |
+| Multi-value relationship (item links, gallery images, …)            | `SearchableMultiSelect` |
+
+Use `SearchableMultiSelect` whenever the user selects **zero or more** values from a potentially large list.
+
+## How It Works
+
+- **Chip rendering** — selected options appear as dismissable chips above the search input.
+- **Live search** — candidates are fetched server-side as the user types, using prefix-first ordering.
+- **Scope composition** — the same named-scope support as `SearchableSelect` lets you narrow candidates (e.g., show only enabled projects, or tags of a specific category).
+- **Hidden inputs** — the component emits one `name[]` hidden input per selected id so that standard HTML form submission round-trips through the existing `IndexListRequest` filter resolution without any changes.
+- **No Eloquent in state** — selected ids are stored as a plain string array. The `selectedOptions` collection is resolved on-demand from the selected ids; no Eloquent model instances are held in the Livewire snapshot.
+
+## Blade Wrapper Props
+
+| Prop                | Type                  | Default               | Description                                                                                                                                                                    |
+| ------------------- | --------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`              | `string`              | `''`                  | Field name; controls the `name[]` hidden inputs.                                                                                                                               |
+| `label`             | `string`              | `''`                  | Optional visible label rendered above the component.                                                                                                                           |
+| `selectedOptions`   | `Collection\|null`    | `null`                | **Caller responsibility** — pre-load only the currently selected rows from the database (bounded by selection count). Used to derive `selectedIds` for initial chip rendering. |
+| `displayField`      | `string`              | `internal_name`       | Model attribute to display in chips and the dropdown.                                                                                                                          |
+| `placeholder`       | `string`              | `'Select...'`         | Placeholder shown when no options are selected.                                                                                                                                |
+| `searchPlaceholder` | `string`              | `'Type to search...'` | Placeholder inside the search input.                                                                                                                                           |
+| `entity`            | `string\|null`        | `null`                | Entity color key (e.g., `'items'`, `'tags'`) for Tailwind focus ring theming.                                                                                                  |
+| `modelClass`        | `string\|null`        | `null`                | Fully-qualified model class for dynamic mode.                                                                                                                                  |
+| `scopes`            | `string\|array\|null` | `null`                | Named Eloquent scope(s) to narrow candidates (see [SearchableSelect scopes](/frontend-blade/livewire/searchable-select)).                                                      |
+| `perPage`           | `int\|null`           | `null`                | Max candidates per search request (defaults to `interface.searchable_select.per_page`).                                                                                        |
+| `options`           | `array\|null`         | `null`                | Static options array for small bounded enums. Do **not** use for growable entities.                                                                                            |
+| `filterColumn`      | `string\|null`        | `null`                | Optional column to apply an additional WHERE filter.                                                                                                                           |
+| `filterOperator`    | `string`              | `'!='`                | Operator for the filter column (`!=`, `IN`, `NOT IN`, etc.).                                                                                                                   |
+| `filterValue`       | `mixed`               | `null`                | Value for the filter column.                                                                                                                                                   |
+
+## `selectedOptions` Contract
+
+The `selectedOptions` prop is a pre-loaded collection supplied by the **caller** (controller or Blade view). It is used only to derive the initial set of selected ids and is never serialized into the Livewire component state. After mount, the component resolves chip labels itself by querying `whereIn('id', $selectedIds)`.
+
+The caller is responsible for keeping `selectedOptions` bounded: query only the rows whose ids are in the current filter/form value. For an index-page tag filter with three selected tags, load those three tag models — not the entire tags table.
+
+## Canonical Usage: Filter Bar (Tags on Items Index)
+
+```blade
+{{-- In the filter bar partial of items/index.blade.php --}}
+<x-form.searchable-multi-select
+    name="filter[tag_ids]"
+    label="Tags"
+    :modelClass="\App\Models\Tag::class"
+    displayField="internal_name"
+    entity="tags"
+    :selectedOptions="$listState->filterValue('tag_ids')
+        ? \App\Models\Tag::whereIn('id', $listState->filterValue('tag_ids'))->get()
+        : collect()"
+    placeholder="Filter by tag..."
+/>
+```
+
+The hidden inputs submitted will be `filter[tag_ids][]`, which `IndexListRequest` resolves to an array of ids — no changes to the request pipeline required.
+
+## Canonical Usage: Form Multi-Picker
+
+```blade
+{{-- In a _form.blade.php where $item->tags is the current relationship --}}
+<x-form.searchable-multi-select
+    name="tag_ids"
+    label="Tags"
+    :modelClass="\App\Models\Tag::class"
+    displayField="internal_name"
+    entity="tags"
+    :selectedOptions="$item->tags"
+    placeholder="Add a tag..."
+/>
+```
+
+The controller reads `$request->input('tag_ids', [])` and passes it to `$item->tags()->sync(...)`.
+
+## Shared Query Engine
+
+`SearchableMultiSelect` delegates all query composition to the `App\Livewire\Support\OptionsLookup` trait, the same trait used by `SearchableSelect`. This ensures prefix-first ordering, named-scope support, filter-column application, and the `perPage` ceiling are identical between the two components.
+
+## Notes
+
+- Duplicate `addOption` calls for the same id are silently ignored.
+- Already-selected ids are excluded from the candidate dropdown so the user cannot select the same option twice.
+- `clear()` resets all selected ids and the search field in a single action.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "inventory-app",
-    "version": "6.13.0",
+    "version": "6.13.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "inventory-app",
-            "version": "6.13.0",
+            "version": "6.13.1",
             "dependencies": {
                 "glob": "^13.0.6"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "inventory-app",
-    "version": "6.13.0",
+    "version": "6.13.1",
     "private": true,
     "type": "module",
     "scripts": {

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -45,7 +45,7 @@
             </div>
         </form>
 
-        @if (Route::has('register') && \App\Models\Setting::get('self_registration_enabled', false))
+        @if (Route::has('register') && $selfRegistrationEnabled)
             <div class="mt-4 text-center text-sm text-gray-600">
                 {{ __("Don't have an account?") }}
                 <a href="{{ route('register') }}" class="underline hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">

--- a/resources/views/collection-translations/index.blade.php
+++ b/resources/views/collection-translations/index.blade.php
@@ -34,23 +34,27 @@
                     <input type="hidden" name="collection_id" value="{{ $listState->filters['collection_id'] }}">
 
                     <div class="w-full md:w-52">
-                        <label for="language" class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Language</label>
-                        <select id="language" name="language" class="block w-full rounded-md border-gray-300 text-sm focus:border-yellow-500 focus:ring-yellow-500">
-                            <option value="">All languages</option>
-                            @foreach($languages as $lang)
-                                <option value="{{ $lang->id }}" @selected(($listState->filters['language'] ?? null) === $lang->id)>{{ $lang->internal_name }}</option>
-                            @endforeach
-                        </select>
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Language</label>
+                        <x-form.entity-select
+                            name="language"
+                            :modelClass="\App\Models\Language::class"
+                            displayField="internal_name"
+                            :value="$selectedLanguage?->id"
+                            entity="languages"
+                            placeholder="All languages"
+                        />
                     </div>
 
                     <div class="w-full md:w-52">
-                        <label for="context" class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Context</label>
-                        <select id="context" name="context" class="block w-full rounded-md border-gray-300 text-sm focus:border-yellow-500 focus:ring-yellow-500">
-                            <option value="">All contexts</option>
-                            @foreach($contexts as $ctx)
-                                <option value="{{ $ctx->id }}" @selected(($listState->filters['context'] ?? null) === $ctx->id)>{{ $ctx->internal_name }}</option>
-                            @endforeach
-                        </select>
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Context</label>
+                        <x-form.entity-select
+                            name="context"
+                            :modelClass="\App\Models\Context::class"
+                            displayField="internal_name"
+                            :value="$selectedContext?->id"
+                            entity="contexts"
+                            placeholder="All contexts"
+                        />
                     </div>
                 </x-list.search-form>
             </div>

--- a/resources/views/collections/_form.blade.php
+++ b/resources/views/collections/_form.blade.php
@@ -35,7 +35,7 @@
     <x-form.entity-select 
         name="language_id" 
         :value="old('language_id', $collection->language_id ?? null)"
-        :options="\App\Models\Language::orderBy('internal_name')->get()"
+        :modelClass="\App\Models\Language::class"
         displayField="internal_name"
         placeholder="Select a language..."
         searchPlaceholder="Type to search languages..."
@@ -49,7 +49,7 @@
     <x-form.entity-select 
         name="context_id" 
         :value="old('context_id', $collection->context_id ?? null)"
-        :options="\App\Models\Context::orderBy('internal_name')->get()"
+        :modelClass="\App\Models\Context::class"
         displayField="internal_name"
         placeholder="Select a context..."
         searchPlaceholder="Type to search contexts..."
@@ -62,7 +62,7 @@
     <x-form.entity-select 
         name="parent_id" 
         :value="old('parent_id', $collection->parent_id ?? $parentId ?? null)"
-        :options="\App\Models\Collection::orderBy('internal_name')->get()"
+        :modelClass="\App\Models\Collection::class"
         displayField="internal_name"
         placeholder="Select a parent collection (optional)..."
         searchPlaceholder="Type to search collections..."

--- a/resources/views/collections/show.blade.php
+++ b/resources/views/collections/show.blade.php
@@ -29,7 +29,7 @@
         <x-entity.children-section :model="$collection" :children="$sections['children']['items']" />
 
         <!-- Items Section -->
-        <x-entity.collection-items-section :model="$collection" :items="$sections['items']['items']" :attachable-items="$sections['items']['attachableItems']" />
+        <x-entity.collection-items-section :model="$collection" :items="$sections['items']['items']" />
 
         <!-- Translations Section -->
         <x-entity.translations-section entity="collections" :model="$collection" translationRoute="collection-translations" :translation-groups="$sections['translations']['groups']" />
@@ -37,7 +37,7 @@
         <!-- Sidebar Content -->
         <x-slot name="sidebar">
             <!-- Parent Collection Card -->
-            <x-sidebar.parent-collection-card :model="$collection" :parent-collection="$sections['parent']['collection']" :parent-options="$sections['parent']['options']" />
+            <x-sidebar.parent-collection-card :model="$collection" :parent-collection="$sections['parent']['collection']" />
 
             <!-- Children Collections Card -->
             <x-sidebar.children-collections-card :model="$collection" :children="$sections['children']['items']" />

--- a/resources/views/components/app-nav.blade.php
+++ b/resources/views/components/app-nav.blade.php
@@ -256,7 +256,7 @@
             @else
                 <div class="hidden md:flex items-center gap-2 text-sm">
                     <a href="{{ route('login') }}" class="px-2 py-1 rounded text-gray-600 hover:text-gray-800 hover:bg-gray-50">Login</a>
-                    @if(Route::has('register') && \App\Models\Setting::get('self_registration_enabled', false))
+                    @if(Route::has('register') && $selfRegistrationEnabled)
                         <a href="{{ route('register') }}" class="px-2 py-1 rounded text-gray-600 hover:text-gray-800 hover:bg-gray-50">Register</a>
                     @endif
                 </div>
@@ -418,7 +418,7 @@
                 @else
                     <div class="flex gap-2">
                         <a href="{{ route('login') }}" class="flex-1 text-center px-2 py-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-50">Login</a>
-                        @if(Route::has('register') && \App\Models\Setting::get('self_registration_enabled', false))
+                        @if(Route::has('register') && $selfRegistrationEnabled)
                             <a href="{{ route('register') }}" class="flex-1 text-center px-2 py-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-50">Register</a>
                         @endif
                     </div>

--- a/resources/views/components/entity/collection-items-section.blade.php
+++ b/resources/views/components/entity/collection-items-section.blade.php
@@ -1,4 +1,4 @@
-@props(['model', 'items', 'attachableItems'])
+@props(['model', 'items'])
 
 @php($tc = $entityColor('collections'))
 <div class="mt-8">
@@ -100,7 +100,8 @@
                 <x-form.field label="Select Item" name="item_id" required>
                     <x-form.entity-select 
                         name="item_id"
-                        :options="$attachableItems"
+                        model-class="\App\Models\Item"
+                        :scopes="[['scope' => 'excludingIds', 'args' => [$items->pluck('id')->all()]]]"
                         displayField="internal_name"
                         placeholder="Select an item..."
                         searchPlaceholder="Type to search items..."

--- a/resources/views/components/entity/tags-section.blade.php
+++ b/resources/views/components/entity/tags-section.blade.php
@@ -26,10 +26,11 @@
                         <x-form.entity-select 
                             name="tag_id" 
                             :value="null"
-                            :options="\App\Models\Tag::orderBy('internal_name')->get()->reject(fn($tag) => $model->tags->contains($tag->id))"
-                            displayField="internal_name"
+                            model-class="\App\Models\Tag"
+                            display-field="internal_name"
+                            :scopes="[['scope' => 'notAttachedTo', 'args' => [$model->id]]]"
                             placeholder="Select a tag..."
-                            searchPlaceholder="Type to search tags..."
+                            search-placeholder="Type to search tags..."
                             required
                             entity="tags"
                         />

--- a/resources/views/components/form/address-select.blade.php
+++ b/resources/views/components/form/address-select.blade.php
@@ -1,12 +1,13 @@
 @props([
     'name' => 'address_id',
     'selected' => null,
+    'addresses' => null,
     'required' => false,
     'placeholder' => 'Select or search for an address...',
 ])
 
 @php
-    $addresses = \App\Models\Address::with('country')->orderBy('internal_name')->get(['id', 'internal_name', 'country_id']);
+    $addresses = $addresses ?? collect();
     $addressesForSelect = $addresses->map(function($address) {
         $label = $address->internal_name;
         if ($address->country) {

--- a/resources/views/components/form/author-select.blade.php
+++ b/resources/views/components/form/author-select.blade.php
@@ -1,12 +1,13 @@
 @props([
     'name' => 'author_id',
     'selected' => null,
+    'authors' => null,
     'required' => false,
     'placeholder' => 'Select or search for an author...',
 ])
 
 @php
-    $authors = \App\Models\Author::orderBy('name')->get(['id', 'name']);
+    $authors = $authors ?? collect();
 @endphp
 
 <x-form.searchable-select 

--- a/resources/views/components/form/contact-select.blade.php
+++ b/resources/views/components/form/contact-select.blade.php
@@ -1,12 +1,13 @@
 @props([
     'name' => 'contact_id',
     'selected' => null,
+    'contacts' => null,
     'required' => false,
     'placeholder' => 'Select or search for a contact...',
 ])
 
 @php
-    $contacts = \App\Models\Contact::orderBy('internal_name')->get(['id', 'internal_name']);
+    $contacts = $contacts ?? collect();
     $contactsForSelect = $contacts->map(function($contact) {
         return [
             'id' => $contact->id,

--- a/resources/views/components/form/context-select.blade.php
+++ b/resources/views/components/form/context-select.blade.php
@@ -8,7 +8,7 @@
 ])
 
 @php
-    $contexts = $contexts ?: \App\Models\Context::orderBy('internal_name')->get();
+    $contexts = $contexts ?? collect();
 @endphp
 
 <x-form.select 

--- a/resources/views/components/form/entity-select.blade.php
+++ b/resources/views/components/form/entity-select.blade.php
@@ -14,6 +14,7 @@
     
     // For dynamic DB queries (e.g., items with 1000+ records)
     'modelClass' => null, // Model class (e.g., \App\Models\Item::class)
+    'scopes' => null, // Named Eloquent scopes (e.g., [['scope' => 'excludingIds', 'args' => [['id1']]]])
     'filterColumn' => null, // Optional: column to filter on (e.g., 'id')
     'filterOperator' => '!=', // Optional: operator for filter (e.g., '!=', 'NOT IN')
     'filterValue' => null, // Optional: value(s) to filter
@@ -37,6 +38,7 @@
     'searchPlaceholder' => $searchPlaceholder,
     'entity' => $entity,
     'required' => $required,
+    'scopes' => $scopes,
     'filterColumn' => $filterColumn,
     'filterOperator' => $filterOperator,
     'filterValue' => $filterValue,

--- a/resources/views/components/form/language-select.blade.php
+++ b/resources/views/components/form/language-select.blade.php
@@ -8,7 +8,7 @@
 ])
 
 @php
-    $languages = $languages ?: \App\Models\Language::orderBy('internal_name')->get();
+    $languages = $languages ?? collect();
 @endphp
 
 <x-form.select 

--- a/resources/views/components/form/searchable-multi-select.blade.php
+++ b/resources/views/components/form/searchable-multi-select.blade.php
@@ -24,6 +24,21 @@
     $initialIds = $selectedOptions
         ? collect($selectedOptions)->map(fn ($o) => (string) (is_object($o) ? $o->id : $o['id']))->all()
         : [];
+
+    $livewireProps = array_merge([
+        'selectedIds' => $initialIds,
+        'name' => $name,
+        'staticOptions' => $options,
+        'modelClass' => $modelClass,
+        'displayField' => $displayField,
+        'placeholder' => $placeholder,
+        'searchPlaceholder' => $searchPlaceholder,
+        'entity' => $entity,
+        'scopes' => $scopes,
+        'filterColumn' => $filterColumn,
+        'filterOperator' => $filterOperator,
+        'filterValue' => $filterValue,
+    ], $perPage !== null ? ['perPage' => $perPage] : []);
 @endphp
 
 @if($label)
@@ -32,18 +47,4 @@
     </label>
 @endif
 
-@livewire('searchable-multi-select', [
-    'selectedIds' => $initialIds,
-    'name' => $name,
-    'staticOptions' => $options,
-    'modelClass' => $modelClass,
-    'displayField' => $displayField,
-    'placeholder' => $placeholder,
-    'searchPlaceholder' => $searchPlaceholder,
-    'entity' => $entity,
-    'scopes' => $scopes,
-    'perPage' => $perPage,
-    'filterColumn' => $filterColumn,
-    'filterOperator' => $filterOperator,
-    'filterValue' => $filterValue,
-])
+@livewire('searchable-multi-select', $livewireProps)

--- a/resources/views/components/form/searchable-multi-select.blade.php
+++ b/resources/views/components/form/searchable-multi-select.blade.php
@@ -1,0 +1,49 @@
+@props([
+    'name' => '',
+    'label' => '',
+    'selectedOptions' => null, // Pre-loaded Eloquent collection of currently selected rows (bounded by selection size)
+    'displayField' => 'internal_name',
+    'placeholder' => 'Select...',
+    'searchPlaceholder' => 'Type to search...',
+    'entity' => null, // For entity color theming
+
+    // For static options (bounded enums only — not growable entities)
+    'options' => null,
+
+    // For dynamic DB queries (growable entities)
+    'modelClass' => null,
+    'scopes' => null,
+    'perPage' => null,
+    'filterColumn' => null,
+    'filterOperator' => '!=',
+    'filterValue' => null,
+])
+
+{{-- Derive the initial selectedIds from the pre-loaded collection (safe: bounded by selection count) --}}
+@php
+    $initialIds = $selectedOptions
+        ? collect($selectedOptions)->map(fn ($o) => (string) (is_object($o) ? $o->id : $o['id']))->all()
+        : [];
+@endphp
+
+@if($label)
+    <label class="block text-sm font-medium text-gray-700 mb-1">
+        {{ $label }}
+    </label>
+@endif
+
+@livewire('searchable-multi-select', [
+    'selectedIds' => $initialIds,
+    'name' => $name,
+    'staticOptions' => $options,
+    'modelClass' => $modelClass,
+    'displayField' => $displayField,
+    'placeholder' => $placeholder,
+    'searchPlaceholder' => $searchPlaceholder,
+    'entity' => $entity,
+    'scopes' => $scopes,
+    'perPage' => $perPage,
+    'filterColumn' => $filterColumn,
+    'filterOperator' => $filterOperator,
+    'filterValue' => $filterValue,
+])

--- a/resources/views/components/sidebar/children-items-card.blade.php
+++ b/resources/views/components/sidebar/children-items-card.blade.php
@@ -3,7 +3,7 @@
     Uses unified item-relationship-card component
 --}}
 
-@props(['model', 'children', 'childOptions', 'collection' => null])
+@props(['model', 'children', 'collection' => null])
 
 @php
     $childItems = $children->map(fn ($child) => (object) [
@@ -23,12 +23,15 @@
     :count="$children->count()"
     :collection="$collection"
 >
-    <x-form.entity-select 
-        name="child_id" 
+    <x-form.entity-select
+        name="child_id"
         :value="null"
-        :options="$childOptions"
+        model-class="\App\Models\Item"
         display-field="internal_name"
         value-field="id"
+        filter-column="parent_id"
+        filter-operator="!="
+        :filter-value="$model->id"
         placeholder="Search items..."
         search-placeholder="Type name or ID..."
         required

--- a/resources/views/components/sidebar/children-items-card.blade.php
+++ b/resources/views/components/sidebar/children-items-card.blade.php
@@ -29,9 +29,7 @@
         model-class="\App\Models\Item"
         display-field="internal_name"
         value-field="id"
-        filter-column="parent_id"
-        filter-operator="!="
-        :filter-value="$model->id"
+        :scopes="[['scope' => 'excludingAncestorsOf', 'args' => [$model->id]], ['scope' => 'excludingIds', 'args' => [$children->pluck('id')->all()]]]"
         placeholder="Search items..."
         search-placeholder="Type name or ID..."
         required

--- a/resources/views/components/sidebar/links-card.blade.php
+++ b/resources/views/components/sidebar/links-card.blade.php
@@ -95,9 +95,7 @@
                         model-class="\App\Models\Item"
                         display-field="internal_name"
                         value-field="id"
-                        filter-column="id"
-                        filter-operator="!="
-                        :filter-value="$model->id"
+                        :scopes="[['scope' => 'excludingIds', 'args' => [[$model->id]]]]"
                         placeholder="Search items to link..."
                         search-placeholder="Type name or ID..."
                         required

--- a/resources/views/components/sidebar/links-card.blade.php
+++ b/resources/views/components/sidebar/links-card.blade.php
@@ -3,7 +3,7 @@
     Groups links by context for better organization
 --}}
 
-@props(['model', 'formattedLinks', 'linkTargetOptions', 'contextOptions', 'collection' => null])
+@props(['model', 'formattedLinks', 'collection' => null])
 
 @php
     $tc = $entityColor('item-item-links');
@@ -89,12 +89,15 @@
                 @csrf
                 <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">Target Item</label>
-                    <x-form.entity-select 
-                        name="target_id" 
+                    <x-form.entity-select
+                        name="target_id"
                         :value="null"
-                        :options="$linkTargetOptions"
+                        model-class="\App\Models\Item"
                         display-field="internal_name"
                         value-field="id"
+                        filter-column="id"
+                        filter-operator="!="
+                        :filter-value="$model->id"
                         placeholder="Search items to link..."
                         search-placeholder="Type name or ID..."
                         required
@@ -103,10 +106,10 @@
                 </div>
                 <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">Context</label>
-                    <x-form.entity-select 
-                        name="context_id" 
+                    <x-form.entity-select
+                        name="context_id"
                         :value="null"
-                        :options="$contextOptions"
+                        model-class="\App\Models\Context"
                         display-field="internal_name"
                         placeholder="Select context..."
                         search-placeholder="Type to search..."

--- a/resources/views/components/sidebar/monument-item-card.blade.php
+++ b/resources/views/components/sidebar/monument-item-card.blade.php
@@ -3,7 +3,7 @@
     Uses unified item-relationship-card component
 --}}
 
-@props(['partner', 'monumentItem' => null, 'monumentOptions'])
+@props(['partner', 'monumentItem' => null])
 
 <x-sidebar.item-relationship-card
     title="Monument Item"
@@ -18,9 +18,10 @@
     <x-form.entity-select 
         name="monument_item_id" 
         :value="$partner->monument_item_id"
-        :options="$monumentOptions"
+        model-class="\App\Models\Item"
         display-field="internal_name"
         value-field="id"
+        :scopes="[['scope' => 'monuments']]"
         placeholder="Search monument items..."
         search-placeholder="Type name or ID..."
         required

--- a/resources/views/components/sidebar/parent-collection-card.blade.php
+++ b/resources/views/components/sidebar/parent-collection-card.blade.php
@@ -3,7 +3,7 @@
     Uses unified collection-relationship-card component
 --}}
 
-@props(['model', 'parentCollection' => null, 'parentOptions'])
+@props(['model', 'parentCollection' => null])
 
 <x-sidebar.collection-relationship-card
     title="Parent Collection"
@@ -18,9 +18,10 @@
     <x-form.entity-select
         name="parent_id"
         :value="$model->parent_id"
-        :options="$parentOptions"
+        model-class="\App\Models\Collection"
         display-field="internal_name"
         value-field="id"
+        :scopes="[['scope' => 'excludingDescendantsOf', 'args' => [$model->id]]]"
         placeholder="Search collections..."
         search-placeholder="Type name or ID..."
         required

--- a/resources/views/components/sidebar/parent-item-card.blade.php
+++ b/resources/views/components/sidebar/parent-item-card.blade.php
@@ -3,7 +3,7 @@
     Uses unified item-relationship-card component
 --}}
 
-@props(['model', 'parentItem' => null, 'parentOptions', 'collection' => null])
+@props(['model', 'parentItem' => null, 'collection' => null])
 
 <x-sidebar.item-relationship-card
     title="Parent Item"
@@ -16,12 +16,15 @@
     :can-remove="true"
     :collection="$collection"
 >
-    <x-form.entity-select 
-        name="parent_id" 
+    <x-form.entity-select
+        name="parent_id"
         :value="$model->parent_id"
-        :options="$parentOptions"
+        model-class="\App\Models\Item"
         display-field="internal_name"
         value-field="id"
+        filter-column="id"
+        filter-operator="!="
+        :filter-value="$model->id"
         placeholder="Search items..."
         search-placeholder="Type name or ID..."
         required

--- a/resources/views/components/sidebar/parent-item-card.blade.php
+++ b/resources/views/components/sidebar/parent-item-card.blade.php
@@ -22,9 +22,7 @@
         model-class="\App\Models\Item"
         display-field="internal_name"
         value-field="id"
-        filter-column="id"
-        filter-operator="!="
-        :filter-value="$model->id"
+        :scopes="[['scope' => 'excludingDescendantsOf', 'args' => [$model->id]]]"
         placeholder="Search items..."
         search-placeholder="Type name or ID..."
         required

--- a/resources/views/components/sidebar/tags-card.blade.php
+++ b/resources/views/components/sidebar/tags-card.blade.php
@@ -60,9 +60,7 @@
                         :value="null"
                         model-class="\App\Models\Tag"
                         display-field="internal_name"
-                        filter-column="id"
-                        filter-operator="NOT IN"
-                        :filter-value="$model->tags->pluck('id')->all()"
+                        :scopes="[['scope' => 'notAttachedTo', 'args' => [$model->id]]]"
                         placeholder="Select a tag..."
                         search-placeholder="Type to search..."
                         required

--- a/resources/views/components/sidebar/tags-card.blade.php
+++ b/resources/views/components/sidebar/tags-card.blade.php
@@ -3,7 +3,7 @@
     Compact display with inline add/remove for two-column layout
 --}}
 
-@props(['model', 'tags', 'availableTags'])
+@props(['model', 'tags'])
 
 @php($tc = $entityColor('tags'))
 
@@ -55,13 +55,16 @@
             <form action="{{ route('items.tags.attach', $model) }}" method="POST" class="space-y-2">
                 @csrf
                 <div>
-                    <x-form.entity-select 
-                        name="tag_id" 
+                    <x-form.entity-select
+                        name="tag_id"
                         :value="null"
-                        :options="$availableTags"
-                        displayField="display_label"
+                        model-class="\App\Models\Tag"
+                        display-field="internal_name"
+                        filter-column="id"
+                        filter-operator="NOT IN"
+                        :filter-value="$model->tags->pluck('id')->all()"
                         placeholder="Select a tag..."
-                        searchPlaceholder="Type to search..."
+                        search-placeholder="Type to search..."
                         required
                         entity="tags"
                     />

--- a/resources/views/glossary-spelling/_form.blade.php
+++ b/resources/views/glossary-spelling/_form.blade.php
@@ -5,7 +5,7 @@
         <x-form.entity-select 
             name="language_id" 
             :value="old('language_id', ($spelling ?? null)?->language_id ?? null)"
-            :options="$languages"
+            :modelClass="\App\Models\Language::class"
             displayField="internal_name"
             placeholder="Select a language..."
             searchPlaceholder="Type to search languages..."

--- a/resources/views/glossary-translation/_form.blade.php
+++ b/resources/views/glossary-translation/_form.blade.php
@@ -5,17 +5,14 @@
         <x-form.entity-select 
             name="language_id" 
             :value="old('language_id', ($translation ?? null)?->language_id ?? null)"
-            :options="$languages->map(function($lang) use ($usedLanguageIds) {
-                $lang->disabled = in_array($lang->id, $usedLanguageIds ?? []);
-                return $lang;
-            })"
+            :options="$languageOptions"
             displayField="internal_name"
             placeholder="Select a language..."
             searchPlaceholder="Type to search languages..."
             required
             :showId="true"
         />
-        @if(isset($usedLanguageIds) && count($usedLanguageIds) > 0)
+        @if($languageOptions->contains('disabled', true))
             <p class="mt-1 text-sm text-gray-500">Some languages may not be available as they are already used for this glossary.</p>
         @endif
     </x-form.field>

--- a/resources/views/glossary-translation/index.blade.php
+++ b/resources/views/glossary-translation/index.blade.php
@@ -37,13 +37,15 @@
                     :clear-url="route('glossaries.translations.index', $glossary)"
                 >
                     <div class="w-full md:w-52">
-                        <label for="language" class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Language</label>
-                        <select id="language" name="language" class="block w-full rounded-md border-gray-300 text-sm focus:border-teal-500 focus:ring-teal-500">
-                            <option value="">All languages</option>
-                            @foreach($languages as $lang)
-                                <option value="{{ $lang->id }}" @selected(($listState->filters['language'] ?? null) === $lang->id)>{{ $lang->internal_name }}</option>
-                            @endforeach
-                        </select>
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Language</label>
+                        <x-form.entity-select
+                            name="language"
+                            :modelClass="\App\Models\Language::class"
+                            displayField="internal_name"
+                            :value="$selectedLanguage?->id"
+                            entity="languages"
+                            placeholder="All languages"
+                        />
                     </div>
                 </x-list.search-form>
             </div>

--- a/resources/views/item-links/_form.blade.php
+++ b/resources/views/item-links/_form.blade.php
@@ -6,7 +6,7 @@
             <x-form.entity-select 
                 name="target_id" 
                 :value="old('target_id', $itemItemLink->target_id ?? null)"
-                :options="$items"
+                :modelClass="\App\Models\Item::class"
                 displayField="internal_name"
                 placeholder="Select a target item..."
                 searchPlaceholder="Type to search items..."
@@ -19,7 +19,7 @@
             <x-form.entity-select 
                 name="context_id" 
                 :value="old('context_id', $itemItemLink->context_id ?? ($defaultContext->id ?? null))"
-                :options="$contexts"
+                :modelClass="\App\Models\Context::class"
                 displayField="internal_name"
                 placeholder="Select a context..."
                 searchPlaceholder="Type to search contexts..."

--- a/resources/views/item-translations/_form.blade.php
+++ b/resources/views/item-translations/_form.blade.php
@@ -7,7 +7,7 @@
             <x-form.entity-select 
                 name="item_id" 
                 :value="old('item_id', $itemTranslation->item_id ?? $selectedItemId ?? null)"
-                :options="$items"
+                :modelClass="\App\Models\Item::class"
                 displayField="internal_name"
                 placeholder="Select an item..."
                 searchPlaceholder="Type to search items..."
@@ -20,7 +20,7 @@
             <x-form.entity-select 
                 name="language_id" 
                 :value="old('language_id', $itemTranslation->language_id ?? ($defaultContext ?? null))"
-                :options="$languages"
+                :modelClass="\App\Models\Language::class"
                 displayField="internal_name"
                 placeholder="Select a language..."
                 searchPlaceholder="Type to search languages..."
@@ -33,7 +33,7 @@
             <x-form.entity-select 
                 name="context_id" 
                 :value="old('context_id', $itemTranslation->context_id ?? ($defaultContext->id ?? null))"
-                :options="$contexts"
+                :modelClass="\App\Models\Context::class"
                 displayField="internal_name"
                 placeholder="Select a context..."
                 searchPlaceholder="Type to search contexts..."
@@ -180,7 +180,7 @@
             <x-form.entity-select 
                 name="author_id"
                 :value="old('author_id', $itemTranslation->author_id ?? null)"
-                :options="$authors"
+                :modelClass="\App\Models\Author::class"
                 displayField="name"
                 placeholder="Select an author..."
                 searchPlaceholder="Type to search authors..."
@@ -191,7 +191,7 @@
             <x-form.entity-select 
                 name="text_copy_editor_id"
                 :value="old('text_copy_editor_id', $itemTranslation->text_copy_editor_id ?? null)"
-                :options="$authors"
+                :modelClass="\App\Models\Author::class"
                 displayField="name"
                 placeholder="Select a copy editor..."
                 searchPlaceholder="Type to search authors..."
@@ -202,7 +202,7 @@
                 <x-form.entity-select 
                     name="translator_id"
                     :value="old('translator_id', $itemTranslation->translator_id ?? null)"
-                    :options="$authors"
+                    :modelClass="\App\Models\Author::class"
                     displayField="name"
                     placeholder="Select a translator..."
                     searchPlaceholder="Type to search authors..."
@@ -213,7 +213,7 @@
                 <x-form.entity-select 
                     name="translation_copy_editor_id"
                     :value="old('translation_copy_editor_id', $itemTranslation->translation_copy_editor_id ?? null)"
-                    :options="$authors"
+                    :modelClass="\App\Models\Author::class"
                     displayField="name"
                     placeholder="Select a translation copy editor..."
                     searchPlaceholder="Type to search authors..."

--- a/resources/views/item-translations/index.blade.php
+++ b/resources/views/item-translations/index.blade.php
@@ -34,23 +34,27 @@
                     <input type="hidden" name="item_id" value="{{ $listState->filters['item_id'] }}">
 
                     <div class="w-full md:w-52">
-                        <label for="language" class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Language</label>
-                        <select id="language" name="language" class="block w-full rounded-md border-gray-300 text-sm focus:border-teal-500 focus:ring-teal-500">
-                            <option value="">All languages</option>
-                            @foreach($languages as $lang)
-                                <option value="{{ $lang->id }}" @selected(($listState->filters['language'] ?? null) === $lang->id)>{{ $lang->internal_name }}</option>
-                            @endforeach
-                        </select>
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Language</label>
+                        <x-form.entity-select
+                            name="language"
+                            :modelClass="\App\Models\Language::class"
+                            displayField="internal_name"
+                            :value="$selectedLanguage?->id"
+                            entity="languages"
+                            placeholder="All languages"
+                        />
                     </div>
 
                     <div class="w-full md:w-52">
-                        <label for="context" class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Context</label>
-                        <select id="context" name="context" class="block w-full rounded-md border-gray-300 text-sm focus:border-teal-500 focus:ring-teal-500">
-                            <option value="">All contexts</option>
-                            @foreach($contexts as $ctx)
-                                <option value="{{ $ctx->id }}" @selected(($listState->filters['context'] ?? null) === $ctx->id)>{{ $ctx->internal_name }}</option>
-                            @endforeach
-                        </select>
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Context</label>
+                        <x-form.entity-select
+                            name="context"
+                            :modelClass="\App\Models\Context::class"
+                            displayField="internal_name"
+                            :value="$selectedContext?->id"
+                            entity="contexts"
+                            placeholder="All contexts"
+                        />
                     </div>
                 </x-list.search-form>
             </div>

--- a/resources/views/items/_form.blade.php
+++ b/resources/views/items/_form.blade.php
@@ -27,7 +27,7 @@
     <x-form.entity-select 
         name="country_id" 
         :value="old('country_id', $item->country_id ?? null)"
-        :options="\App\Models\Country::orderBy('internal_name')->get()"
+        :modelClass="\App\Models\Country::class"
         displayField="internal_name"
         placeholder="Select a country..."
         searchPlaceholder="Type to search countries..."

--- a/resources/views/items/index.blade.php
+++ b/resources/views/items/index.blade.php
@@ -83,60 +83,63 @@
                     </div>
 
                     <div class="w-full md:w-52">
-                        <label for="partner_id" class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Partner</label>
-                        <select id="partner_id" name="partner_id" class="block w-full rounded-md border-gray-300 text-sm focus:border-teal-500 focus:ring-teal-500">
-                            <option value="">All partners</option>
-                            @foreach($partners as $partner)
-                                <option value="{{ $partner->id }}" @selected(($listState->filters['partner_id'] ?? null) === $partner->id)>{{ $partner->internal_name }}</option>
-                            @endforeach
-                        </select>
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Partner</label>
+                        <x-form.entity-select
+                            name="partner_id"
+                            :modelClass="\App\Models\Partner::class"
+                            displayField="internal_name"
+                            :value="$selectedPartner?->id"
+                            entity="partners"
+                            placeholder="All partners"
+                        />
                     </div>
 
                     <div class="w-full md:w-52">
-                        <label for="collection_id" class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Collection</label>
-                        <select id="collection_id" name="collection_id" class="block w-full rounded-md border-gray-300 text-sm focus:border-teal-500 focus:ring-teal-500">
-                            <option value="">All collections</option>
-                            @foreach($collections as $collection)
-                                <option value="{{ $collection->id }}" @selected(($listState->filters['collection_id'] ?? null) === $collection->id)>{{ $collection->internal_name }}</option>
-                            @endforeach
-                        </select>
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Collection</label>
+                        <x-form.entity-select
+                            name="collection_id"
+                            :modelClass="\App\Models\Collection::class"
+                            displayField="internal_name"
+                            :value="$selectedCollection?->id"
+                            entity="collections"
+                            placeholder="All collections"
+                        />
                     </div>
 
                     <div class="w-full md:w-52">
-                        <label for="project_id" class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Project</label>
-                        <select id="project_id" name="project_id" class="block w-full rounded-md border-gray-300 text-sm focus:border-teal-500 focus:ring-teal-500">
-                            <option value="">All projects</option>
-                            @foreach($projects as $project)
-                                <option value="{{ $project->id }}" @selected(($listState->filters['project_id'] ?? null) === $project->id)>{{ $project->internal_name }}</option>
-                            @endforeach
-                        </select>
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Project</label>
+                        <x-form.entity-select
+                            name="project_id"
+                            :modelClass="\App\Models\Project::class"
+                            displayField="internal_name"
+                            :value="$selectedProject?->id"
+                            entity="projects"
+                            placeholder="All projects"
+                        />
                     </div>
 
                     <div class="w-full md:w-52">
-                        <label for="country_id" class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Country</label>
-                        <select id="country_id" name="country_id" class="block w-full rounded-md border-gray-300 text-sm focus:border-teal-500 focus:ring-teal-500">
-                            <option value="">All countries</option>
-                            @foreach($countries as $country)
-                                <option value="{{ $country->id }}" @selected(($listState->filters['country_id'] ?? null) === $country->id)>{{ $country->internal_name }}</option>
-                            @endforeach
-                        </select>
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Country</label>
+                        <x-form.entity-select
+                            name="country_id"
+                            :modelClass="\App\Models\Country::class"
+                            displayField="internal_name"
+                            :value="$selectedCountry?->id"
+                            entity="countries"
+                            placeholder="All countries"
+                        />
                     </div>
 
                     <div class="w-full">
-                        <label for="tags" class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Tags</label>
-                        <select
-                            id="tags"
-                            name="tags[]"
-                            multiple
-                            size="{{ min(max($availableTags->count(), 3), 8) }}"
-                            class="block w-full rounded-md border-gray-300 text-sm focus:border-teal-500 focus:ring-teal-500"
-                        >
-                            @foreach($availableTags as $tag)
-                                <option value="{{ $tag->id }}" @selected(in_array($tag->id, $selectedTagIds, true))>
-                                    {{ $tag->internal_name }}@if($tag->description) - {{ $tag->description }}@endif
-                                </option>
-                            @endforeach
-                        </select>
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Tags</label>
+                        <x-form.searchable-multi-select
+                            name="tags"
+                            :modelClass="\App\Models\Tag::class"
+                            displayField="internal_name"
+                            :selected-options="$selectedTags"
+                            entity="tags"
+                            placeholder="Filter by tags"
+                        />
                     </div>
                 </x-list.search-form>
             </div>

--- a/resources/views/items/show.blade.php
+++ b/resources/views/items/show.blade.php
@@ -42,16 +42,16 @@
         <!-- Sidebar Content -->
         <x-slot name="sidebar">
             <!-- Parent Item Card -->
-            <x-sidebar.parent-item-card :model="$item" :parent-item="$sections['parent']['item']" :parent-options="$sections['parent']['options']" :collection="$collection ?? null" />
+            <x-sidebar.parent-item-card :model="$item" :parent-item="$sections['parent']['item']" :collection="$collection ?? null" />
 
             <!-- Children Items Card -->
-            <x-sidebar.children-items-card :model="$item" :children="$sections['children']['items']" :child-options="$sections['children']['options']" :collection="$collection ?? null" />
+            <x-sidebar.children-items-card :model="$item" :children="$sections['children']['items']" :collection="$collection ?? null" />
 
             <!-- Tags Card -->
-            <x-sidebar.tags-card :model="$item" :tags="$sections['tags']['items']" :available-tags="$sections['tags']['availableTags']" />
+            <x-sidebar.tags-card :model="$item" :tags="$sections['tags']['items']" />
 
             <!-- Links Card -->
-            <x-sidebar.links-card :model="$item" :formatted-links="$sections['links']['formatted']" :link-target-options="$sections['links']['targetOptions']" :context-options="$sections['links']['contextOptions']" :collection="$collection ?? null" />
+            <x-sidebar.links-card :model="$item" :formatted-links="$sections['links']['formatted']" :collection="$collection ?? null" />
 
             <!-- System Properties Card -->
             <x-sidebar.system-properties-card

--- a/resources/views/livewire/searchable-multi-select.blade.php
+++ b/resources/views/livewire/searchable-multi-select.blade.php
@@ -1,0 +1,89 @@
+<div class="relative">
+    {{-- Hidden inputs for form submission: emitted as name[] per selected id --}}
+    @foreach($selectedIds as $id)
+        <input type="hidden" name="{{ $name }}[]" value="{{ $id }}" />
+    @endforeach
+
+    {{-- Chips for currently selected options --}}
+    @if($selectedOptions->isNotEmpty())
+        <div class="flex flex-wrap gap-1 mb-2">
+            @foreach($selectedOptions as $option)
+                @php
+                    $chipId = (string) (is_object($option) ? ($option->id ?? null) : ($option['id'] ?? null));
+                    $chipLabel = is_object($option) ? ($option->{$displayField} ?? '') : ($option[$displayField] ?? '');
+                @endphp
+                <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700">
+                    {{ $chipLabel }}
+                    <button
+                        type="button"
+                        wire:click="removeOption('{{ $chipId }}')"
+                        class="text-gray-400 hover:text-gray-600"
+                        aria-label="Remove {{ $chipLabel }}"
+                    >
+                        <svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                            <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
+                        </svg>
+                    </button>
+                </span>
+            @endforeach
+
+            <button
+                type="button"
+                wire:click="clear"
+                class="text-xs text-gray-400 hover:text-gray-600 self-center ml-1"
+            >
+                Clear all
+            </button>
+        </div>
+    @endif
+
+    {{-- Search / combobox input --}}
+    <div class="relative">
+        <input
+            type="text"
+            wire:model.live.debounce.300ms="search"
+            @focus="$wire.set('open', true)"
+            @click.away="$wire.set('open', false); $wire.set('search', '')"
+            @keydown.escape="$wire.set('open', false); $wire.set('search', '')"
+            placeholder="{{ $searchPlaceholder }}"
+            class="block w-full rounded-md border-gray-300 shadow-sm {{ $focusClasses }} sm:text-sm"
+            autocomplete="off"
+        />
+
+        {{-- Dropdown chevron --}}
+        <div class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+            <svg class="h-5 w-5 text-gray-400" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"></path>
+            </svg>
+        </div>
+    </div>
+
+    {{-- Candidate options dropdown --}}
+    @if($open && $options->isNotEmpty())
+        <div class="absolute z-10 mt-1 w-full bg-white shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm">
+            @foreach($options as $option)
+                @php
+                    $optionValue = (string) (is_object($option) ? ($option->id ?? null) : ($option['id'] ?? null));
+                    $optionDisplay = is_object($option) ? ($option->{$displayField} ?? '') : ($option[$displayField] ?? '');
+                @endphp
+                <div
+                    wire:click="addOption('{{ $optionValue }}')"
+                    class="cursor-pointer select-none relative py-2 px-3 hover:bg-gray-50"
+                >
+                    <span class="block truncate font-medium">{{ $optionDisplay }}</span>
+                </div>
+            @endforeach
+        </div>
+    @endif
+
+    {{-- No results message --}}
+    @if($open && $search !== '' && $options->isEmpty())
+        <div class="absolute z-10 mt-1 w-full bg-white shadow-lg rounded-md py-3 px-3 text-sm text-gray-500 ring-1 ring-black ring-opacity-5">
+            No results found for "{{ $search }}"
+        </div>
+    @endif
+
+    @error($name)
+        <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
+    @enderror
+</div>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -149,7 +149,7 @@
                             </a>
                         @endif
 
-                        @if (Route::has('register') && \App\Models\Setting::get('self_registration_enabled', false))
+                        @if (Route::has('register') && $selfRegistrationEnabled)
                             <a href="{{ route('register') }}" class="text-sm text-gray-700 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-md px-3 py-2 bg-gray-100 hover:bg-gray-200">
                                 {{ __('Register') }}
                             </a>
@@ -275,7 +275,7 @@
                         </x-responsive-nav-link>
                     @endif
 
-                    @if (Route::has('register') && \App\Models\Setting::get('self_registration_enabled', false))
+                    @if (Route::has('register') && $selfRegistrationEnabled)
                         <x-responsive-nav-link href="{{ route('register') }}">
                             {{ __('Register') }}
                         </x-responsive-nav-link>

--- a/resources/views/partner-translations/_form.blade.php
+++ b/resources/views/partner-translations/_form.blade.php
@@ -7,7 +7,7 @@
                 <x-form.entity-select 
                     name="partner_id" 
                     :value="old('partner_id', $partnerTranslation->partner_id ?? $selectedPartnerId ?? null)"
-                    :options="$partners"
+                    :modelClass="\App\Models\Partner::class"
                     displayField="internal_name"
                     placeholder="Select a partner..."
                     searchPlaceholder="Type to search partners..."
@@ -20,7 +20,7 @@
                 <x-form.entity-select 
                     name="language_id" 
                     :value="old('language_id', $partnerTranslation->language_id ?? ($defaultLanguage->id ?? null))"
-                    :options="$languages"
+                    :modelClass="\App\Models\Language::class"
                     displayField="internal_name"
                     placeholder="Select a language..."
                     searchPlaceholder="Type to search languages..."
@@ -33,7 +33,7 @@
                 <x-form.entity-select 
                     name="context_id" 
                     :value="old('context_id', $partnerTranslation->context_id ?? ($defaultContext->id ?? null))"
-                    :options="$contexts"
+                    :modelClass="\App\Models\Context::class"
                     displayField="internal_name"
                     placeholder="Select a context..."
                     searchPlaceholder="Type to search contexts..."

--- a/resources/views/partner-translations/index.blade.php
+++ b/resources/views/partner-translations/index.blade.php
@@ -34,23 +34,27 @@
                     <input type="hidden" name="partner_id" value="{{ $listState->filters['partner_id'] }}">
 
                     <div class="w-full md:w-52">
-                        <label for="language" class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Language</label>
-                        <select id="language" name="language" class="block w-full rounded-md border-gray-300 text-sm focus:border-yellow-500 focus:ring-yellow-500">
-                            <option value="">All languages</option>
-                            @foreach($languages as $lang)
-                                <option value="{{ $lang->id }}" @selected(($listState->filters['language'] ?? null) === $lang->id)>{{ $lang->internal_name }}</option>
-                            @endforeach
-                        </select>
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Language</label>
+                        <x-form.entity-select
+                            name="language"
+                            :modelClass="\App\Models\Language::class"
+                            displayField="internal_name"
+                            :value="$selectedLanguage?->id"
+                            entity="languages"
+                            placeholder="All languages"
+                        />
                     </div>
 
                     <div class="w-full md:w-52">
-                        <label for="context" class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Context</label>
-                        <select id="context" name="context" class="block w-full rounded-md border-gray-300 text-sm focus:border-yellow-500 focus:ring-yellow-500">
-                            <option value="">All contexts</option>
-                            @foreach($contexts as $ctx)
-                                <option value="{{ $ctx->id }}" @selected(($listState->filters['context'] ?? null) === $ctx->id)>{{ $ctx->internal_name }}</option>
-                            @endforeach
-                        </select>
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Context</label>
+                        <x-form.entity-select
+                            name="context"
+                            :modelClass="\App\Models\Context::class"
+                            displayField="internal_name"
+                            :value="$selectedContext?->id"
+                            entity="contexts"
+                            placeholder="All contexts"
+                        />
                     </div>
                 </x-list.search-form>
             </div>

--- a/resources/views/partners/_form.blade.php
+++ b/resources/views/partners/_form.blade.php
@@ -31,7 +31,7 @@
     <x-form.entity-select 
         name="country_id" 
         :value="old('country_id', $partner->country_id ?? null)"
-        :options="\App\Models\Country::orderBy('internal_name')->get()"
+        :modelClass="\App\Models\Country::class"
         displayField="internal_name"
         placeholder="Select a country..."
         searchPlaceholder="Type to search countries..."

--- a/resources/views/partners/index.blade.php
+++ b/resources/views/partners/index.blade.php
@@ -16,7 +16,20 @@
                     :search="$listState->search"
                     placeholder="Search internal names..."
                     :clear-url="route('partners.index')"
-                />
+                    class="gap-4"
+                >
+                    <div class="w-full md:w-44">
+                        <label class="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500">Country</label>
+                        <x-form.entity-select
+                            name="country_id"
+                            :modelClass="\App\Models\Country::class"
+                            displayField="internal_name"
+                            :value="$selectedCountry?->id"
+                            entity="countries"
+                            placeholder="All countries"
+                        />
+                    </div>
+                </x-list.search-form>
             </div>
 
             <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">

--- a/resources/views/partners/show.blade.php
+++ b/resources/views/partners/show.blade.php
@@ -43,7 +43,7 @@
         <!-- Sidebar Content -->
         <x-slot name="sidebar">
             <!-- Monument Item Card -->
-            <x-sidebar.monument-item-card :partner="$partner" :monument-item="$sections['monument']['item']" :monument-options="$sections['monument']['options']" />
+            <x-sidebar.monument-item-card :partner="$partner" :monument-item="$sections['monument']['item']" />
 
             <!-- System Properties Card -->
             <x-sidebar.system-properties-card

--- a/resources/views/projects/_form.blade.php
+++ b/resources/views/projects/_form.blade.php
@@ -23,7 +23,7 @@
     <x-form.entity-select 
         name="context_id" 
         :value="old('context_id', $project->context_id ?? null)"
-        :options="$contexts"
+        :modelClass="\App\Models\Context::class"
         displayField="internal_name"
         placeholder="Select a context..."
         searchPlaceholder="Type to search contexts..."
@@ -35,7 +35,7 @@
     <x-form.entity-select 
         name="language_id" 
         :value="old('language_id', $project->language_id ?? null)"
-        :options="$languages"
+        :modelClass="\App\Models\Language::class"
         displayField="internal_name"
         placeholder="Select a language..."
         searchPlaceholder="Type to search languages..."

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -24,7 +24,7 @@
                             Login
                         </x-welcome-cta-button>
                         
-                        @if (Route::has('register') && \App\Models\Setting::get('self_registration_enabled', false))
+                        @if (Route::has('register') && $selfRegistrationEnabled)
                             <x-welcome-cta-button href="{{ route('register') }}" variant="secondary">
                                 <x-heroicon-o-user-plus class="size-5 mr-2" />
                                 Register
@@ -55,7 +55,7 @@
                         :highlighted="true"
                     >Login</x-ui.card>
                     
-                    @if(Route::has('register') && \App\Models\Setting::get('self_registration_enabled', false))
+                    @if(Route::has('register') && $selfRegistrationEnabled)
                         {{-- Register Tile --}}
                         <x-ui.card 
                             href="{{ route('register') }}"
@@ -129,7 +129,7 @@
                 </p>
                 <div class="flex flex-wrap justify-center gap-4">
                     @guest
-                        @if(\App\Models\Setting::get('self_registration_enabled', false))
+                        @if($selfRegistrationEnabled)
                             <x-welcome-cta-button href="{{ route('register') }}" variant="primary">
                                 <x-heroicon-o-user-plus class="size-5 mr-2" />
                                 Get Started Today

--- a/spa/package-lock.json
+++ b/spa/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inventory-app-spa",
-  "version": "6.0.11",
+  "version": "6.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inventory-app-spa",
-      "version": "6.0.11",
+      "version": "6.0.12",
       "dependencies": {
         "@headlessui/vue": "^1.7.23",
         "@heroicons/vue": "^2.2.0",
@@ -14,7 +14,7 @@
         "@vueuse/core": "^14.0.0",
         "axios": "^1.15.0",
         "pinia": "^3.0.3",
-        "uuid": "^13.0.0",
+        "uuid": "^14.0.0",
         "vue": "^3.5.32",
         "vue-router": "^5.0.3"
       },
@@ -5061,9 +5061,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/spa/package.json
+++ b/spa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inventory-app-spa",
-  "version": "6.0.11",
+  "version": "6.0.12",
   "private": true,
   "type": "module",
   "scripts": {
@@ -30,7 +30,7 @@
     "@vueuse/core": "^14.0.0",
     "axios": "^1.15.0",
     "pinia": "^3.0.3",
-    "uuid": "^13.0.0",
+    "uuid": "^14.0.0",
     "vue": "^3.5.32",
     "vue-router": "^5.0.3"
   },

--- a/tests/Configuration/BladeHasNoEloquentTest.php
+++ b/tests/Configuration/BladeHasNoEloquentTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Configuration;
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+/**
+ * CI guard that fails the Configuration suite the moment any Blade view
+ * reintroduces a namespace-qualified Eloquent static call.
+ *
+ * ## Rule
+ *
+ * No file under `resources/views/` may contain a pattern of the form
+ * `\App\Models\SomeThing::method(...)`.  Class-name constant references
+ * (`::class`) are explicitly excluded because they appear legitimately in
+ * `modelClass=` component attributes and are NOT Eloquent calls.
+ *
+ * ## Allow-list
+ *
+ * The allow-list below is empty by default (all offenders were removed in
+ * EPICs 5 and 7).  If a future change deliberately requires a static call
+ * (e.g. a bounded enum conversion), add the *full relative path* from the
+ * project root and a comment explaining the exception:
+ *
+ *   'resources/views/example/show.blade.php' => 'reason …',
+ *
+ * ## How the guard catches a violation
+ *
+ * When a Blade view contains `\App\Models\Language::orderBy(...)`, the test
+ * lists the offending file path, line number, and the matching line content
+ * so the developer can identify and fix the regression quickly.
+ */
+class BladeHasNoEloquentTest extends TestCase
+{
+    /**
+     * Relative paths (from the project root) that are permitted to contain
+     * Eloquent static calls.  Keep this empty; add entries only with explicit
+     * sign-off and a documented reason.
+     *
+     * @var array<string, string>
+     */
+    private array $allowList = [
+        // 'resources/views/example/show.blade.php' => 'reason',
+    ];
+
+    /**
+     * Regex that matches a namespace-qualified Eloquent static call.
+     *
+     * Matches:  \App\Models\Item::get(
+     * Excludes: \App\Models\Item::class  (class-name constant, not a call)
+     *
+     * The pattern requires a literal backslash before App to distinguish it
+     * from unqualified `App\Models\` imports (which Blade files should not
+     * have anyway, but we add the shorter-form check below for defence-in-depth).
+     */
+    private string $fullyQualifiedPattern = '/\\\\App\\\\Models\\\\[A-Z]\\w+::(?!class\\b)/';
+
+    /**
+     * Defensive secondary pattern for shorter-form static calls that would
+     * appear if someone added a `use App\Models\*` import at the top of a
+     * Blade file (which itself is a code-smell but is technically possible).
+     *
+     * Matches:  Models\Item::get(
+     * Excludes: Models\Item::class
+     */
+    private string $shortFormPattern = '/\\bModels\\\\[A-Z]\\w+::(?!class\\b)/';
+
+    public function test_blade_views_contain_no_eloquent_static_calls(): void
+    {
+        $viewsPath = base_path('resources/views');
+        $bladeFiles = File::allFiles($viewsPath);
+
+        $violations = [];
+
+        foreach ($bladeFiles as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relativePath = str_replace('\\', '/', $file->getRelativePathname());
+            $fullRelativePath = 'resources/views/'.$relativePath;
+
+            if (array_key_exists($fullRelativePath, $this->allowList)) {
+                continue;
+            }
+
+            $lines = explode("\n", $file->getContents());
+
+            foreach ($lines as $lineNumber => $line) {
+                $humanLine = $lineNumber + 1;
+
+                if (preg_match($this->fullyQualifiedPattern, $line)) {
+                    $violations[] = "{$fullRelativePath}:{$humanLine} — {$line}";
+                }
+
+                if (preg_match($this->shortFormPattern, $line)) {
+                    $violations[] = "{$fullRelativePath}:{$humanLine} [short-form] — {$line}";
+                }
+            }
+        }
+
+        $this->assertEmpty(
+            $violations,
+            "Eloquent static call(s) found in Blade views:\n".implode("\n", $violations).
+            "\n\nEloquent calls in Blade views are forbidden (see docs/guidelines for the approved pattern).".
+            "\nIf this is intentional, add the file to the allow-list in BladeHasNoEloquentTest.",
+        );
+    }
+}

--- a/tests/Unit/Livewire/SearchableMultiSelectTest.php
+++ b/tests/Unit/Livewire/SearchableMultiSelectTest.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace Tests\Unit\Livewire;
+
+use App\Livewire\SearchableMultiSelect;
+use App\Models\Item;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Unit tests for the SearchableMultiSelect Livewire component (Story 3.3).
+ *
+ * Covers:
+ *   1. Initial state: no selected ids.
+ *   2. addOption($id) appends once; duplicate adds are no-ops.
+ *   3. removeOption($id) removes by id.
+ *   4. clear() empties the selection.
+ *   5. Search composes with scopes.
+ *   6. Ceiling guard (from Story 2.1) still applies when staticOptions is used.
+ *   7. selectedOptions collection renders chips without issuing a new query.
+ */
+class SearchableMultiSelectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Walk the exception chain to find the root cause.
+     * Livewire 3 wraps mount() exceptions in ViewException.
+     */
+    private function getRootException(\Throwable $e): \Throwable
+    {
+        while ($e->getPrevious() !== null) {
+            $e = $e->getPrevious();
+        }
+
+        return $e;
+    }
+
+    // 1. Initial state: no selected ids ───────────────────────────────────────
+
+    public function test_initial_state_has_no_selected_ids(): void
+    {
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_ids',
+        ]);
+
+        $this->assertEmpty($component->get('selectedIds'));
+    }
+
+    // 2. addOption: appends once, duplicate is a no-op ─────────────────────────
+
+    public function test_add_option_appends_id(): void
+    {
+        $item = Item::factory()->create();
+
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_ids',
+        ]);
+
+        $component->call('addOption', $item->id);
+
+        $this->assertContains($item->id, $component->get('selectedIds'));
+    }
+
+    public function test_add_option_duplicate_is_a_noop(): void
+    {
+        $item = Item::factory()->create();
+
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_ids',
+        ]);
+
+        $component->call('addOption', $item->id);
+        $component->call('addOption', $item->id);
+
+        $this->assertCount(1, $component->get('selectedIds'));
+    }
+
+    public function test_add_option_resets_search_and_closes_dropdown(): void
+    {
+        $item = Item::factory()->create();
+
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_ids',
+        ]);
+
+        $component->set('search', 'something');
+        $component->set('open', true);
+        $component->call('addOption', $item->id);
+
+        $this->assertEquals('', $component->get('search'));
+        $this->assertFalse($component->get('open'));
+    }
+
+    // 3. removeOption: removes by id ──────────────────────────────────────────
+
+    public function test_remove_option_removes_the_specified_id(): void
+    {
+        $itemA = Item::factory()->create();
+        $itemB = Item::factory()->create();
+
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_ids',
+            'selectedIds' => [$itemA->id, $itemB->id],
+        ]);
+
+        $component->call('removeOption', $itemA->id);
+
+        $ids = $component->get('selectedIds');
+        $this->assertNotContains($itemA->id, $ids);
+        $this->assertContains($itemB->id, $ids);
+    }
+
+    public function test_remove_option_on_non_selected_id_is_a_noop(): void
+    {
+        $item = Item::factory()->create();
+        $other = Item::factory()->create();
+
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_ids',
+            'selectedIds' => [$item->id],
+        ]);
+
+        $component->call('removeOption', $other->id);
+
+        $this->assertCount(1, $component->get('selectedIds'));
+    }
+
+    // 4. clear: empties the selection ─────────────────────────────────────────
+
+    public function test_clear_empties_all_selected_ids(): void
+    {
+        $itemA = Item::factory()->create();
+        $itemB = Item::factory()->create();
+
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_ids',
+            'selectedIds' => [$itemA->id, $itemB->id],
+        ]);
+
+        $component->call('clear');
+
+        $this->assertEmpty($component->get('selectedIds'));
+    }
+
+    public function test_clear_resets_search_field(): void
+    {
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_ids',
+        ]);
+
+        $component->set('search', 'something');
+        $component->call('clear');
+
+        $this->assertEquals('', $component->get('search'));
+    }
+
+    // 5. Search composes with scopes ──────────────────────────────────────────
+
+    public function test_search_filters_candidates_with_scope(): void
+    {
+        $enabledMatch = Project::factory()->withEnabled()->create(['internal_name' => 'Alpha Enabled']);
+        $enabledNoMatch = Project::factory()->withEnabled()->create(['internal_name' => 'Beta Enabled']);
+        $disabledMatch = Project::factory()->create(['internal_name' => 'Alpha Disabled', 'is_enabled' => false]);
+
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'modelClass' => Project::class,
+            'name' => 'project_ids',
+            'scopes' => 'isEnabled',
+        ]);
+
+        $component->set('search', 'Alpha');
+        $component->set('open', true);
+
+        $options = $component->get('options');
+
+        $this->assertTrue($options->contains('id', $enabledMatch->id));
+        $this->assertFalse($options->contains('id', $enabledNoMatch->id));
+        $this->assertFalse($options->contains('id', $disabledMatch->id));
+    }
+
+    // 6. Ceiling guard still applies with staticOptions ───────────────────────
+
+    public function test_static_options_ceiling_guard_throws_when_exceeded(): void
+    {
+        $options = array_map(
+            fn ($i) => ['id' => (string) $i, 'internal_name' => "Option {$i}"],
+            range(1, 51)
+        );
+
+        try {
+            Livewire::test(SearchableMultiSelect::class, [
+                'staticOptions' => $options,
+                'name' => 'test_field',
+            ]);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\Throwable $e) {
+            $root = $this->getRootException($e);
+            $this->assertInstanceOf(\InvalidArgumentException::class, $root);
+            $this->assertStringContainsString('SearchableMultiSelect received', $root->getMessage());
+        }
+    }
+
+    public function test_static_options_within_ceiling_mounts_successfully(): void
+    {
+        $options = array_map(
+            fn ($i) => ['id' => (string) $i, 'internal_name' => "Option {$i}"],
+            range(1, 5)
+        );
+
+        Livewire::test(SearchableMultiSelect::class, [
+            'staticOptions' => $options,
+            'name' => 'test_field',
+        ])->assertOk();
+    }
+
+    // 7. selectedOptions renders chips without issuing a new query ─────────────
+
+    public function test_selected_options_returns_empty_collection_when_nothing_selected(): void
+    {
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_ids',
+        ]);
+
+        $this->assertTrue($component->get('selectedOptions')->isEmpty());
+    }
+
+    public function test_selected_options_hydrates_from_selected_ids(): void
+    {
+        $itemA = Item::factory()->create(['internal_name' => 'Item A']);
+        $itemB = Item::factory()->create(['internal_name' => 'Item B']);
+        $other = Item::factory()->create(['internal_name' => 'Other']);
+
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_ids',
+            'selectedIds' => [$itemA->id, $itemB->id],
+        ]);
+
+        $selected = $component->get('selectedOptions');
+
+        $this->assertCount(2, $selected);
+        $this->assertTrue($selected->contains('id', $itemA->id));
+        $this->assertTrue($selected->contains('id', $itemB->id));
+        $this->assertFalse($selected->contains('id', $other->id));
+    }
+
+    public function test_selected_options_with_static_options_returns_matching_entries(): void
+    {
+        $options = [
+            ['id' => '1', 'internal_name' => 'Option A'],
+            ['id' => '2', 'internal_name' => 'Option B'],
+            ['id' => '3', 'internal_name' => 'Option C'],
+        ];
+
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'staticOptions' => $options,
+            'name' => 'test_field',
+            'selectedIds' => ['1', '3'],
+        ]);
+
+        $selected = $component->get('selectedOptions');
+
+        $this->assertCount(2, $selected);
+    }
+
+    // Candidate options exclude already-selected ids ──────────────────────────
+
+    public function test_options_excludes_already_selected_ids(): void
+    {
+        $itemA = Item::factory()->create(['internal_name' => 'Item A']);
+        $itemB = Item::factory()->create(['internal_name' => 'Item B']);
+
+        $component = Livewire::test(SearchableMultiSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_ids',
+            'selectedIds' => [$itemA->id],
+        ]);
+
+        $component->set('open', true);
+
+        $options = $component->get('options');
+
+        $this->assertFalse($options->contains('id', $itemA->id));
+        $this->assertTrue($options->contains('id', $itemB->id));
+    }
+}

--- a/tests/Unit/Livewire/SearchableSelectScopeTest.php
+++ b/tests/Unit/Livewire/SearchableSelectScopeTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\Unit\Livewire;
+
+use App\Livewire\SearchableSelect;
+use App\Models\Project;
+use App\Models\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Tests for SearchableSelect scope parameter (Story 2.2).
+ *
+ * Verifies that named Eloquent scopes are accepted, normalised,
+ * applied to dynamic queries, and rejected when invalid.
+ */
+class SearchableSelectScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Walk the exception chain to find the root cause.
+     * Livewire 3 wraps mount() exceptions in ViewException.
+     */
+    private function getRootException(\Throwable $e): \Throwable
+    {
+        while ($e->getPrevious() !== null) {
+            $e = $e->getPrevious();
+        }
+
+        return $e;
+    }
+
+    public function test_valid_single_scope_filters_results(): void
+    {
+        $enabledProject = Project::factory()->withEnabled()->create(['internal_name' => 'Alpha']);
+        $disabledProject = Project::factory()->create(['internal_name' => 'Beta', 'is_enabled' => false]);
+
+        $component = Livewire::test(SearchableSelect::class, [
+            'modelClass' => Project::class,
+            'name' => 'project_id',
+            'scopes' => 'isEnabled',
+        ]);
+
+        $options = $component->get('options');
+
+        $this->assertTrue($options->contains('id', $enabledProject->id));
+        $this->assertFalse($options->contains('id', $disabledProject->id));
+    }
+
+    public function test_multiple_scopes_are_composed(): void
+    {
+        $enabledOnly = Project::factory()->withEnabled()->create(['internal_name' => 'Enabled Only', 'is_launched' => false]);
+        $launchedOnly = Project::factory()->create(['internal_name' => 'Launched Only', 'is_enabled' => false, 'is_launched' => true]);
+        $both = Project::factory()->withEnabled()->create(['internal_name' => 'Both', 'is_launched' => true]);
+
+        $component = Livewire::test(SearchableSelect::class, [
+            'modelClass' => Project::class,
+            'name' => 'project_id',
+            'scopes' => ['isEnabled', 'isLaunched'],
+        ]);
+
+        $options = $component->get('options');
+
+        $this->assertFalse($options->contains('id', $enabledOnly->id));
+        $this->assertFalse($options->contains('id', $launchedOnly->id));
+        $this->assertTrue($options->contains('id', $both->id));
+    }
+
+    public function test_scope_with_arguments_filters_results(): void
+    {
+        $keywordTag = Tag::factory()->keyword()->create(['internal_name' => 'Keyword Tag']);
+        $materialTag = Tag::factory()->material()->create(['internal_name' => 'Material Tag']);
+
+        $component = Livewire::test(SearchableSelect::class, [
+            'modelClass' => Tag::class,
+            'name' => 'tag_id',
+            'scopes' => [['scope' => 'byCategory', 'args' => ['keyword']]],
+        ]);
+
+        $options = $component->get('options');
+
+        $this->assertTrue($options->contains('id', $keywordTag->id));
+        $this->assertFalse($options->contains('id', $materialTag->id));
+    }
+
+    public function test_scope_with_arguments_can_be_combined_with_filter_column(): void
+    {
+        $keywordTagA = Tag::factory()->keyword()->create(['internal_name' => 'Keyword A']);
+        $keywordTagB = Tag::factory()->keyword()->create(['internal_name' => 'Keyword B']);
+
+        $component = Livewire::test(SearchableSelect::class, [
+            'modelClass' => Tag::class,
+            'name' => 'tag_id',
+            'scopes' => [['scope' => 'byCategory', 'args' => ['keyword']]],
+            'filterColumn' => 'id',
+            'filterOperator' => '!=',
+            'filterValue' => $keywordTagA->id,
+        ]);
+
+        $options = $component->get('options');
+
+        $this->assertFalse($options->contains('id', $keywordTagA->id));
+        $this->assertTrue($options->contains('id', $keywordTagB->id));
+    }
+
+    public function test_invalid_scope_name_with_non_alphanumeric_characters_throws(): void
+    {
+        try {
+            Livewire::test(SearchableSelect::class, [
+                'modelClass' => Project::class,
+                'name' => 'project_id',
+                'scopes' => 'invalid-scope!',
+            ]);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\Throwable $e) {
+            $root = $e;
+            while ($root->getPrevious() !== null) {
+                $root = $root->getPrevious();
+            }
+            $this->assertInstanceOf(\InvalidArgumentException::class, $root);
+            $this->assertStringContainsString('non-alphanumeric', $root->getMessage());
+        }
+    }
+
+    public function test_unknown_scope_on_model_throws(): void
+    {
+        try {
+            Livewire::test(SearchableSelect::class, [
+                'modelClass' => Project::class,
+                'name' => 'project_id',
+                'scopes' => 'nonExistentScope',
+            ]);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\Throwable $e) {
+            $root = $e;
+            while ($root->getPrevious() !== null) {
+                $root = $root->getPrevious();
+            }
+            $this->assertInstanceOf(\InvalidArgumentException::class, $root);
+            $this->assertStringContainsString('does not exist on model', $root->getMessage());
+        }
+    }
+
+    public function test_scopes_accepted_as_string_shape(): void
+    {
+        Project::factory()->withEnabled()->create(['internal_name' => 'Enabled']);
+        Project::factory()->create(['internal_name' => 'Disabled', 'is_enabled' => false]);
+
+        Livewire::test(SearchableSelect::class, [
+            'modelClass' => Project::class,
+            'name' => 'project_id',
+            'scopes' => 'isEnabled',
+        ])->assertOk();
+    }
+
+    public function test_scopes_accepted_as_array_of_strings_shape(): void
+    {
+        Project::factory()->withEnabled()->create(['internal_name' => 'Enabled', 'is_launched' => true]);
+
+        Livewire::test(SearchableSelect::class, [
+            'modelClass' => Project::class,
+            'name' => 'project_id',
+            'scopes' => ['isEnabled', 'isLaunched'],
+        ])->assertOk();
+    }
+
+    public function test_scopes_accepted_as_array_of_scope_arrays_shape(): void
+    {
+        Tag::factory()->keyword()->create(['internal_name' => 'Keyword']);
+
+        Livewire::test(SearchableSelect::class, [
+            'modelClass' => Tag::class,
+            'name' => 'tag_id',
+            'scopes' => [['scope' => 'byCategory', 'args' => ['keyword']]],
+        ])->assertOk();
+    }
+}

--- a/tests/Unit/Livewire/SearchableSelectSearchTest.php
+++ b/tests/Unit/Livewire/SearchableSelectSearchTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Unit\Livewire;
+
+use App\Livewire\SearchableSelect;
+use App\Models\Item;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Tests for SearchableSelect prefix-first search and configurable perPage (Story 2.3).
+ *
+ * Verifies that prefix matches appear before infix-only matches and that
+ * the result set is bounded by the perPage prop (or its config default).
+ */
+class SearchableSelectSearchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_prefix_match_is_returned_before_infix_only_match(): void
+    {
+        // 'Alpha Item' starts with 'Alpha' (prefix match)
+        $prefixItem = Item::factory()->create(['internal_name' => 'Alpha Item']);
+        // 'Not Alpha' contains 'Alpha' but does not start with it (infix-only match)
+        $infixItem = Item::factory()->create(['internal_name' => 'Not Alpha']);
+
+        $component = Livewire::test(SearchableSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_id',
+        ])->set('search', 'Alpha');
+
+        $options = $component->get('options');
+
+        $this->assertCount(2, $options);
+        $this->assertEquals($prefixItem->id, $options->first()->id);
+        $this->assertEquals($infixItem->id, $options->last()->id);
+    }
+
+    public function test_fallback_infix_match_appears_after_prefix_matches(): void
+    {
+        $prefixA = Item::factory()->create(['internal_name' => 'Alpha First']);
+        $prefixB = Item::factory()->create(['internal_name' => 'Alpha Second']);
+        $infixOnly = Item::factory()->create(['internal_name' => 'Not Alpha At All']);
+
+        $component = Livewire::test(SearchableSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_id',
+        ])->set('search', 'Alpha');
+
+        $options = $component->get('options');
+        $ids = $options->pluck('id')->all();
+
+        // Both prefix matches come before the infix-only match
+        $posA = array_search($prefixA->id, $ids);
+        $posB = array_search($prefixB->id, $ids);
+        $posInfix = array_search($infixOnly->id, $ids);
+
+        $this->assertLessThan($posInfix, $posA);
+        $this->assertLessThan($posInfix, $posB);
+    }
+
+    public function test_per_page_prop_limits_results(): void
+    {
+        Item::factory()->count(10)->create();
+
+        $component = Livewire::test(SearchableSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_id',
+            'perPage' => 3,
+        ]);
+
+        $this->assertCount(3, $component->get('options'));
+    }
+
+    public function test_per_page_config_default_is_honoured(): void
+    {
+        config()->set('interface.searchable_select.per_page', 4);
+
+        Item::factory()->count(10)->create();
+
+        $component = Livewire::test(SearchableSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_id',
+        ]);
+
+        $this->assertLessThanOrEqual(4, $component->get('options')->count());
+    }
+
+    public function test_empty_search_returns_results_ordered_alphabetically(): void
+    {
+        Item::factory()->create(['internal_name' => 'Zeta']);
+        Item::factory()->create(['internal_name' => 'Alpha']);
+        Item::factory()->create(['internal_name' => 'Mu']);
+
+        $component = Livewire::test(SearchableSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_id',
+        ])->set('search', '');
+
+        $options = $component->get('options');
+        $names = $options->pluck('internal_name')->all();
+
+        $sorted = $names;
+        sort($sorted);
+        $this->assertEquals($sorted, $names);
+    }
+
+    public function test_no_results_returned_when_nothing_matches_search(): void
+    {
+        Item::factory()->create(['internal_name' => 'Alpha Item']);
+
+        $component = Livewire::test(SearchableSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_id',
+        ])->set('search', 'xyzxyzxyz');
+
+        $this->assertCount(0, $component->get('options'));
+    }
+}

--- a/tests/Unit/Livewire/SearchableSelectStaticOptionsCeilingTest.php
+++ b/tests/Unit/Livewire/SearchableSelectStaticOptionsCeilingTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Unit\Livewire;
+
+use App\Livewire\SearchableSelect;
+use App\Models\Item;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Tests for SearchableSelect staticOptions ceiling guard (Story 2.1).
+ *
+ * Verifies that mount() throws InvalidArgumentException when staticOptions
+ * exceeds the configured maximum, and that the limit is configurable.
+ */
+class SearchableSelectStaticOptionsCeilingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeOptions(int $count): array
+    {
+        return array_map(
+            fn ($i) => ['id' => (string) $i, 'internal_name' => "Option {$i}"],
+            range(1, $count)
+        );
+    }
+
+    /**
+     * Walk the exception chain to find the root cause.
+     * Livewire 3 wraps mount() exceptions in ViewException.
+     */
+    private function getRootException(\Throwable $e): \Throwable
+    {
+        while ($e->getPrevious() !== null) {
+            $e = $e->getPrevious();
+        }
+
+        return $e;
+    }
+
+    public function test_component_mounts_when_static_options_are_within_ceiling(): void
+    {
+        $options = $this->makeOptions(3);
+
+        Livewire::test(SearchableSelect::class, [
+            'staticOptions' => $options,
+            'name' => 'test_field',
+        ])->assertOk();
+    }
+
+    public function test_component_throws_when_static_options_exceed_ceiling(): void
+    {
+        $options = $this->makeOptions(51);
+
+        try {
+            Livewire::test(SearchableSelect::class, [
+                'staticOptions' => $options,
+                'name' => 'test_field',
+            ]);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\Throwable $e) {
+            $root = $this->getRootException($e);
+            $this->assertInstanceOf(\InvalidArgumentException::class, $root);
+            $this->assertMatchesRegularExpression(
+                '/SearchableSelect received \d+ staticOptions but the configured maximum is \d+/',
+                $root->getMessage()
+            );
+        }
+    }
+
+    public function test_exception_message_includes_count_max_and_guidance(): void
+    {
+        config()->set('interface.searchable_select.static_options_max', 10);
+
+        $options = $this->makeOptions(15);
+
+        try {
+            Livewire::test(SearchableSelect::class, [
+                'staticOptions' => $options,
+                'name' => 'test_field',
+            ]);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\Throwable $e) {
+            $root = $this->getRootException($e);
+            $this->assertInstanceOf(\InvalidArgumentException::class, $root);
+            $this->assertStringContainsString('SearchableSelect received 15 staticOptions', $root->getMessage());
+            $this->assertStringContainsString('the configured maximum is 10', $root->getMessage());
+            $this->assertStringContainsString('dynamic mode', $root->getMessage());
+        }
+    }
+
+    public function test_config_override_raises_the_ceiling(): void
+    {
+        config()->set('interface.searchable_select.static_options_max', 100);
+
+        $options = $this->makeOptions(60);
+
+        Livewire::test(SearchableSelect::class, [
+            'staticOptions' => $options,
+            'name' => 'test_field',
+        ])->assertOk();
+    }
+
+    public function test_config_override_lowers_the_ceiling(): void
+    {
+        config()->set('interface.searchable_select.static_options_max', 2);
+
+        $options = $this->makeOptions(3);
+
+        try {
+            Livewire::test(SearchableSelect::class, [
+                'staticOptions' => $options,
+                'name' => 'test_field',
+            ]);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\Throwable $e) {
+            $root = $this->getRootException($e);
+            $this->assertInstanceOf(\InvalidArgumentException::class, $root);
+        }
+    }
+
+    public function test_ceiling_is_not_applied_in_dynamic_mode(): void
+    {
+        config()->set('interface.searchable_select.static_options_max', 2);
+
+        Livewire::test(SearchableSelect::class, [
+            'modelClass' => Item::class,
+            'name' => 'item_id',
+        ])->assertOk();
+    }
+}

--- a/tests/Unit/Livewire/Support/OptionsLookupTest.php
+++ b/tests/Unit/Livewire/Support/OptionsLookupTest.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Tests\Unit\Livewire\Support;
+
+use App\Livewire\Support\OptionsLookup;
+use App\Models\Item;
+use App\Models\Project;
+use App\Models\Tag;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Minimal stub for testing OptionsLookup methods in isolation.
+ *
+ * Exposes the protected normalizeScopes method so the test can call it directly.
+ */
+class OptionsLookupStub
+{
+    use OptionsLookup;
+
+    public string $search = '';
+
+    public $staticOptions = null;
+
+    public ?string $modelClass = null;
+
+    public string $displayField = 'internal_name';
+
+    public ?string $filterColumn = null;
+
+    public ?string $filterOperator = '!=';
+
+    public $filterValue = null;
+
+    public $scopes = null;
+
+    public int $perPage = 50;
+
+    public function exposeNormalizeScopes(mixed $scopes, ?string $modelClass): array
+    {
+        return $this->normalizeScopes($scopes, $modelClass);
+    }
+}
+
+/**
+ * Unit tests for the OptionsLookup trait (Story 3.1).
+ *
+ * Uses a lightweight stub class to exercise the trait in complete isolation
+ * from Livewire's component infrastructure.
+ */
+class OptionsLookupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeStub(array $properties = []): OptionsLookupStub
+    {
+        $stub = new OptionsLookupStub;
+        foreach ($properties as $key => $value) {
+            $stub->$key = $value;
+        }
+
+        return $stub;
+    }
+
+    // ── resolveStaticOptions ──────────────────────────────────────────────────
+
+    public function test_resolve_static_options_returns_all_when_search_is_empty(): void
+    {
+        $stub = $this->makeStub([
+            'staticOptions' => [
+                ['id' => '1', 'internal_name' => 'Alpha'],
+                ['id' => '2', 'internal_name' => 'Beta'],
+            ],
+        ]);
+
+        $this->assertCount(2, $stub->resolveStaticOptions());
+    }
+
+    public function test_resolve_static_options_filters_by_search(): void
+    {
+        $stub = $this->makeStub([
+            'staticOptions' => [
+                ['id' => '1', 'internal_name' => 'Alpha'],
+                ['id' => '2', 'internal_name' => 'Beta'],
+            ],
+            'search' => 'alp',
+        ]);
+
+        $result = $stub->resolveStaticOptions();
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('Alpha', $result->first()['internal_name']);
+    }
+
+    public function test_resolve_static_options_is_case_insensitive(): void
+    {
+        $stub = $this->makeStub([
+            'staticOptions' => [['id' => '1', 'internal_name' => 'Alpha']],
+            'search' => 'ALPHA',
+        ]);
+
+        $this->assertCount(1, $stub->resolveStaticOptions());
+    }
+
+    // ── resolveOptionsQuery ───────────────────────────────────────────────────
+
+    public function test_resolve_options_query_returns_builder(): void
+    {
+        $stub = $this->makeStub(['modelClass' => Item::class]);
+
+        $this->assertInstanceOf(Builder::class, $stub->resolveOptionsQuery());
+    }
+
+    public function test_resolve_options_query_respects_per_page_limit(): void
+    {
+        Item::factory()->count(10)->create();
+
+        $stub = $this->makeStub(['modelClass' => Item::class, 'perPage' => 3]);
+
+        $this->assertCount(3, $stub->resolveOptionsQuery()->get());
+    }
+
+    // ── applySearch ───────────────────────────────────────────────────────────
+
+    public function test_apply_search_orders_prefix_matches_before_infix(): void
+    {
+        $prefixItem = Item::factory()->create(['internal_name' => 'Alpha Item']);
+        $infixItem = Item::factory()->create(['internal_name' => 'Not Alpha']);
+
+        $stub = $this->makeStub(['modelClass' => Item::class, 'perPage' => 50]);
+
+        $results = $stub->applySearch(Item::query(), 'Alpha')->get();
+
+        $this->assertEquals($prefixItem->id, $results->first()->id);
+        $this->assertEquals($infixItem->id, $results->last()->id);
+    }
+
+    public function test_apply_search_with_empty_string_returns_all_ordered(): void
+    {
+        Item::factory()->count(3)->create();
+
+        $stub = $this->makeStub(['modelClass' => Item::class, 'perPage' => 50]);
+
+        $results = $stub->applySearch(Item::query(), '')->get();
+
+        $this->assertCount(3, $results);
+    }
+
+    // ── applyScopes ───────────────────────────────────────────────────────────
+
+    public function test_apply_scopes_filters_with_named_scope(): void
+    {
+        $enabled = Project::factory()->withEnabled()->create(['internal_name' => 'Enabled']);
+        $disabled = Project::factory()->create(['internal_name' => 'Disabled', 'is_enabled' => false]);
+
+        $stub = $this->makeStub([
+            'scopes' => [['scope' => 'isEnabled', 'args' => []]],
+        ]);
+
+        $results = $stub->applyScopes(Project::query())->get();
+
+        $this->assertTrue($results->contains('id', $enabled->id));
+        $this->assertFalse($results->contains('id', $disabled->id));
+    }
+
+    public function test_apply_scopes_with_null_scopes_returns_unfiltered(): void
+    {
+        Project::factory()->count(3)->create();
+
+        $stub = $this->makeStub(['scopes' => null]);
+
+        $results = $stub->applyScopes(Project::query())->get();
+
+        $this->assertCount(3, $results);
+    }
+
+    // ── normalizeScopes ───────────────────────────────────────────────────────
+
+    public function test_normalize_scopes_accepts_single_string(): void
+    {
+        $stub = $this->makeStub();
+
+        $result = $stub->exposeNormalizeScopes('isEnabled', Project::class);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('isEnabled', $result[0]['scope']);
+        $this->assertEquals([], $result[0]['args']);
+    }
+
+    public function test_normalize_scopes_accepts_array_of_strings(): void
+    {
+        $stub = $this->makeStub();
+
+        $result = $stub->exposeNormalizeScopes(['isEnabled', 'isLaunched'], Project::class);
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('isEnabled', $result[0]['scope']);
+        $this->assertEquals('isLaunched', $result[1]['scope']);
+    }
+
+    public function test_normalize_scopes_accepts_fully_specified_array_with_args(): void
+    {
+        $stub = $this->makeStub();
+
+        $result = $stub->exposeNormalizeScopes(
+            [['scope' => 'byCategory', 'args' => ['keyword']]],
+            Tag::class
+        );
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('byCategory', $result[0]['scope']);
+        $this->assertEquals(['keyword'], $result[0]['args']);
+    }
+
+    public function test_normalize_scopes_throws_for_non_alphanumeric_name(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/non-alphanumeric/');
+
+        $stub = $this->makeStub();
+        $stub->exposeNormalizeScopes('invalid-scope', null);
+    }
+
+    public function test_normalize_scopes_throws_for_unknown_scope_on_model(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/does not exist on model/');
+
+        $stub = $this->makeStub();
+        $stub->exposeNormalizeScopes('nonExistentScope', Project::class);
+    }
+
+    public function test_normalize_scopes_throws_for_non_array_non_string_input(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $stub = $this->makeStub();
+        $stub->exposeNormalizeScopes(123, null);
+    }
+
+    public function test_normalize_scopes_throws_for_object_scope_arg(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Scope arguments must be/');
+
+        $stub = $this->makeStub();
+        $stub->exposeNormalizeScopes(
+            [['scope' => 'byCategory', 'args' => [new \stdClass]]],
+            Tag::class
+        );
+    }
+
+    public function test_normalize_scopes_throws_for_malformed_scope_entry(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $stub = $this->makeStub();
+        // Array entry without 'scope' key
+        $stub->exposeNormalizeScopes([['invalid_key' => 'isEnabled']], null);
+    }
+}

--- a/tests/Unit/Models/CollectionScopeTest.php
+++ b/tests/Unit/Models/CollectionScopeTest.php
@@ -60,4 +60,56 @@ class CollectionScopeTest extends TestCase
         $this->assertFalse($results->contains('id', $collection->id));
         $this->assertFalse($results->contains('id', $exhibition->id));
     }
+
+    public function test_scope_excluding_ids_excludes_given_ids(): void
+    {
+        $col1 = Collection::factory()->collection()->create();
+        $col2 = Collection::factory()->collection()->create();
+        $col3 = Collection::factory()->collection()->create();
+
+        $results = Collection::excludingIds([$col1->id, $col2->id])->get();
+
+        $this->assertFalse($results->contains('id', $col1->id));
+        $this->assertFalse($results->contains('id', $col2->id));
+        $this->assertTrue($results->contains('id', $col3->id));
+    }
+
+    public function test_scope_excluding_ids_with_empty_array_returns_all(): void
+    {
+        Collection::factory()->collection()->count(3)->create();
+
+        $results = Collection::excludingIds([])->get();
+
+        $this->assertCount(3, $results);
+    }
+
+    public function test_scope_excluding_descendants_of_excludes_self_and_children(): void
+    {
+        $root = Collection::factory()->collection()->create();
+        $child = Collection::factory()->collection()->withParent($root->id)->create();
+        $grandchild = Collection::factory()->collection()->withParent($child->id)->create();
+        $unrelated = Collection::factory()->collection()->create();
+
+        $results = Collection::excludingDescendantsOf($root->id)->get();
+
+        $this->assertFalse($results->contains('id', $root->id));
+        $this->assertFalse($results->contains('id', $child->id));
+        $this->assertFalse($results->contains('id', $grandchild->id));
+        $this->assertTrue($results->contains('id', $unrelated->id));
+    }
+
+    public function test_scope_excluding_ancestors_of_excludes_self_and_parents(): void
+    {
+        $grandparent = Collection::factory()->collection()->create();
+        $parent = Collection::factory()->collection()->withParent($grandparent->id)->create();
+        $subject = Collection::factory()->collection()->withParent($parent->id)->create();
+        $unrelated = Collection::factory()->collection()->create();
+
+        $results = Collection::excludingAncestorsOf($subject->id)->get();
+
+        $this->assertFalse($results->contains('id', $subject->id));
+        $this->assertFalse($results->contains('id', $parent->id));
+        $this->assertFalse($results->contains('id', $grandparent->id));
+        $this->assertTrue($results->contains('id', $unrelated->id));
+    }
 }

--- a/tests/Unit/Models/ContextScopeTest.php
+++ b/tests/Unit/Models/ContextScopeTest.php
@@ -25,4 +25,26 @@ class ContextScopeTest extends TestCase
         $this->assertEquals($default->id, $result->id);
         $this->assertTrue($result->is_default);
     }
+
+    public function test_scope_excluding_ids_excludes_given_ids(): void
+    {
+        $ctx1 = Context::factory()->create(['is_default' => false]);
+        $ctx2 = Context::factory()->create(['is_default' => false]);
+        $ctx3 = Context::factory()->create(['is_default' => false]);
+
+        $results = Context::excludingIds([$ctx1->id, $ctx2->id])->get();
+
+        $this->assertFalse($results->contains('id', $ctx1->id));
+        $this->assertFalse($results->contains('id', $ctx2->id));
+        $this->assertTrue($results->contains('id', $ctx3->id));
+    }
+
+    public function test_scope_excluding_ids_with_empty_array_returns_all(): void
+    {
+        Context::factory()->count(3)->create(['is_default' => false]);
+
+        $results = Context::excludingIds([])->get();
+
+        $this->assertCount(3, $results);
+    }
 }

--- a/tests/Unit/Models/ItemScopeTest.php
+++ b/tests/Unit/Models/ItemScopeTest.php
@@ -116,4 +116,84 @@ class ItemScopeTest extends TestCase
         $this->assertCount(1, $itemsWithAnyTags);
         $this->assertTrue($itemsWithAnyTags->contains('id', $item->id));
     }
+
+    public function test_scope_excluding_ids_excludes_given_ids(): void
+    {
+        $item1 = Item::factory()->create();
+        $item2 = Item::factory()->create();
+        $item3 = Item::factory()->create();
+
+        $results = Item::excludingIds([$item1->id, $item2->id])->get();
+
+        $this->assertFalse($results->contains('id', $item1->id));
+        $this->assertFalse($results->contains('id', $item2->id));
+        $this->assertTrue($results->contains('id', $item3->id));
+    }
+
+    public function test_scope_excluding_ids_with_empty_array_returns_all(): void
+    {
+        Item::factory()->count(3)->create();
+
+        $results = Item::excludingIds([])->get();
+
+        $this->assertCount(3, $results);
+    }
+
+    public function test_scope_excluding_descendants_of_excludes_self_and_children(): void
+    {
+        $root = Item::factory()->create();
+        $child = Item::factory()->withParent($root)->create();
+        $grandchild = Item::factory()->withParent($child)->create();
+        $unrelated = Item::factory()->create();
+
+        $results = Item::excludingDescendantsOf($root->id)->get();
+
+        $this->assertFalse($results->contains('id', $root->id));
+        $this->assertFalse($results->contains('id', $child->id));
+        $this->assertFalse($results->contains('id', $grandchild->id));
+        $this->assertTrue($results->contains('id', $unrelated->id));
+    }
+
+    public function test_scope_excluding_descendants_of_only_excludes_own_subtree(): void
+    {
+        $branch1 = Item::factory()->create();
+        $branch1Child = Item::factory()->withParent($branch1)->create();
+        $branch2 = Item::factory()->create();
+        $branch2Child = Item::factory()->withParent($branch2)->create();
+
+        $results = Item::excludingDescendantsOf($branch1->id)->get();
+
+        $this->assertFalse($results->contains('id', $branch1->id));
+        $this->assertFalse($results->contains('id', $branch1Child->id));
+        $this->assertTrue($results->contains('id', $branch2->id));
+        $this->assertTrue($results->contains('id', $branch2Child->id));
+    }
+
+    public function test_scope_excluding_ancestors_of_excludes_self_and_parents(): void
+    {
+        $grandparent = Item::factory()->create();
+        $parent = Item::factory()->withParent($grandparent)->create();
+        $subject = Item::factory()->withParent($parent)->create();
+        $unrelated = Item::factory()->create();
+
+        $results = Item::excludingAncestorsOf($subject->id)->get();
+
+        $this->assertFalse($results->contains('id', $subject->id));
+        $this->assertFalse($results->contains('id', $parent->id));
+        $this->assertFalse($results->contains('id', $grandparent->id));
+        $this->assertTrue($results->contains('id', $unrelated->id));
+    }
+
+    public function test_scope_excluding_ancestors_of_leaves_siblings_visible(): void
+    {
+        $parent = Item::factory()->create();
+        $subject = Item::factory()->withParent($parent)->create();
+        $sibling = Item::factory()->withParent($parent)->create();
+
+        $results = Item::excludingAncestorsOf($subject->id)->get();
+
+        $this->assertFalse($results->contains('id', $subject->id));
+        $this->assertFalse($results->contains('id', $parent->id));
+        $this->assertTrue($results->contains('id', $sibling->id));
+    }
 }

--- a/tests/Unit/Models/TagScopeTest.php
+++ b/tests/Unit/Models/TagScopeTest.php
@@ -51,4 +51,28 @@ class TagScopeTest extends TestCase
         $this->assertCount(1, $tagsForItem);
         $this->assertTrue($tagsForItem->contains('id', $tag->id));
     }
+
+    public function test_scope_not_attached_to_excludes_tags_already_on_item(): void
+    {
+        $item = Item::factory()->create();
+        $attachedTag = Tag::factory()->create();
+        $unattachedTag = Tag::factory()->create();
+
+        $item->tags()->attach($attachedTag->id);
+
+        $results = Tag::notAttachedTo($item->id)->get();
+
+        $this->assertFalse($results->contains('id', $attachedTag->id));
+        $this->assertTrue($results->contains('id', $unattachedTag->id));
+    }
+
+    public function test_scope_not_attached_to_returns_all_when_no_tags_attached(): void
+    {
+        $item = Item::factory()->create();
+        Tag::factory()->count(3)->create();
+
+        $results = Tag::notAttachedTo($item->id)->get();
+
+        $this->assertCount(3, $results);
+    }
 }

--- a/tests/Unit/Requests/Web/IndexListRequestTest.php
+++ b/tests/Unit/Requests/Web/IndexListRequestTest.php
@@ -43,7 +43,7 @@ class IndexListRequestTest extends TestCase
         $partnerDefinition = new PartnerListDefinition;
         $collectionDefinition = new CollectionListDefinition;
 
-        $this->assertSame([], $partnerDefinition->filterParameters());
+        $this->assertSame(['country_id'], $partnerDefinition->filterParameters());
         $this->assertSame(['country'], $partnerDefinition->eagerLoads());
 
         $this->assertSame(['parent_id', 'mode'], $collectionDefinition->filterParameters());

--- a/tests/Unit/Services/CollectionShowPageDataTest.php
+++ b/tests/Unit/Services/CollectionShowPageDataTest.php
@@ -7,7 +7,6 @@ use App\Models\CollectionImage;
 use App\Models\CollectionTranslation;
 use App\Models\Context;
 use App\Models\Item;
-use App\Models\ItemImage;
 use App\Models\Language;
 use App\Services\Web\CollectionShowPageData;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -33,7 +32,6 @@ class CollectionShowPageDataTest extends TestCase
         ]);
         $item = Item::factory()->create();
         $collection->attachItem($item);
-        ItemImage::factory()->create(['item_id' => $item->id]);
         CollectionImage::factory()->create(['collection_id' => $collection->id]);
         CollectionTranslation::factory()->forCollection($collection->id)->withLanguage($defaultLanguage->id)->withContext($defaultContext->id)->create();
 
@@ -54,12 +52,16 @@ class CollectionShowPageDataTest extends TestCase
             ['images', 'children', 'items', 'translations', 'parent', 'system'],
             array_keys($pageData['sections'])
         );
+        $this->assertArrayHasKey('items', $pageData['sections']['items']);
+        $this->assertArrayNotHasKey('attachableItems', $pageData['sections']['items']);
+        $this->assertArrayHasKey('collection', $pageData['sections']['parent']);
+        $this->assertArrayNotHasKey('options', $pageData['sections']['parent']);
 
         $pageData['sections']['images']['images']->first()?->alt_text;
         $pageData['sections']['translations']['groups']->first()['translations']->first()?->language?->internal_name;
         $pageData['sections']['children']['items']->first()?->internal_name;
-        $pageData['sections']['items']['attachableItems']->first()?->internal_name;
-        $pageData['sections']['parent']['options']->first()?->internal_name;
+        $pageData['sections']['items']['items']->first()?->internal_name;
+        $pageData['sections']['parent']['collection']?->internal_name;
         $pageData['sections']['children']['items']->first()?->display_order;
         $pageData['sections']['system']['id'];
 

--- a/tests/Unit/Services/ItemShowPageDataTest.php
+++ b/tests/Unit/Services/ItemShowPageDataTest.php
@@ -74,10 +74,8 @@ class ItemShowPageDataTest extends TestCase
         $pageData['sections']['pictureChildren']['items']->first()?->itemImages->first()?->alt_text;
         $pageData['sections']['translations']['groups']->first()['translations']->first()?->language?->internal_name;
         $pageData['sections']['links']['formatted']->first()?->item?->internal_name;
-        $pageData['sections']['links']['contextOptions']->first()?->internal_name;
-        $pageData['sections']['links']['targetOptions']->first()?->internal_name;
-        $pageData['sections']['parent']['options']->first()?->internal_name;
-        $pageData['sections']['children']['options']->first()?->internal_name;
+        $pageData['sections']['parent']['item']?->internal_name;
+        $pageData['sections']['children']['items']->first()?->internal_name;
         $pageData['sections']['system']['id'];
 
         $this->assertCount($queryCountAfterBuild, DB::getQueryLog());

--- a/tests/Unit/Services/PartnerShowPageDataTest.php
+++ b/tests/Unit/Services/PartnerShowPageDataTest.php
@@ -42,10 +42,12 @@ class PartnerShowPageDataTest extends TestCase
             ['images', 'translations', 'monument', 'system'],
             array_keys($pageData['sections'])
         );
+        $this->assertArrayHasKey('item', $pageData['sections']['monument']);
+        $this->assertArrayNotHasKey('options', $pageData['sections']['monument']);
 
         $pageData['sections']['images']['images']->first()?->alt_text;
         $pageData['sections']['translations']['groups']->first()['translations']->first()?->language?->internal_name;
-        $pageData['sections']['monument']['options']->first()?->internal_name;
+        $pageData['sections']['monument']['item']?->internal_name;
         $pageData['sections']['system']['id'];
 
         $this->assertCount($queryCountAfterBuild, DB::getQueryLog());

--- a/tests/Unit/View/Composers/SettingsComposerTest.php
+++ b/tests/Unit/View/Composers/SettingsComposerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit\View\Composers;
+
+use App\Models\Setting;
+use App\Services\Settings;
+use App\View\Composers\SettingsComposer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\View\View;
+use Tests\TestCase;
+
+class SettingsComposerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_compose_binds_false_when_setting_is_absent(): void
+    {
+        Setting::query()->delete();
+
+        $settings = new Settings;
+        $composer = new SettingsComposer($settings);
+
+        $view = $this->createMock(View::class);
+        $view->expects($this->once())
+            ->method('with')
+            ->with('selfRegistrationEnabled', false);
+
+        $composer->compose($view);
+    }
+
+    public function test_compose_binds_true_when_setting_is_enabled(): void
+    {
+        Setting::set('self_registration_enabled', true, 'boolean');
+
+        $settings = new Settings;
+        $composer = new SettingsComposer($settings);
+
+        $view = $this->createMock(View::class);
+        $view->expects($this->once())
+            ->method('with')
+            ->with('selfRegistrationEnabled', true);
+
+        $composer->compose($view);
+    }
+
+    public function test_compose_binds_false_when_setting_is_disabled(): void
+    {
+        Setting::set('self_registration_enabled', false, 'boolean');
+
+        $settings = new Settings;
+        $composer = new SettingsComposer($settings);
+
+        $view = $this->createMock(View::class);
+        $view->expects($this->once())
+            ->method('with')
+            ->with('selfRegistrationEnabled', false);
+
+        $composer->compose($view);
+    }
+
+    public function test_settings_service_caches_result_within_same_instance(): void
+    {
+        Setting::set('self_registration_enabled', true, 'boolean');
+
+        $settings = new Settings;
+
+        $first = $settings->selfRegistrationEnabled();
+
+        // Delete setting after first call — cached value must be returned
+        Setting::query()->delete();
+
+        $second = $settings->selfRegistrationEnabled();
+
+        $this->assertTrue($first);
+        $this->assertTrue($second);
+    }
+}

--- a/tests/Web/Pages/CollectionShowRealisticDatasetTest.php
+++ b/tests/Web/Pages/CollectionShowRealisticDatasetTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Web\Pages;
+
+use App\Models\Collection;
+use App\Models\CollectionImage;
+use App\Models\CollectionTranslation;
+use App\Models\Item;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Web\Traits\AuthenticatesWebRequests;
+use Tests\Web\Traits\RendersShowPageUnderRealisticDataset;
+
+/**
+ * Realistic-dataset HTTP test for GET /web/collections/{id}.
+ *
+ * Seeds a production-like number of related rows to surface memory-exhaustion
+ * and query-count regressions that a single-record test would not catch.
+ */
+class CollectionShowRealisticDatasetTest extends TestCase
+{
+    use AuthenticatesWebRequests;
+    use RefreshDatabase;
+    use RendersShowPageUnderRealisticDataset;
+
+    /**
+     * 30 covers collection eager-loads (context, language, parent, children,
+     * translations, attachedItems.itemImages, collectionImages) plus auth
+     * overhead.  The page does not embed full-table option snapshots.
+     */
+    protected function queryBudget(): int
+    {
+        return 30;
+    }
+
+    /**
+     * 1 MB ceiling — with dynamic-mode Livewire selects the page should be
+     * well within this; we keep a generous default for future additions.
+     */
+    protected function responseSizeBudget(): int
+    {
+        return 1_000_000;
+    }
+
+    protected function getShowRouteName(): string
+    {
+        return 'collections.show';
+    }
+
+    protected function seedRealisticDataset(): Model
+    {
+        $subject = Collection::factory()->create();
+
+        // ≥ 200 sibling collections to verify no full-table load
+        Collection::factory()->count(200)->create();
+
+        // ≥ 20 child collections attached to the subject
+        Collection::factory()->count(20)->create(['parent_id' => $subject->id, 'display_order' => null]);
+
+        // ≥ 50 items attached to the subject
+        $items = Item::factory()->count(50)->create();
+        $subject->attachedItems()->attach($items->pluck('id'));
+
+        // ≥ 10 translations attached to the subject
+        CollectionTranslation::factory()->count(10)->create(['collection_id' => $subject->id]);
+
+        // ≥ 5 images attached to the subject
+        CollectionImage::factory()->count(5)->forCollection($subject)->create();
+
+        return $subject;
+    }
+}

--- a/tests/Web/Pages/CollectionTranslationIndexTest.php
+++ b/tests/Web/Pages/CollectionTranslationIndexTest.php
@@ -196,4 +196,56 @@ class CollectionTranslationIndexTest extends TestCase
 
         $this->assertSame($collection->id, $response->viewData('collection')->id);
     }
+
+    public function test_index_does_not_preload_full_language_or_context_tables(): void
+    {
+        $collection = Collection::factory()->create();
+
+        $response = $this->get(route('collection-translations.index', ['collection_id' => $collection->id]));
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey('languages', $response->viewData());
+        $this->assertArrayNotHasKey('contexts', $response->viewData());
+    }
+
+    public function test_index_exposes_selected_language_when_filter_is_active(): void
+    {
+        $collection = Collection::factory()->create();
+        $language = Language::factory()->create(['internal_name' => 'English']);
+        CollectionTranslation::factory()->forCollection($collection->id)->withLanguage($language->id)->create();
+
+        $response = $this->get(route('collection-translations.index', [
+            'collection_id' => $collection->id,
+            'language' => $language->id,
+        ]));
+
+        $response->assertOk();
+        $this->assertSame($language->id, $response->viewData('selectedLanguage')->id);
+    }
+
+    public function test_index_exposes_selected_context_when_filter_is_active(): void
+    {
+        $collection = Collection::factory()->create();
+        $context = Context::factory()->create(['internal_name' => 'Web']);
+        CollectionTranslation::factory()->forCollection($collection->id)->withContext($context->id)->create();
+
+        $response = $this->get(route('collection-translations.index', [
+            'collection_id' => $collection->id,
+            'context' => $context->id,
+        ]));
+
+        $response->assertOk();
+        $this->assertSame($context->id, $response->viewData('selectedContext')->id);
+    }
+
+    public function test_index_exposes_null_selected_options_when_no_filter_active(): void
+    {
+        $collection = Collection::factory()->create();
+
+        $response = $this->get(route('collection-translations.index', ['collection_id' => $collection->id]));
+
+        $response->assertOk();
+        $this->assertNull($response->viewData('selectedLanguage'));
+        $this->assertNull($response->viewData('selectedContext'));
+    }
 }

--- a/tests/Web/Pages/ContextShowRealisticDatasetTest.php
+++ b/tests/Web/Pages/ContextShowRealisticDatasetTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Web\Pages;
+
+use App\Models\Context;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Web\Traits\AuthenticatesWebRequests;
+use Tests\Web\Traits\RendersShowPageUnderRealisticDataset;
+
+/**
+ * Realistic-dataset HTTP test for GET /web/contexts/{id}.
+ *
+ * Seeds a production-like number of sibling rows to verify no full-table
+ * loads are issued from the show page.
+ */
+class ContextShowRealisticDatasetTest extends TestCase
+{
+    use AuthenticatesWebRequests;
+    use RefreshDatabase;
+    use RendersShowPageUnderRealisticDataset;
+
+    /**
+     * 15 covers auth overhead and the single record fetch.
+     * The context show page has no relationship sections.
+     */
+    protected function queryBudget(): int
+    {
+        return 15;
+    }
+
+    /**
+     * 500 KB ceiling — minimal page with no dynamic option snapshots.
+     */
+    protected function responseSizeBudget(): int
+    {
+        return 500_000;
+    }
+
+    protected function getShowRouteName(): string
+    {
+        return 'contexts.show';
+    }
+
+    protected function seedRealisticDataset(): Model
+    {
+        $subject = Context::factory()->create();
+
+        // ≥ 200 sibling contexts to verify no full-table load
+        Context::factory()->count(200)->create();
+
+        return $subject;
+    }
+}

--- a/tests/Web/Pages/CountryShowRealisticDatasetTest.php
+++ b/tests/Web/Pages/CountryShowRealisticDatasetTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Web\Pages;
+
+use App\Models\Country;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Web\Traits\AuthenticatesWebRequests;
+use Tests\Web\Traits\RendersShowPageUnderRealisticDataset;
+
+/**
+ * Realistic-dataset HTTP test for GET /web/countries/{id}.
+ *
+ * Seeds a production-like number of sibling rows to verify no full-table
+ * loads are issued from the show page.
+ */
+class CountryShowRealisticDatasetTest extends TestCase
+{
+    use AuthenticatesWebRequests;
+    use RefreshDatabase;
+    use RendersShowPageUnderRealisticDataset;
+
+    /**
+     * 15 covers auth overhead and the single record fetch.
+     * The country show page has no relationship sections.
+     */
+    protected function queryBudget(): int
+    {
+        return 15;
+    }
+
+    /**
+     * 500 KB ceiling — minimal page with no dynamic option snapshots.
+     */
+    protected function responseSizeBudget(): int
+    {
+        return 500_000;
+    }
+
+    protected function getShowRouteName(): string
+    {
+        return 'countries.show';
+    }
+
+    protected function seedRealisticDataset(): Model
+    {
+        $subject = Country::factory()->create();
+
+        // ≥ 100 sibling countries to verify no full-table load
+        Country::factory()->count(100)->create();
+
+        return $subject;
+    }
+}

--- a/tests/Web/Pages/GlossaryShowRealisticDatasetTest.php
+++ b/tests/Web/Pages/GlossaryShowRealisticDatasetTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Web\Pages;
+
+use App\Models\Glossary;
+use App\Models\GlossarySpelling;
+use App\Models\GlossaryTranslation;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Web\Traits\AuthenticatesWebRequests;
+use Tests\Web\Traits\RendersShowPageUnderRealisticDataset;
+
+/**
+ * Realistic-dataset HTTP test for GET /web/glossaries/{id}.
+ *
+ * Seeds a production-like number of related rows to surface memory-exhaustion
+ * and query-count regressions that a single-record test would not catch.
+ */
+class GlossaryShowRealisticDatasetTest extends TestCase
+{
+    use AuthenticatesWebRequests;
+    use RefreshDatabase;
+    use RendersShowPageUnderRealisticDataset;
+
+    /**
+     * 20 covers eager-loads (translations.language, spellings.language, synonyms)
+     * plus auth overhead.  No option snapshots are embedded.
+     */
+    protected function queryBudget(): int
+    {
+        return 20;
+    }
+
+    /**
+     * 500 KB ceiling — the glossary show page has no Livewire snapshot bloat.
+     */
+    protected function responseSizeBudget(): int
+    {
+        return 500_000;
+    }
+
+    protected function getShowRouteName(): string
+    {
+        return 'glossaries.show';
+    }
+
+    protected function seedRealisticDataset(): Model
+    {
+        $subject = Glossary::factory()->create();
+
+        // ≥ 200 sibling glossaries to verify no full-table load
+        Glossary::factory()->count(200)->create();
+
+        // ≥ 10 translations attached to the subject
+        GlossaryTranslation::factory()->count(10)->create(['glossary_id' => $subject->id]);
+
+        // ≥ 10 spellings attached to the subject
+        GlossarySpelling::factory()->count(10)->create(['glossary_id' => $subject->id]);
+
+        return $subject;
+    }
+}

--- a/tests/Web/Pages/GlossaryTranslationIndexTest.php
+++ b/tests/Web/Pages/GlossaryTranslationIndexTest.php
@@ -135,15 +135,36 @@ class GlossaryTranslationIndexTest extends TestCase
     public function test_index_passes_languages_to_view_for_dropdown(): void
     {
         $glossary = Glossary::factory()->create();
-        Language::factory()->create(['internal_name' => 'FilterLanguage']);
+        $language = Language::factory()->create(['internal_name' => 'FilterLanguage']);
+        GlossaryTranslation::factory()->for($glossary)->for($language)->create();
+
+        $response = $this->get(route('glossaries.translations.index', [
+            'glossary' => $glossary->id,
+            'language' => $language->id,
+        ]));
+
+        $response->assertOk();
+        $this->assertSame($language->id, $response->viewData('selectedLanguage')->id);
+    }
+
+    public function test_index_does_not_preload_full_language_table(): void
+    {
+        $glossary = Glossary::factory()->create();
 
         $response = $this->get(route('glossaries.translations.index', $glossary));
 
         $response->assertOk();
+        $this->assertArrayNotHasKey('languages', $response->viewData());
+    }
 
-        $languages = $response->viewData('languages');
-        $this->assertNotEmpty($languages);
-        $response->assertSee('FilterLanguage');
+    public function test_index_exposes_null_selected_language_when_no_filter_active(): void
+    {
+        $glossary = Glossary::factory()->create();
+
+        $response = $this->get(route('glossaries.translations.index', $glossary));
+
+        $response->assertOk();
+        $this->assertNull($response->viewData('selectedLanguage'));
     }
 
     public function test_index_preserves_query_strings_in_pagination_links(): void

--- a/tests/Web/Pages/ItemIndexTest.php
+++ b/tests/Web/Pages/ItemIndexTest.php
@@ -182,4 +182,69 @@ class ItemIndexTest extends TestCase
             $response->getContent(),
         );
     }
+
+    public function test_index_does_not_preload_full_partner_collection_project_country_tables(): void
+    {
+        $partner = Partner::factory()->create(['internal_name' => 'Solo Partner']);
+        Partner::factory()->count(3)->create();
+
+        $response = $this->get(route('items.index', [
+            'hierarchy' => false,
+            'partner_id' => $partner->id,
+        ]));
+
+        $response->assertOk();
+
+        $this->assertArrayNotHasKey('partners', $response->viewData());
+        $this->assertArrayNotHasKey('collections', $response->viewData());
+        $this->assertArrayNotHasKey('projects', $response->viewData());
+        $this->assertArrayNotHasKey('countries', $response->viewData());
+        $this->assertArrayNotHasKey('availableTags', $response->viewData());
+    }
+
+    public function test_index_exposes_selected_option_variables_when_filter_is_active(): void
+    {
+        $partner = Partner::factory()->create(['internal_name' => 'Active Partner']);
+        $collection = Collection::factory()->create(['internal_name' => 'Active Collection']);
+        $project = Project::factory()->create(['internal_name' => 'Active Project']);
+        $country = Country::factory()->create(['internal_name' => 'Active Country']);
+        $tag = Tag::factory()->create(['internal_name' => 'active-tag']);
+        $item = Item::factory()->create([
+            'partner_id' => $partner->id,
+            'collection_id' => $collection->id,
+            'project_id' => $project->id,
+            'country_id' => $country->id,
+        ]);
+        $item->tags()->attach($tag->id);
+
+        $response = $this->get(route('items.index', [
+            'hierarchy' => false,
+            'partner_id' => $partner->id,
+            'collection_id' => $collection->id,
+            'project_id' => $project->id,
+            'country_id' => $country->id,
+            'tags' => [$tag->id],
+        ]));
+
+        $response->assertOk();
+
+        $this->assertSame($partner->id, $response->viewData('selectedPartner')->id);
+        $this->assertSame($collection->id, $response->viewData('selectedCollection')->id);
+        $this->assertSame($project->id, $response->viewData('selectedProject')->id);
+        $this->assertSame($country->id, $response->viewData('selectedCountry')->id);
+        $this->assertSame($tag->id, $response->viewData('selectedTags')->first()->id);
+    }
+
+    public function test_index_exposes_null_selected_option_when_no_filter_is_active(): void
+    {
+        $response = $this->get(route('items.index'));
+
+        $response->assertOk();
+
+        $this->assertNull($response->viewData('selectedPartner'));
+        $this->assertNull($response->viewData('selectedCollection'));
+        $this->assertNull($response->viewData('selectedProject'));
+        $this->assertNull($response->viewData('selectedCountry'));
+        $this->assertTrue($response->viewData('selectedTags')->isEmpty());
+    }
 }

--- a/tests/Web/Pages/ItemShowRealisticDatasetTest.php
+++ b/tests/Web/Pages/ItemShowRealisticDatasetTest.php
@@ -5,49 +5,49 @@ namespace Tests\Web\Pages;
 use App\Models\Item;
 use App\Models\ItemItemLink;
 use App\Models\Tag;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 use Tests\Web\Traits\AuthenticatesWebRequests;
+use Tests\Web\Traits\RendersShowPageUnderRealisticDataset;
 
 /**
  * Realistic-dataset HTTP test for GET /web/items/{id}.
  *
  * Seeds a production-like number of related rows to surface memory-exhaustion
  * and query-count regressions that a single-record test would not catch.
- *
- * Budget constants (documenting the "why" for reviewers and future tuners):
- *
- *  QUERY_BUDGET        – Maximum number of DB queries the show page may issue.
- *                        25 is generous for a page that eager-loads ~8 relations.
- *                        A full-table get() for the items table alone would add
- *                        queries and (more critically) explode memory/response size.
- *
- *  RESPONSE_SIZE_BUDGET – Maximum allowed response body in bytes (1 MB).
- *                         With static-options Livewire snapshots for 500+ items
- *                         the dehydrated snapshot alone reaches several MB.
  */
 class ItemShowRealisticDatasetTest extends TestCase
 {
     use AuthenticatesWebRequests;
     use RefreshDatabase;
+    use RendersShowPageUnderRealisticDataset;
 
     /**
-     * Maximum number of DB queries the show page may issue.
-     * Full-table get() calls would inflate this far above 25.
+     * 25 covers ~8 eager-loaded relations with framework overhead.
+     * A full-table get() on items alone would push well past this.
      */
-    private const QUERY_BUDGET = 25;
-
-    /**
-     * Maximum allowed response body size in bytes.
-     * Livewire snapshots containing 500+ item rows exceed this easily.
-     */
-    private const RESPONSE_SIZE_BUDGET = 1_000_000; // 1 MB
-
-    public function test_show_page_renders_under_realistic_dataset(): void
+    protected function queryBudget(): int
     {
-        // ── Seed a realistic dataset ──────────────────────────────────────
+        return 25;
+    }
 
+    /**
+     * 1 MB ceiling — Livewire snapshots embedding 500+ item rows easily
+     * exceed this in the static-options regime.
+     */
+    protected function responseSizeBudget(): int
+    {
+        return 1_000_000;
+    }
+
+    protected function getShowRouteName(): string
+    {
+        return 'items.show';
+    }
+
+    protected function seedRealisticDataset(): Model
+    {
         $subject = Item::factory()->create();
 
         // ≥ 500 sibling items (not related to the subject)
@@ -66,29 +66,6 @@ class ItemShowRealisticDatasetTest extends TestCase
         // ≥ 20 incoming ItemItemLink records targeting the subject
         ItemItemLink::factory()->count(20)->toTarget($subject)->create();
 
-        // ── Issue the request and collect diagnostics ──────────────────────
-        DB::enableQueryLog();
-
-        $response = $this->get(route('items.show', $subject));
-
-        $queryCount = count(DB::getQueryLog());
-        DB::disableQueryLog();
-
-        $responseSize = strlen($response->getContent());
-
-        // ── Assertions ────────────────────────────────────────────────────
-        $response->assertOk();
-
-        $this->assertLessThanOrEqual(
-            self::QUERY_BUDGET,
-            $queryCount,
-            "Show page issued {$queryCount} queries; budget is ".self::QUERY_BUDGET.'.',
-        );
-
-        $this->assertLessThanOrEqual(
-            self::RESPONSE_SIZE_BUDGET,
-            $responseSize,
-            "Response body is {$responseSize} bytes; budget is ".self::RESPONSE_SIZE_BUDGET.'.',
-        );
+        return $subject;
     }
 }

--- a/tests/Web/Pages/ItemShowRealisticDatasetTest.php
+++ b/tests/Web/Pages/ItemShowRealisticDatasetTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Web\Pages;
+
+use App\Models\Item;
+use App\Models\ItemItemLink;
+use App\Models\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+use Tests\Web\Traits\AuthenticatesWebRequests;
+
+/**
+ * Realistic-dataset HTTP test for GET /web/items/{id}.
+ *
+ * Seeds a production-like number of related rows to surface memory-exhaustion
+ * and query-count regressions that a single-record test would not catch.
+ *
+ * Budget constants (documenting the "why" for reviewers and future tuners):
+ *
+ *  QUERY_BUDGET        – Maximum number of DB queries the show page may issue.
+ *                        25 is generous for a page that eager-loads ~8 relations.
+ *                        A full-table get() for the items table alone would add
+ *                        queries and (more critically) explode memory/response size.
+ *
+ *  RESPONSE_SIZE_BUDGET – Maximum allowed response body in bytes (1 MB).
+ *                         With static-options Livewire snapshots for 500+ items
+ *                         the dehydrated snapshot alone reaches several MB.
+ */
+class ItemShowRealisticDatasetTest extends TestCase
+{
+    use AuthenticatesWebRequests;
+    use RefreshDatabase;
+
+    /**
+     * Maximum number of DB queries the show page may issue.
+     * Full-table get() calls would inflate this far above 25.
+     */
+    private const QUERY_BUDGET = 25;
+
+    /**
+     * Maximum allowed response body size in bytes.
+     * Livewire snapshots containing 500+ item rows exceed this easily.
+     */
+    private const RESPONSE_SIZE_BUDGET = 1_000_000; // 1 MB
+
+    public function test_show_page_renders_under_realistic_dataset(): void
+    {
+        // ── Seed a realistic dataset ──────────────────────────────────────
+
+        $subject = Item::factory()->create();
+
+        // ≥ 500 sibling items (not related to the subject)
+        Item::factory()->count(500)->create();
+
+        // ≥ 50 children attached to the subject
+        Item::factory()->count(50)->withParent($subject)->create();
+
+        // ≥ 200 tags; attach ≥ 50 of them to the subject
+        $allTags = Tag::factory()->count(200)->create();
+        $subject->tags()->attach($allTags->take(50)->pluck('id'));
+
+        // ≥ 20 outgoing ItemItemLink records from the subject
+        ItemItemLink::factory()->count(20)->fromSource($subject)->create();
+
+        // ≥ 20 incoming ItemItemLink records targeting the subject
+        ItemItemLink::factory()->count(20)->toTarget($subject)->create();
+
+        // ── Issue the request and collect diagnostics ──────────────────────
+        DB::enableQueryLog();
+
+        $response = $this->get(route('items.show', $subject));
+
+        $queryCount = count(DB::getQueryLog());
+        DB::disableQueryLog();
+
+        $responseSize = strlen($response->getContent());
+
+        // ── Assertions ────────────────────────────────────────────────────
+        $response->assertOk();
+
+        $this->assertLessThanOrEqual(
+            self::QUERY_BUDGET,
+            $queryCount,
+            "Show page issued {$queryCount} queries; budget is ".self::QUERY_BUDGET.'.',
+        );
+
+        $this->assertLessThanOrEqual(
+            self::RESPONSE_SIZE_BUDGET,
+            $responseSize,
+            "Response body is {$responseSize} bytes; budget is ".self::RESPONSE_SIZE_BUDGET.'.',
+        );
+    }
+}

--- a/tests/Web/Pages/ItemTranslationIndexTest.php
+++ b/tests/Web/Pages/ItemTranslationIndexTest.php
@@ -196,4 +196,56 @@ class ItemTranslationIndexTest extends TestCase
 
         $this->assertSame($item->id, $response->viewData('item')->id);
     }
+
+    public function test_index_does_not_preload_full_language_or_context_tables(): void
+    {
+        $item = Item::factory()->create();
+
+        $response = $this->get(route('item-translations.index', ['item_id' => $item->id]));
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey('languages', $response->viewData());
+        $this->assertArrayNotHasKey('contexts', $response->viewData());
+    }
+
+    public function test_index_exposes_selected_language_when_filter_is_active(): void
+    {
+        $item = Item::factory()->create();
+        $language = Language::factory()->create(['internal_name' => 'English']);
+        ItemTranslation::factory()->forItem($item->id)->forLanguage($language->id)->create();
+
+        $response = $this->get(route('item-translations.index', [
+            'item_id' => $item->id,
+            'language' => $language->id,
+        ]));
+
+        $response->assertOk();
+        $this->assertSame($language->id, $response->viewData('selectedLanguage')->id);
+    }
+
+    public function test_index_exposes_selected_context_when_filter_is_active(): void
+    {
+        $item = Item::factory()->create();
+        $context = Context::factory()->create(['internal_name' => 'Web']);
+        ItemTranslation::factory()->forItem($item->id)->forContext($context->id)->create();
+
+        $response = $this->get(route('item-translations.index', [
+            'item_id' => $item->id,
+            'context' => $context->id,
+        ]));
+
+        $response->assertOk();
+        $this->assertSame($context->id, $response->viewData('selectedContext')->id);
+    }
+
+    public function test_index_exposes_null_selected_options_when_no_filter_active(): void
+    {
+        $item = Item::factory()->create();
+
+        $response = $this->get(route('item-translations.index', ['item_id' => $item->id]));
+
+        $response->assertOk();
+        $this->assertNull($response->viewData('selectedLanguage'));
+        $this->assertNull($response->viewData('selectedContext'));
+    }
 }

--- a/tests/Web/Pages/ItemTranslationTest.php
+++ b/tests/Web/Pages/ItemTranslationTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Web\Pages;
 
-use App\Models\Author;
 use App\Models\Item;
 use App\Models\ItemTranslation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -111,26 +110,5 @@ class ItemTranslationTest extends TestCase
         $response->assertSee('Note');
         $response->assertSee('Test note');
         $response->assertSee('empty');
-    }
-
-    public function test_edit_page_passes_authors_from_controller(): void
-    {
-        Author::factory()->count(3)->create();
-        $itemTranslation = ItemTranslation::factory()->create();
-
-        $response = $this->get(route('item-translations.edit', $itemTranslation));
-
-        $response->assertOk()
-            ->assertViewHas('authors');
-    }
-
-    public function test_create_page_passes_authors_from_controller(): void
-    {
-        Author::factory()->count(3)->create();
-
-        $response = $this->get(route('item-translations.create'));
-
-        $response->assertOk()
-            ->assertViewHas('authors');
     }
 }

--- a/tests/Web/Pages/LanguageShowRealisticDatasetTest.php
+++ b/tests/Web/Pages/LanguageShowRealisticDatasetTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Web\Pages;
+
+use App\Models\Language;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Web\Traits\AuthenticatesWebRequests;
+use Tests\Web\Traits\RendersShowPageUnderRealisticDataset;
+
+/**
+ * Realistic-dataset HTTP test for GET /web/languages/{id}.
+ *
+ * Seeds a production-like number of sibling rows to verify no full-table
+ * loads are issued from the show page.
+ */
+class LanguageShowRealisticDatasetTest extends TestCase
+{
+    use AuthenticatesWebRequests;
+    use RefreshDatabase;
+    use RendersShowPageUnderRealisticDataset;
+
+    /**
+     * 15 covers auth overhead and the single record fetch.
+     * The language show page has no relationship sections.
+     */
+    protected function queryBudget(): int
+    {
+        return 15;
+    }
+
+    /**
+     * 500 KB ceiling — minimal page with no dynamic option snapshots.
+     */
+    protected function responseSizeBudget(): int
+    {
+        return 500_000;
+    }
+
+    protected function getShowRouteName(): string
+    {
+        return 'languages.show';
+    }
+
+    protected function seedRealisticDataset(): Model
+    {
+        $subject = Language::factory()->create();
+
+        // ≥ 100 sibling languages to verify no full-table load
+        Language::factory()->count(100)->create();
+
+        return $subject;
+    }
+}

--- a/tests/Web/Pages/PartnerIndexTest.php
+++ b/tests/Web/Pages/PartnerIndexTest.php
@@ -99,4 +99,45 @@ class PartnerIndexTest extends TestCase
             $response->getContent(),
         );
     }
+
+    public function test_index_can_filter_by_country(): void
+    {
+        $country = Country::factory()->create(['internal_name' => 'Jordan']);
+        Partner::factory()->create([
+            'internal_name' => 'Museum Alpha',
+            'country_id' => $country->id,
+        ]);
+        Partner::factory()->create([
+            'internal_name' => 'Other Partner',
+            'country_id' => null,
+        ]);
+
+        $response = $this->get(route('partners.index', ['country_id' => $country->id]));
+
+        $response
+            ->assertOk()
+            ->assertSee('Museum Alpha')
+            ->assertDontSee('Other Partner');
+    }
+
+    public function test_index_exposes_selected_country_when_filter_is_active(): void
+    {
+        $country = Country::factory()->create(['internal_name' => 'Jordan']);
+        Partner::factory()->create(['country_id' => $country->id]);
+
+        $response = $this->get(route('partners.index', ['country_id' => $country->id]));
+
+        $response->assertOk();
+
+        $this->assertSame($country->id, $response->viewData('selectedCountry')->id);
+    }
+
+    public function test_index_exposes_null_selected_country_when_no_filter_is_active(): void
+    {
+        $response = $this->get(route('partners.index'));
+
+        $response->assertOk();
+
+        $this->assertNull($response->viewData('selectedCountry'));
+    }
 }

--- a/tests/Web/Pages/PartnerShowRealisticDatasetTest.php
+++ b/tests/Web/Pages/PartnerShowRealisticDatasetTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Web\Pages;
+
+use App\Models\Item;
+use App\Models\Partner;
+use App\Models\PartnerImage;
+use App\Models\PartnerTranslation;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Web\Traits\AuthenticatesWebRequests;
+use Tests\Web\Traits\RendersShowPageUnderRealisticDataset;
+
+/**
+ * Realistic-dataset HTTP test for GET /web/partners/{id}.
+ *
+ * Seeds a production-like number of related rows to surface memory-exhaustion
+ * and query-count regressions that a single-record test would not catch.
+ */
+class PartnerShowRealisticDatasetTest extends TestCase
+{
+    use AuthenticatesWebRequests;
+    use RefreshDatabase;
+    use RendersShowPageUnderRealisticDataset;
+
+    /**
+     * 25 covers partner eager-loads (country, project, monumentItem,
+     * partnerImages, translations.context, translations.language) plus
+     * framework auth overhead.
+     */
+    protected function queryBudget(): int
+    {
+        return 25;
+    }
+
+    /**
+     * 1 MB ceiling — translations and images do not embed large option
+     * snapshots, but 1 MB gives headroom for future additions.
+     */
+    protected function responseSizeBudget(): int
+    {
+        return 1_000_000;
+    }
+
+    protected function getShowRouteName(): string
+    {
+        return 'partners.show';
+    }
+
+    protected function seedRealisticDataset(): Model
+    {
+        $subject = Partner::factory()->withCountry()->withProject()->create();
+
+        // A monument item attached to this partner
+        $monument = Item::factory()->create();
+        $subject->update(['monument_item_id' => $monument->id]);
+
+        // ≥ 200 sibling partners to verify no full-table load
+        Partner::factory()->count(200)->create();
+
+        // ≥ 10 translations attached to the subject
+        PartnerTranslation::factory()->count(10)->create(['partner_id' => $subject->id]);
+
+        // ≥ 5 images attached to the subject
+        PartnerImage::factory()->count(5)->forPartner($subject)->create();
+
+        return $subject;
+    }
+}

--- a/tests/Web/Pages/PartnerTranslationIndexTest.php
+++ b/tests/Web/Pages/PartnerTranslationIndexTest.php
@@ -196,4 +196,56 @@ class PartnerTranslationIndexTest extends TestCase
 
         $this->assertSame($partner->id, $response->viewData('partner')->id);
     }
+
+    public function test_index_does_not_preload_full_language_or_context_tables(): void
+    {
+        $partner = Partner::factory()->create();
+
+        $response = $this->get(route('partner-translations.index', ['partner_id' => $partner->id]));
+
+        $response->assertOk();
+        $this->assertArrayNotHasKey('languages', $response->viewData());
+        $this->assertArrayNotHasKey('contexts', $response->viewData());
+    }
+
+    public function test_index_exposes_selected_language_when_filter_is_active(): void
+    {
+        $partner = Partner::factory()->create();
+        $language = Language::factory()->create(['internal_name' => 'English']);
+        PartnerTranslation::factory()->forPartner($partner->id)->forLanguage($language->id)->create();
+
+        $response = $this->get(route('partner-translations.index', [
+            'partner_id' => $partner->id,
+            'language' => $language->id,
+        ]));
+
+        $response->assertOk();
+        $this->assertSame($language->id, $response->viewData('selectedLanguage')->id);
+    }
+
+    public function test_index_exposes_selected_context_when_filter_is_active(): void
+    {
+        $partner = Partner::factory()->create();
+        $context = Context::factory()->create(['internal_name' => 'Web']);
+        PartnerTranslation::factory()->forPartner($partner->id)->forContext($context->id)->create();
+
+        $response = $this->get(route('partner-translations.index', [
+            'partner_id' => $partner->id,
+            'context' => $context->id,
+        ]));
+
+        $response->assertOk();
+        $this->assertSame($context->id, $response->viewData('selectedContext')->id);
+    }
+
+    public function test_index_exposes_null_selected_options_when_no_filter_active(): void
+    {
+        $partner = Partner::factory()->create();
+
+        $response = $this->get(route('partner-translations.index', ['partner_id' => $partner->id]));
+
+        $response->assertOk();
+        $this->assertNull($response->viewData('selectedLanguage'));
+        $this->assertNull($response->viewData('selectedContext'));
+    }
 }

--- a/tests/Web/Pages/ProjectShowRealisticDatasetTest.php
+++ b/tests/Web/Pages/ProjectShowRealisticDatasetTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Web\Pages;
+
+use App\Models\Context;
+use App\Models\Language;
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Web\Traits\AuthenticatesWebRequests;
+use Tests\Web\Traits\RendersShowPageUnderRealisticDataset;
+
+/**
+ * Realistic-dataset HTTP test for GET /web/projects/{id}.
+ *
+ * Seeds a production-like number of sibling rows to verify no full-table
+ * loads are issued from the show page.
+ */
+class ProjectShowRealisticDatasetTest extends TestCase
+{
+    use AuthenticatesWebRequests;
+    use RefreshDatabase;
+    use RendersShowPageUnderRealisticDataset;
+
+    /**
+     * 15 covers auth overhead, single record fetch, and context/language
+     * eager-loads.  No option snapshots are embedded.
+     */
+    protected function queryBudget(): int
+    {
+        return 15;
+    }
+
+    /**
+     * 500 KB ceiling — minimal page with no dynamic option snapshots.
+     */
+    protected function responseSizeBudget(): int
+    {
+        return 500_000;
+    }
+
+    protected function getShowRouteName(): string
+    {
+        return 'projects.show';
+    }
+
+    protected function seedRealisticDataset(): Model
+    {
+        $context = Context::factory()->create();
+        $language = Language::factory()->create();
+
+        $subject = Project::factory()->create([
+            'context_id' => $context->id,
+            'language_id' => $language->id,
+        ]);
+
+        // ≥ 200 sibling projects to verify no full-table load
+        Project::factory()->count(200)->create();
+
+        return $subject;
+    }
+}

--- a/tests/Web/Pages/ProjectTest.php
+++ b/tests/Web/Pages/ProjectTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\Web\Pages;
 
-use App\Models\Context;
-use App\Models\Language;
 use App\Models\Project;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -29,30 +27,5 @@ class ProjectTest extends TestCase
     protected function getFormData(): array
     {
         return Project::factory()->make()->toArray();
-    }
-
-    public function test_edit_page_passes_contexts_and_languages_from_controller(): void
-    {
-        Context::factory()->count(2)->create();
-        Language::factory()->count(2)->create();
-        $project = Project::factory()->create();
-
-        $response = $this->get(route('projects.edit', $project));
-
-        $response->assertOk()
-            ->assertViewHas('contexts')
-            ->assertViewHas('languages');
-    }
-
-    public function test_create_page_passes_contexts_and_languages_from_controller(): void
-    {
-        Context::factory()->count(2)->create();
-        Language::factory()->count(2)->create();
-
-        $response = $this->get(route('projects.create'));
-
-        $response->assertOk()
-            ->assertViewHas('contexts')
-            ->assertViewHas('languages');
     }
 }

--- a/tests/Web/Pages/RoleShowRealisticDatasetTest.php
+++ b/tests/Web/Pages/RoleShowRealisticDatasetTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Web\Pages;
+
+use App\Enums\Permission;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission as SpatiePermission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+use Tests\Web\Traits\RendersShowPageUnderRealisticDataset;
+
+/**
+ * Realistic-dataset HTTP test for GET /web/admin/roles/{id}.
+ *
+ * Seeds a production-like number of permissions assigned to the role and
+ * users carrying it to verify no full-table snapshot bloat.
+ */
+class RoleShowRealisticDatasetTest extends TestCase
+{
+    use RefreshDatabase;
+    use RendersShowPageUnderRealisticDataset;
+
+    /**
+     * 20 covers auth overhead, role fetch, and permissions + users eager-loads.
+     * The page does not embed full-table option snapshots.
+     */
+    protected function queryBudget(): int
+    {
+        return 20;
+    }
+
+    /**
+     * 500 KB ceiling — the show page lists permissions and users in plain HTML.
+     */
+    protected function responseSizeBudget(): int
+    {
+        return 500_000;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $manager = User::factory()->create(['email_verified_at' => now()]);
+        $manager->givePermissionTo(Permission::MANAGE_ROLES);
+        $this->actingAs($manager);
+    }
+
+    protected function getShowRouteName(): string
+    {
+        return 'admin.roles.show';
+    }
+
+    protected function seedRealisticDataset(): Model
+    {
+        $subject = Role::create(['name' => 'Benchmark Role', 'guard_name' => 'web']);
+
+        // ≥ 200 sibling roles to verify no full-table load
+        for ($i = 0; $i < 200; $i++) {
+            Role::create(['name' => "Sibling Role {$i}", 'guard_name' => 'web']);
+        }
+
+        // Assign all existing permissions to the subject role
+        $permissions = SpatiePermission::all();
+        $subject->syncPermissions($permissions);
+
+        // ≥ 20 users assigned to the subject role
+        $users = User::factory()->count(20)->create();
+        foreach ($users as $user) {
+            $user->assignRole($subject);
+        }
+
+        return $subject;
+    }
+}

--- a/tests/Web/Pages/TagShowRealisticDatasetTest.php
+++ b/tests/Web/Pages/TagShowRealisticDatasetTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Web\Pages;
+
+use App\Models\Item;
+use App\Models\Tag;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Web\Traits\AuthenticatesWebRequests;
+use Tests\Web\Traits\RendersShowPageUnderRealisticDataset;
+
+/**
+ * Realistic-dataset HTTP test for GET /web/tags/{id}.
+ *
+ * Seeds a production-like number of related rows to surface memory-exhaustion
+ * and query-count regressions that a single-record test would not catch.
+ */
+class TagShowRealisticDatasetTest extends TestCase
+{
+    use AuthenticatesWebRequests;
+    use RefreshDatabase;
+    use RendersShowPageUnderRealisticDataset;
+
+    /**
+     * 15 covers auth overhead, single record fetch, and the item count
+     * aggregation query.  No option snapshots are embedded.
+     */
+    protected function queryBudget(): int
+    {
+        return 15;
+    }
+
+    /**
+     * 500 KB ceiling — the show page displays only a count link, not the items.
+     */
+    protected function responseSizeBudget(): int
+    {
+        return 500_000;
+    }
+
+    protected function getShowRouteName(): string
+    {
+        return 'tags.show';
+    }
+
+    protected function seedRealisticDataset(): Model
+    {
+        $subject = Tag::factory()->create();
+
+        // ≥ 200 sibling tags to verify no full-table load
+        Tag::factory()->count(200)->create();
+
+        // ≥ 100 items tagged with the subject to exercise the count query
+        $items = Item::factory()->count(100)->create();
+        $subject->items()->attach($items->pluck('id'));
+
+        return $subject;
+    }
+}

--- a/tests/Web/Pages/UserShowRealisticDatasetTest.php
+++ b/tests/Web/Pages/UserShowRealisticDatasetTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Web\Pages;
+
+use App\Enums\Permission;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+use Tests\Web\Traits\RendersShowPageUnderRealisticDataset;
+
+/**
+ * Realistic-dataset HTTP test for GET /web/admin/users/{id}.
+ *
+ * Seeds a production-like number of roles (with permissions) assigned to the
+ * subject user to verify no full-table snapshot bloat.
+ */
+class UserShowRealisticDatasetTest extends TestCase
+{
+    use RefreshDatabase;
+    use RendersShowPageUnderRealisticDataset;
+
+    /**
+     * 20 covers auth overhead, user fetch, and roles.permissions eager-loads.
+     * The page does not embed full-table option snapshots.
+     */
+    protected function queryBudget(): int
+    {
+        return 20;
+    }
+
+    /**
+     * 500 KB ceiling — the show page lists roles and permissions in plain HTML.
+     */
+    protected function responseSizeBudget(): int
+    {
+        return 500_000;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $manager = User::factory()->create(['email_verified_at' => now()]);
+        $manager->givePermissionTo(Permission::MANAGE_USERS);
+        $this->actingAs($manager);
+    }
+
+    protected function getShowRouteName(): string
+    {
+        return 'admin.users.show';
+    }
+
+    protected function seedRealisticDataset(): Model
+    {
+        $subject = User::factory()->create(['email_verified_at' => now()]);
+
+        // ≥ 200 sibling users to verify no full-table load
+        User::factory()->count(200)->create();
+
+        // Create roles (with permissions) and assign them to the subject
+        $roleA = Role::create(['name' => 'Role Alpha', 'guard_name' => 'web']);
+        $roleB = Role::create(['name' => 'Role Beta', 'guard_name' => 'web']);
+
+        $subject->assignRole([$roleA, $roleB]);
+
+        return $subject;
+    }
+}

--- a/tests/Web/Traits/RendersShowPageUnderRealisticDataset.php
+++ b/tests/Web/Traits/RendersShowPageUnderRealisticDataset.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Web\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Pest/PHPUnit trait that runs a single HTTP GET against an entity show page
+ * seeded with a production-like dataset and asserts three quality budgets:
+ *
+ *   1. HTTP 200 – the page must not error out.
+ *   2. Query budget – `DB::enableQueryLog()` counts queries; full-table
+ *      `get()` calls would push this far above the default of 25.
+ *   3. Response-size ceiling – a Livewire snapshot that embeds hundreds of
+ *      option rows can easily reach several MB; default ceiling is 1 MB.
+ *
+ * ## How to use
+ *
+ * 1. Add the trait to your test class alongside `RefreshDatabase` and
+ *    `AuthenticatesWebRequests`.
+ * 2. Implement `seedRealisticDataset()` – create the subject model and seed
+ *    enough related rows to expose N+1 / memory regressions.  Return the
+ *    subject model.
+ * 3. Implement `getShowRouteName()` – return the Laravel route name for the
+ *    show action, e.g. `'items.show'`.
+ * 4. Override `queryBudget()` and / or `responseSizeBudget()` when the entity's
+ *    page legitimately needs a different ceiling.  Document the override with
+ *    a short comment above the method so future maintainers understand why.
+ *
+ * ## Budget-tuning advice
+ *
+ * - Override `queryBudget()` with the smallest value that passes against the
+ *   optimised page state (after EPICs 4–7).  Leave a margin of ~5 queries for
+ *   framework overhead that varies between environments.
+ * - Override `responseSizeBudget()` with `500_000` (500 KB) for pages that
+ *   have no Livewire components, and up to `1_000_000` (1 MB) for pages that
+ *   do.  Tighten the ceiling once you measure the actual size on a clean
+ *   dataset.
+ */
+trait RendersShowPageUnderRealisticDataset
+{
+    /**
+     * Maximum number of DB queries the show page may issue.
+     * Full-table `get()` calls inflate this far above 25.
+     * Override per entity with a short comment explaining the budget.
+     */
+    protected function queryBudget(): int
+    {
+        return 25;
+    }
+
+    /**
+     * Maximum allowed response body size in bytes.
+     * Livewire snapshots containing hundreds of option rows exceed this easily.
+     * Override per entity with a short comment explaining the budget.
+     */
+    protected function responseSizeBudget(): int
+    {
+        return 1_000_000; // 1 MB
+    }
+
+    /**
+     * PHP memory limit applied before the request is issued.
+     * Mimics a constrained hosting environment; PHP catches the OOM as a
+     * fatal and Pest reports it as a test failure.
+     */
+    protected function memoryLimit(): string
+    {
+        return '128M';
+    }
+
+    /**
+     * Seed a production-like dataset and return the subject model whose show
+     * page will be requested.
+     *
+     * Implementations must:
+     * - Create the subject model via its factory.
+     * - Create enough related rows (siblings, children, tags, translations,
+     *   images, …) to surface N+1 and memory regressions.
+     * - Keep counts deterministic; prefer `factory()->count(N)->create()`.
+     */
+    abstract protected function seedRealisticDataset(): Model;
+
+    /**
+     * Return the Laravel route name for the entity show action,
+     * e.g. `'items.show'` or `'partners.show'`.
+     */
+    abstract protected function getShowRouteName(): string;
+
+    /**
+     * Runs the realistic-dataset show-page HTTP test.
+     *
+     * Seeding, query-log capture, and all three budget assertions are
+     * performed in a single test method so the failure message points
+     * directly to the offending entity.
+     */
+    public function test_show_page_renders_under_realistic_dataset(): void
+    {
+        ini_set('memory_limit', $this->memoryLimit());
+
+        $subject = $this->seedRealisticDataset();
+
+        DB::enableQueryLog();
+
+        $response = $this->get(route($this->getShowRouteName(), $subject));
+
+        $queryCount = count(DB::getQueryLog());
+        DB::disableQueryLog();
+
+        $responseSize = strlen($response->getContent());
+
+        $response->assertOk();
+
+        $this->assertLessThanOrEqual(
+            $this->queryBudget(),
+            $queryCount,
+            "Show page issued {$queryCount} queries; budget is {$this->queryBudget()}.",
+        );
+
+        $this->assertLessThanOrEqual(
+            $this->responseSizeBudget(),
+            $responseSize,
+            "Response body is {$responseSize} bytes; budget is {$this->responseSizeBudget()}.",
+        );
+    }
+}


### PR DESCRIPTION
## Milestone 2 — Scalable Option Selection and Memory-Safe Backoffice Pages

Resolves all stories in Milestone 2. Fixes the `/web/items/{id}` memory exhaustion regression discovered in production and prevents the same class of regression from shipping again.

---

### Epic 1 — Hotfix: Item show page memory exhaustion

- **Story 1.1** `fix(web): add failing realistic-dataset test for /web/items/{id}`
- **Story 1.2** `fix(web): remove relatableItems preload; switch parent/children/links to dynamic mode`
- **Story 1.3** `fix(web): remove all-unattached-tags preload; switch tags sidebar to dynamic mode`

### Epic 2 — Harden SearchableSelect

- Enforce `static_options_max` ceiling in `mount()` (throws `InvalidArgumentException`).
- Add prefix-first search ordering via the `OptionsLookup` shared trait.
- Add `scope` parameter support with serialization-safe normalization.

### Epic 3 — Introduce SearchableMultiSelect

- New `App\Livewire\SearchableMultiSelect` component.
- New `x-form.searchable-multi-select` Blade wrapper.
- Delegates all query composition to `App\Livewire\Support\OptionsLookup`.

### Epic 4 — Sidebar cards: named scopes and dynamic entity-select mode

- All sidebar cards (`parent-item-card`, `children-items-card`, `links-card`, `tags-card`) use dynamic mode with named scopes — no full-table preloads.

### Epic 5 — Forms: eliminate full-table loads

- All `_form.blade.php` files (items, partners, collections, projects, translations, glossary) use dynamic `SearchableSelect` — no full-collection `staticOptions`.

### Epic 6 — Index filter bars: eliminate full-table loads

- All index filter dropdowns (partner, collection, project, country, tags) use dynamic `SearchableSelect` / `SearchableMultiSelect`.

### Epic 7 — Eliminate Eloquent calls from shared Blade layouts

- Removed all `\App\Models\*::` static calls from `components/app-nav.blade.php`, `auth/login.blade.php`, and all remaining `_form.blade.php` files.
- Shared layout data injected via `App\View\Composers\SettingsComposer`.

### Epic 8 — Realistic-dataset show-page tests and Blade Eloquent CI guard

- New `Tests\Web\Traits\RendersShowPageUnderRealisticDataset` trait (HTTP 200 + query budget + response-size ceiling).
- Realistic-dataset tests for all major entity show pages (items, partners, collections, glossary, context, project, tag, country, language, role, user).
- `Tests\Configuration\BladeHasNoEloquentTest` — CI guard that fails if any Blade view reintroduces a namespace-qualified Eloquent static call.

---

### Fixes
Fixes #808 Fixes #809 Fixes #810 Fixes #811 Fixes #812 Fixes #813 Fixes #803