### PR TITLE
fix: Milestone 3 rules realignment + grant access-admin-panel to Visitor role

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,6 +32,24 @@ Use mocking/stubbing to isolate code under test.
 
 ---
 
+## Active milestone: Filament 3 is the main UI
+
+> This project is mid-migration under **Milestone 3** (see `temp_MILESTONE3_FILAMENT_MIGRATION.md` and EPIC 0 — GitHub issue #849). The rules below supersede any Blade/Livewire back-office guidance in this file or the per-file instruction files until EPIC 14 rewrites them.
+
+1. **`/admin` (Filament 3) is the main UI**, not a restricted admin-only back-office. Every authenticated role except `Non-verified users` must be able to reach `/admin`.
+2. **Three-tier authorization model** (enforced by EPIC 2):
+   - **Tier 1 — Panel gate**: Spatie permission `access-admin-panel` grants entry to `/admin`. Assigned to `Visitor`, `Regular User`, and `Manager of Users`. Never assigned to `Non-verified users`.
+   - **Tier 2 — Navigation / Resource visibility**: per-feature Spatie permissions (`view-data`, `manage-users`, `manage-roles`, `manage-settings`, `manage-reference-data`) drive `canViewAny()` and `shouldRegisterNavigation()`.
+   - **Tier 3 — Record / Action authorization**: existing `App\Policies\*` classes, unchanged.
+3. **Test placement during Milestone 3**:
+   - All new Filament tests live under `tests/Filament/{Resources,Pages,Panel,Authorization}/`.
+   - Never add tests to `tests/Web/` — that suite is frozen and deleted in EPIC 12. The Blade/Livewire back-office no longer receives new coverage.
+   - `tests/Api/`, `tests/Unit/`, `tests/Configuration/`, `tests/Console/`, `tests/Event/`, `tests/Integration/` remain the correct homes for non-UI tests.
+4. **Self-service is first-class**: user profile, password change, two-factor enrolment, browser-session logout, and account deletion are delivered as a Filament `ProfilePage` (EPIC 10b). Do not reintroduce Jetstream Blade profile pages.
+5. **Forward-pointer to EPIC 14**: existing sections of this file (and `php.instructions.md`, `test-php.instructions.md`) that describe `IndexListRequest`, `{Entity}IndexQuery`, `SearchableSelect`, `SearchAndPaginate`, Livewire list components, or `/web/*` routes describe the **legacy** stack being removed. Do not author new code against those patterns. When in doubt, prefer a Filament Resource / Relation Manager / Page.
+
+---
+
 ## Project Overview
 
 The **Inventory Management API** is a comprehensive Laravel 12 backend application for museum inventory management at Museum With No Frontiers. This is a monorepo containing:

--- a/.github/instructions/php.instructions.md
+++ b/.github/instructions/php.instructions.md
@@ -3,6 +3,14 @@ applyTo: "**/*.php"
 ---
 # Project coding standards and conventions for PHP
 
+> **Active milestone — Milestone 3 (Filament 3 migration)**
+>
+> `/admin` (Filament 3) is the **main UI** — not a restricted back-office. See `.github/copilot-instructions.md` for the three-tier authorization model and the self-service scope.
+>
+> **Do not** author new code against `IndexListRequest`, `{Entity}IndexQuery`, `SearchAndPaginate`, `SearchableSelect`, Livewire components, web-scoped Form Requests, or `/web/*` controllers. These describe the **legacy** stack being removed in EPIC 12. Prefer a Filament `Resource`, `RelationManager`, `Page`, `Action`, or `Widget`.
+>
+> New tests for Filament code go under `tests/Filament/{Resources,Pages,Panel,Authorization}/`. Never extend `tests/Web/`.
+
 ## General Guidelines
 
 - **CRITICAL: Strictly follow Laravel 12 guidelines and recommendations.**

--- a/.github/instructions/test-php.instructions.md
+++ b/.github/instructions/test-php.instructions.md
@@ -7,6 +7,14 @@ applyTo: "tests/**/*Test.php"
 > - ✅ `php artisan test --testsuite=Web --no-ansi --stop-on-failure`
 > - ❌ `php artisan test --testsuite=Web --no-ansi --stop-on-failure 2>&1 | Select-Object -Last 10`
 
+> **Active milestone — Milestone 3 (Filament 3 migration)**
+>
+> New UI tests **must** live under `tests/Filament/{Resources,Pages,Panel,Authorization}/`. Never add tests to `tests/Web/` — that suite is frozen and is deleted in EPIC 12.
+>
+> Non-UI suites (`tests/Api`, `tests/Unit`, `tests/Configuration`, `tests/Console`, `tests/Event`, `tests/Integration`) are unchanged.
+>
+> When a Milestone 3 story references `tests/Web/...` as a reference example, treat it as **context only** — author the new test under `tests/Filament/...` following Filament's test helpers (`livewire()`, `Livewire::test()`, `assertCanSeeTableRecords()`, etc.).
+
 - Organize tests in a logical and consistent directory structure.
 - Keep tests simple and focused on a single behavior.
 - Keep tests isolated and independent from each other.

--- a/app/Console/Commands/SyncPermissions.php
+++ b/app/Console/Commands/SyncPermissions.php
@@ -202,6 +202,7 @@ class SyncPermissions extends Command
                 'description' => 'Read-only access to data (list and show operations only)',
                 'permissions' => [
                     PermissionEnum::VIEW_DATA->value,
+                    PermissionEnum::ACCESS_ADMIN_PANEL->value,
                 ],
             ]]);
         }

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -65,6 +65,7 @@ class RolePermissionSeeder extends Seeder
 
         $visitorRole->syncPermissions([
             PermissionEnum::VIEW_DATA->value,
+            PermissionEnum::ACCESS_ADMIN_PANEL->value,
         ]);
 
         // Create "Regular User" role with data operation permissions

--- a/tests/Console/SyncPermissionsCommandTest.php
+++ b/tests/Console/SyncPermissionsCommandTest.php
@@ -67,10 +67,11 @@ class SyncPermissionsCommandTest extends TestCase
         $nonVerifiedRole = Role::findByName('Non-verified users');
         $this->assertCount(0, $nonVerifiedRole->permissions);
 
-        // Verify Visitor has only VIEW_DATA
+        // Verify Visitor has VIEW_DATA and ACCESS_ADMIN_PANEL
         $visitorRole = Role::findByName('Visitor');
-        $this->assertCount(1, $visitorRole->permissions);
+        $this->assertCount(2, $visitorRole->permissions);
         $this->assertTrue($visitorRole->hasPermissionTo(PermissionEnum::VIEW_DATA->value));
+        $this->assertTrue($visitorRole->hasPermissionTo(PermissionEnum::ACCESS_ADMIN_PANEL->value));
 
         // Verify Regular User has data operation permissions and Filament reference-data access
         $regularRole = Role::findByName('Regular User');

--- a/tests/Filament/AdminPanelTest.php
+++ b/tests/Filament/AdminPanelTest.php
@@ -64,6 +64,15 @@ class AdminPanelTest extends TestCase
         $this->assertTrue($role->hasPermissionTo(Permission::ACCESS_ADMIN_PANEL->value));
     }
 
+    public function test_visitor_role_is_seeded_with_admin_panel_permission(): void
+    {
+        $this->seed(RolePermissionSeeder::class);
+
+        $role = Role::findByName('Visitor');
+
+        $this->assertTrue($role->hasPermissionTo(Permission::ACCESS_ADMIN_PANEL->value));
+    }
+
     public function test_regular_user_role_is_seeded_with_filament_reference_data_access(): void
     {
         $this->seed(RolePermissionSeeder::class);


### PR DESCRIPTION
## Summary

Realigns the codebase with the updated EPIC 0 rules documented in GitHub #849 (EPIC 0 §2.bis — three-tier authorization model).

### Instruction file updates
- \.github/copilot-instructions.md\ — added Milestone-3 banner: Filament is the main UI, three-tier authz model, test-placement rule, self-service scope, EPIC 14 forward-pointer.
- \.github/instructions/php.instructions.md\ — banner: no new legacy patterns, prefer Filament constructs, tests under \	ests/Filament/\.
- \.github/instructions/test-php.instructions.md\ — rule: Filament UI tests under \	ests/Filament/{Resources,Pages,Panel,Authorization}/\; \	ests/Web/\ is frozen.

### Code fix (Story 2.2 realignment — closes #876)

\Visitor\ role was missing \ccess-admin-panel\. Per EPIC 0 §2.bis, every authenticated role except \Non-verified users\ must hold this permission to reach \/admin\.

| File | Change |
|---|---|
| \database/seeders/RolePermissionSeeder.php\ | Add \ACCESS_ADMIN_PANEL\ to Visitor's \syncPermissions\ |
| \pp/Console/Commands/SyncPermissions.php\ | Add \ACCESS_ADMIN_PANEL\ to Visitor definition (parity) |
| \	ests/Console/SyncPermissionsCommandTest.php\ | Update Visitor assertions: count 1→2, add \ACCESS_ADMIN_PANEL\ |
| \	ests/Filament/AdminPanelTest.php\ | Add \	est_visitor_role_is_seeded_with_admin_panel_permission()\ |

## Testing

Tests validated by CI (PHP 8.4). Local PHP 8.2 cannot run Filament tests.

## Related issues
Closes #876 (Story 2.2 realignment)