### PR TITLE
refactor: centralize image view/download via Responsable response classes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -459,18 +459,55 @@ User-supplied image binaries are **never** written directly to public storage. A
 2. Creation dispatches `App\Events\ImageUploadEvent`.
 3. `App\Listeners\ImageUploadListener` validates the binary (Intervention Image), resizes if it exceeds the configured max dimensions, creates an `App\Models\AvailableImage` record (same UUID), deletes the `ImageUpload`, and dispatches `App\Events\AvailableImageEvent`.
 4. `App\Listeners\AvailableImageListener` moves the validated file to the **public** `public` disk under the `images` directory.
-5. Only then can an `AvailableImage` be attached to a host entity (Item, Collection, Partner, …) through the existing per-entity image pivot models (`ItemImage`, `CollectionImage`, `PartnerImage`).
+5. Only then can an `AvailableImage` be attached to a host entity (Item, Collection, Partner, …). **Attach is a move, not a reference.** The per-entity image models (`ItemImage`, `CollectionImage`, `PartnerImage`) are **NOT pivot tables** — they do not hold a foreign key to `available_images`. Each row is a standalone, entity-owned record that carries its own copy of the metadata (`path`, `original_name`, `mime_type`, `size`, `alt_text`, `display_order`). The canonical transition is implemented by the model methods `ItemImage::attachFromAvailableImage()`, `CollectionImage::attachFromAvailableImage()`, `PartnerImage::attachFromAvailableImage()` (and their reverse `detachToAvailableImage()` counterparts).
+
+**How attach actually works (in a DB transaction):**
+
+- Moves the file from `public`/`images/` to `public`/`pictures/` (directories from `config/localstorage.php`).
+- Creates the `ItemImage` / `CollectionImage` / `PartnerImage` row, **reusing the same UUID** as the source `AvailableImage`.
+- **Deletes** the `AvailableImage` record.
+
+**How detach works (exact reverse, in a DB transaction):**
+
+- Moves the file from `public`/`pictures/` back to `public`/`images/`.
+- Recreates the `AvailableImage` row with the same UUID.
+- Deletes the entity image row.
+
+**Consequences that all code MUST honor:**
+
+- Each image is **unique and owned by at most one entity at a time**. An `AvailableImage` is transient — it exists only while the image is unattached.
+- The `AvailableImage` pool stays small and manageable (the production corpus is ~25 000 images; holding every attached image in the pool would make the pool unusable).
+- Attach errors can be corrected by detach → re-attach **without re-uploading the binary**.
+- A Filament/API/Web "attach" code path MUST call the existing `*::attachFromAvailableImage()` model method. Do not reimplement the move, do not create an `ItemImage`/`CollectionImage`/`PartnerImage` row directly from an `AvailableImage` without going through it.
+- A "detach" code path MUST call the existing `*->detachToAvailableImage()` model method. Do not reimplement the reverse move.
 
 **Rules — apply to every UI surface (API, `/web`, `/admin` Filament, future surfaces):**
 
 - ❌ **NEVER** write user-uploaded image binaries to the `public` disk, the `images` directory, or any web-reachable location directly. The `public` disk is the **output** of validation, never an input.
-- ❌ **NEVER** create an `AvailableImage` record from a user upload. `AvailableImage` is produced exclusively by `ImageUploadListener`.
+- ❌ **NEVER** create an `AvailableImage` record from a user upload. `AvailableImage` is produced exclusively by `ImageUploadListener` or by a detach operation.
 - ❌ **NEVER** use `Filament\Forms\Components\FileUpload->disk('public')` (or any equivalent) to accept a user image. Filament image upload fields MUST target the `local` disk + `image_uploads` directory and persist as an `ImageUpload` record so the existing event chain runs.
 - ❌ **NEVER** reimplement validation, resizing, or thumbnailing in a new controller, action, page, or Filament component. Trigger the existing event chain.
-- ❌ **NEVER** introduce a new disk, directory, or storage path for image uploads.
+- ❌ **NEVER** reimplement the attach or detach file-move logic. Call `*::attachFromAvailableImage()` / `*->detachToAvailableImage()`.
+- ❌ **NEVER** treat `ItemImage`/`CollectionImage`/`PartnerImage` as pivot tables; they have no foreign key to `available_images` and the same image cannot be simultaneously attached to multiple entities.
+- ❌ **NEVER** introduce a new disk, directory, or storage path for image uploads or attachments.
 - ✅ A Filament "upload" Action / Page / Resource MUST create an `ImageUpload` (so `ImageUploadEvent` fires) and surface the resulting `AvailableImage` once the listeners have run.
-- ✅ A Filament "attach image to entity" Action MUST pick from the existing `AvailableImage` pool via server-side search; it MUST NOT accept a raw file.
-- ✅ Tests covering upload flows MUST use `Storage::fake('local')` and `Storage::fake('public')`, dispatch through the real event chain (or assert it was dispatched), and never write directly to the `public` disk.
+- ✅ A Filament "attach image to entity" Action MUST pick from the existing `AvailableImage` pool via server-side search and invoke `*::attachFromAvailableImage()`; it MUST NOT accept a raw file.
+- ✅ A Filament "detach image" Action MUST invoke `*->detachToAvailableImage()` so the binary returns to the `AvailableImage` pool under the same UUID.
+- ✅ Tests covering upload, attach, or detach flows MUST use `Storage::fake('local')` and `Storage::fake('public')`, dispatch through the real event chain (or assert it was dispatched) for uploads, and never write directly to the `public` disk outside the existing listener/model methods.
+
+**Image display and download — every UI surface MUST reuse the existing controller endpoints:**
+
+Image bytes are NEVER served from a constructed `/storage/...` URL or any direct disk path. Each image model has its own dedicated `view` (inline) and `download` (attachment) controller actions that stream the file through `App\Http\Responses\FileResponse`. These endpoints exist for both the API and `/web`, are tested, and enforce authorization. Filament `/admin` MUST use the same endpoints.
+
+- `AvailableImage` — `App\Http\Controllers\AvailableImageController@view|download` (API) and `App\Http\Controllers\Web\AvailableImageController@view|download` (Web).
+- `ItemImage` — `App\Http\Controllers\ItemImageController@view|download` (API) and `App\Http\Controllers\Web\ItemImageController@view|download` (Web).
+- `CollectionImage` — `App\Http\Controllers\CollectionImageController@view|download` (API) and `App\Http\Controllers\Web\CollectionImageController@view|download` (Web).
+- `PartnerImage` — `App\Http\Controllers\PartnerImageController@view|download` (API) and `App\Http\Controllers\Web\PartnerImageController@view|download` (Web).
+
+- ❌ **NEVER** build an image URL from `Storage::url()`, `asset('storage/images/...')`, `/storage/pictures/...`, or any direct disk path. There is no `getUrl()` accessor on `AvailableImage` to "reuse"; URL conventions on the public disk are an implementation detail of the controllers, not an API for clients.
+- ❌ **NEVER** add a new endpoint that streams image bytes. The four pairs of controllers above are the canonical, tested, authorized boundary.
+- ✅ Filament view/edit pages, gallery components, and lightboxes MUST resolve image URLs from the named routes that target the four controllers above (e.g. `route('item-image.view', $itemImage)` for inline display, `route('item-image.download', $itemImage)` for download). The same applies to thumbnails on the `AvailableImage` pool — use the `available-images.view` route, not a constructed `/storage/images/...` URL.
+- ✅ Tests asserting display/download MUST hit the route, not assert against a constructed disk URL.
 
 ## File-Specific Instructions
 

--- a/.github/instructions/php.instructions.md
+++ b/.github/instructions/php.instructions.md
@@ -105,25 +105,70 @@ User-supplied image binaries are **never** written directly to public storage. E
 2. `ImageUpload` creation dispatches `App\Events\ImageUploadEvent`.
 3. `App\Listeners\ImageUploadListener` validates (Intervention Image), resizes to the configured max dimensions, creates an `App\Models\AvailableImage` record (same UUID), deletes the `ImageUpload`, and dispatches `App\Events\AvailableImageEvent`.
 4. `App\Listeners\AvailableImageListener` moves the validated file to the **public** `public` disk in the `images` directory.
-5. Only then can the `AvailableImage` be attached to a host entity via the existing pivot models (`ItemImage`, `CollectionImage`, `PartnerImage`).
+5. The `AvailableImage` is the unattached pool. **Attach is a move, not a reference.** `ItemImage`, `CollectionImage`, `PartnerImage` are **NOT pivot tables** — they have no foreign key to `available_images`. Each row is a standalone, entity-owned record carrying its own copy of `path`, `original_name`, `mime_type`, `size`, `alt_text`, `display_order`. The transition is implemented exclusively by the model methods `*::attachFromAvailableImage()` and `*->detachToAvailableImage()`.
+
+### Attach / detach semantics (canonical, do not reimplement)
+
+- **Attach** (`ItemImage::attachFromAvailableImage(AvailableImage, $hostId, $altText = null)` and the `Collection`/`Partner` equivalents) — runs in a DB transaction:
+  - Moves the file from `public`/`images/` to `public`/`pictures/` (`config/localstorage.php` → `available.images.*` and `pictures.*`).
+  - Creates the entity image row, **reusing the source `AvailableImage` UUID**, copying `path`, `original_name`, `mime_type`, `size`, `comment` → `alt_text`.
+  - **Deletes the `AvailableImage` row.**
+- **Detach** (`$itemImage->detachToAvailableImage()` and the `Collection`/`Partner` equivalents) — exact reverse, in a DB transaction:
+  - Moves the file from `public`/`pictures/` back to `public`/`images/`.
+  - Recreates the `AvailableImage` row with the same UUID, restoring `path`, `original_name`, `mime_type`, `size`, `alt_text` → `comment`.
+  - Deletes the entity image row.
+
+**Consequences that all attach/detach call sites MUST honor:**
+
+- Each image is **unique and owned by at most one entity at a time**. `AvailableImage` is transient — it exists only while the image is unattached.
+- The `AvailableImage` pool stays small (production: ~25 000 images; the pool is a workbench, not a catalogue).
+- Attach errors are corrected by **detach → re-attach** without re-uploading the binary.
 
 ### Rules
 
 - ❌ **NEVER** write user-uploaded image binaries to the `public` disk, the `images` directory, or any web-reachable location directly. The `public` disk is the **output** of validation, never an input.
-- ❌ **NEVER** create an `AvailableImage` record from a user upload. `AvailableImage` is produced exclusively by `ImageUploadListener`.
+- ❌ **NEVER** create an `AvailableImage` record from a user upload. `AvailableImage` is produced exclusively by `ImageUploadListener` or by a detach operation.
 - ❌ **NEVER** use `Filament\Forms\Components\FileUpload->disk('public')` (or any equivalent) to accept a user image. Filament image upload fields MUST target the `local` disk + `image_uploads` directory and persist as an `ImageUpload` record so the event chain runs.
 - ❌ **NEVER** reimplement validation, resizing, or thumbnailing in a new controller, action, page, or Filament component. Trigger the existing event chain.
-- ❌ **NEVER** introduce a new disk, directory, or storage path for image uploads.
+- ❌ **NEVER** reimplement the attach or detach file move. Always call `*::attachFromAvailableImage()` / `*->detachToAvailableImage()`.
+- ❌ **NEVER** treat `ItemImage`/`CollectionImage`/`PartnerImage` as pivots — they hold no foreign key to `available_images`, and the same image cannot be attached to multiple entities at once.
+- ❌ **NEVER** introduce a new disk, directory, or storage path for image uploads or attachments.
 - ✅ A Filament "upload" Action / Page / Resource MUST create an `ImageUpload` (so `ImageUploadEvent` fires) and surface the resulting `AvailableImage` once the listeners have run.
-- ✅ A Filament "attach image to entity" Action MUST pick from the existing `AvailableImage` pool via server-side search; it MUST NOT accept a raw file.
-- ✅ Tests covering upload flows MUST use `Storage::fake('local')` and `Storage::fake('public')`, dispatch through the real event chain (or assert it was dispatched), and never write directly to the `public` disk.
+- ✅ A Filament "attach image to entity" Action MUST pick from the existing `AvailableImage` pool via server-side search and invoke `*::attachFromAvailableImage()`; it MUST NOT accept a raw file.
+- ✅ A Filament "detach image" Action MUST invoke `*->detachToAvailableImage()` so the binary returns to the `AvailableImage` pool with the same UUID.
+- ✅ Tests covering upload, attach, or detach flows MUST use `Storage::fake('local')` and `Storage::fake('public')`, dispatch through the real event chain (or assert it was dispatched) for uploads, and never write directly to the `public` disk outside the existing listener / model methods.
+
+### Display and download — reuse the existing controller endpoints (every surface)
+
+Image bytes are NEVER served from a constructed `/storage/...` URL or any direct disk path. Each image model has its own dedicated `view` (inline) and `download` (attachment) controller actions that stream the file through `App\Http\Responses\FileResponse`. These endpoints exist for both the API and `/web`, are covered by `tests/Api/Traits/TestsApiImageViewing.php`, and enforce authorization (`auth` + `permission:view-data` on the Web controllers). Filament `/admin` MUST hit the same endpoints.
+
+| Model            | API controller (`view` / `download`)                       | Web controller (`view` / `download`)                            |
+| ---------------- | ---------------------------------------------------------- | --------------------------------------------------------------- |
+| `AvailableImage` | `App\Http\Controllers\AvailableImageController`            | `App\Http\Controllers\Web\AvailableImageController`             |
+| `ItemImage`      | `App\Http\Controllers\ItemImageController`                 | `App\Http\Controllers\Web\ItemImageController`                  |
+| `CollectionImage`| `App\Http\Controllers\CollectionImageController`           | `App\Http\Controllers\Web\CollectionImageController`            |
+| `PartnerImage`   | `App\Http\Controllers\PartnerImageController`              | `App\Http\Controllers\Web\PartnerImageController`               |
+
+**Rules:**
+
+- ❌ **NEVER** build an image URL from `Storage::url()`, `asset('storage/images/...')`, `/storage/pictures/...`, or any other direct disk path.
+- ❌ **NEVER** assume an `AvailableImage` URL accessor exists for "the URL convention" — there is none. The pool's URL pattern is an internal detail of `AvailableImageController`, not a public contract.
+- ❌ **NEVER** add a new endpoint that streams image bytes. The four pairs of controllers above are the canonical, tested, authorized boundary.
+- ✅ Filament view pages, gallery components, table columns, and lightboxes MUST resolve URLs from the existing named routes that target the four controllers above — e.g. `route('item-image.view', $itemImage)` for inline display, `route('item-image.download', $itemImage)` for download, and the `available-images.view` / `available-images.download` routes for the unattached pool.
+- ✅ When configuring Filament's `ImageColumn` / `ImageEntry` (or any other component that needs a URL), feed it the route URL — not a `Storage::url($path)` value.
+- ✅ Tests asserting display or download flows MUST hit the route (`get(route('item-image.view', $image))` etc.) and assert the streamed response, not assert against a constructed disk URL.
 
 ### Reference implementation
 
 - Model (upload staging): `app/Models/ImageUpload.php`
 - Model (validated pool): `app/Models/AvailableImage.php`
+- Models (attached, entity-owned): `app/Models/ItemImage.php`, `app/Models/CollectionImage.php`, `app/Models/PartnerImage.php` — see `attachFromAvailableImage()` / `detachToAvailableImage()`.
 - Events: `app/Events/ImageUploadEvent.php`, `app/Events/AvailableImageEvent.php`
 - Listeners: `app/Listeners/ImageUploadListener.php`, `app/Listeners/AvailableImageListener.php`
 - Config: `config/localstorage.php` (disks, directories, max dimensions)
-- API controller: `app/Http/Controllers/ImageUploadController.php`
+- API controller (upload): `app/Http/Controllers/ImageUploadController.php`
+- API controllers (display/download): `app/Http/Controllers/{AvailableImage,ItemImage,CollectionImage,PartnerImage}Controller.php` — `view()` and `download()` actions.
+- Web controllers (display/download): `app/Http/Controllers/Web/{AvailableImage,ItemImage,CollectionImage,PartnerImage}Controller.php` — `view()` and `download()` actions.
+- Streaming helper: `app/Http/Responses/FileResponse.php`.
+- Display/download test trait: `tests/Api/Traits/TestsApiImageViewing.php`.
 - Event tests: `tests/Event/ImageUpload/ImageUploadTest.php`, `tests/Event/AvailableImage/AvailableImageTest.php`

--- a/app/Contracts/StreamableImageFile.php
+++ b/app/Contracts/StreamableImageFile.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Contracts;
+
+interface StreamableImageFile
+{
+    /**
+     * Storage disk name (e.g. 'public').
+     */
+    public function imageDisk(): string;
+
+    /**
+     * Path inside the disk, including the directory prefix (e.g. 'images/uuid.jpg').
+     */
+    public function imageStoragePath(): string;
+
+    /**
+     * MIME type, or null to let the response auto-detect via mime_content_type.
+     */
+    public function imageMimeType(): ?string;
+
+    /**
+     * Filename advertised in the Content-Disposition: attachment; filename=… header.
+     */
+    public function imageDownloadFilename(): string;
+}

--- a/app/Http/Controllers/AvailableImageController.php
+++ b/app/Http/Controllers/AvailableImageController.php
@@ -5,7 +5,8 @@ namespace App\Http\Controllers;
 use App\Http\Requests\Api\IndexAvailableImageRequest;
 use App\Http\Requests\Api\UpdateAvailableImageRequest;
 use App\Http\Resources\AvailableImageResource;
-use App\Http\Responses\FileResponse;
+use App\Http\Responses\Image\DownloadImageResponse;
+use App\Http\Responses\Image\InlineImageResponse;
 use App\Models\AvailableImage;
 use Illuminate\Support\Facades\Storage;
 
@@ -67,18 +68,7 @@ class AvailableImageController extends Controller
      */
     public function download(AvailableImage $availableImage)
     {
-        $disk = config('localstorage.available.images.disk');
-        $directory = trim(config('localstorage.available.images.directory'), '/');
-        $filename = basename($availableImage->path);
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$availableImage->path;
-
-        return FileResponse::download(
-            $disk,
-            $storagePath,
-            $filename
-        );
+        return new DownloadImageResponse($availableImage);
     }
 
     /**
@@ -86,15 +76,6 @@ class AvailableImageController extends Controller
      */
     public function view(AvailableImage $availableImage)
     {
-        $disk = config('localstorage.available.images.disk');
-        $directory = trim(config('localstorage.available.images.directory'), '/');
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$availableImage->path;
-
-        return FileResponse::view(
-            $disk,
-            $storagePath
-        );
+        return new InlineImageResponse($availableImage);
     }
 }

--- a/app/Http/Controllers/CollectionImageController.php
+++ b/app/Http/Controllers/CollectionImageController.php
@@ -9,7 +9,8 @@ use App\Http\Requests\Api\StoreCollectionImageRequest;
 use App\Http\Requests\Api\UpdateCollectionImageRequest;
 use App\Http\Resources\CollectionImageResource;
 use App\Http\Resources\OperationSuccessResource;
-use App\Http\Responses\FileResponse;
+use App\Http\Responses\Image\DownloadImageResponse;
+use App\Http\Responses\Image\InlineImageResponse;
 use App\Models\AvailableImage;
 use App\Models\Collection;
 use App\Models\CollectionImage;
@@ -163,19 +164,7 @@ class CollectionImageController extends Controller
      */
     public function download(CollectionImage $collectionImage)
     {
-        $disk = config('localstorage.pictures.disk');
-        $directory = trim(config('localstorage.pictures.directory'), '/');
-        $filename = $collectionImage->original_name ?: basename($collectionImage->path);
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$collectionImage->path;
-
-        return FileResponse::download(
-            $disk,
-            $storagePath,
-            $filename,
-            $collectionImage->mime_type
-        );
+        return new DownloadImageResponse($collectionImage);
     }
 
     /**
@@ -183,16 +172,6 @@ class CollectionImageController extends Controller
      */
     public function view(CollectionImage $collectionImage)
     {
-        $disk = config('localstorage.pictures.disk');
-        $directory = trim(config('localstorage.pictures.directory'), '/');
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$collectionImage->path;
-
-        return FileResponse::view(
-            $disk,
-            $storagePath,
-            $collectionImage->mime_type
-        );
+        return new InlineImageResponse($collectionImage);
     }
 }

--- a/app/Http/Controllers/ItemImageController.php
+++ b/app/Http/Controllers/ItemImageController.php
@@ -9,7 +9,8 @@ use App\Http\Requests\Api\StoreItemImageRequest;
 use App\Http\Requests\Api\UpdateItemImageRequest;
 use App\Http\Resources\ItemImageResource;
 use App\Http\Resources\OperationSuccessResource;
-use App\Http\Responses\FileResponse;
+use App\Http\Responses\Image\DownloadImageResponse;
+use App\Http\Responses\Image\InlineImageResponse;
 use App\Models\AvailableImage;
 use App\Models\Item;
 use App\Models\ItemImage;
@@ -163,19 +164,7 @@ class ItemImageController extends Controller
      */
     public function download(ItemImage $itemImage)
     {
-        $disk = config('localstorage.pictures.disk');
-        $directory = trim(config('localstorage.pictures.directory'), '/');
-        $filename = $itemImage->original_name ?: basename($itemImage->path);
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$itemImage->path;
-
-        return FileResponse::download(
-            $disk,
-            $storagePath,
-            $filename,
-            $itemImage->mime_type
-        );
+        return new DownloadImageResponse($itemImage);
     }
 
     /**
@@ -183,16 +172,6 @@ class ItemImageController extends Controller
      */
     public function view(ItemImage $itemImage)
     {
-        $disk = config('localstorage.pictures.disk');
-        $directory = trim(config('localstorage.pictures.directory'), '/');
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$itemImage->path;
-
-        return FileResponse::view(
-            $disk,
-            $storagePath,
-            $itemImage->mime_type
-        );
+        return new InlineImageResponse($itemImage);
     }
 }

--- a/app/Http/Controllers/PartnerImageController.php
+++ b/app/Http/Controllers/PartnerImageController.php
@@ -9,7 +9,8 @@ use App\Http\Requests\Api\StorePartnerImageRequest;
 use App\Http\Requests\Api\UpdatePartnerImageRequest;
 use App\Http\Resources\OperationSuccessResource;
 use App\Http\Resources\PartnerImageResource;
-use App\Http\Responses\FileResponse;
+use App\Http\Responses\Image\DownloadImageResponse;
+use App\Http\Responses\Image\InlineImageResponse;
 use App\Models\AvailableImage;
 use App\Models\Partner;
 use App\Models\PartnerImage;
@@ -168,19 +169,7 @@ class PartnerImageController extends Controller
      */
     public function download(PartnerImage $partnerImage)
     {
-        $disk = config('localstorage.pictures.disk');
-        $directory = trim(config('localstorage.pictures.directory'), '/');
-        $filename = $partnerImage->original_name ?: basename($partnerImage->path);
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$partnerImage->path;
-
-        return FileResponse::download(
-            $disk,
-            $storagePath,
-            $filename,
-            $partnerImage->mime_type
-        );
+        return new DownloadImageResponse($partnerImage);
     }
 
     /**
@@ -188,16 +177,6 @@ class PartnerImageController extends Controller
      */
     public function view(PartnerImage $partnerImage)
     {
-        $disk = config('localstorage.pictures.disk');
-        $directory = trim(config('localstorage.pictures.directory'), '/');
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$partnerImage->path;
-
-        return FileResponse::view(
-            $disk,
-            $storagePath,
-            $partnerImage->mime_type
-        );
+        return new InlineImageResponse($partnerImage);
     }
 }

--- a/app/Http/Controllers/Web/AvailableImageController.php
+++ b/app/Http/Controllers/Web/AvailableImageController.php
@@ -6,7 +6,8 @@ use App\Enums\Permission;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Web\IndexAvailableImageRequest;
 use App\Http\Requests\Web\UpdateAvailableImageRequest;
-use App\Http\Responses\FileResponse;
+use App\Http\Responses\Image\DownloadImageResponse;
+use App\Http\Responses\Image\InlineImageResponse;
 use App\Models\AvailableImage;
 use App\Services\Web\AvailableImageIndexQuery;
 use Illuminate\Contracts\View\View;
@@ -46,16 +47,7 @@ class AvailableImageController extends Controller
      */
     public function view(AvailableImage $availableImage)
     {
-        $disk = config('localstorage.available.images.disk');
-        $directory = trim(config('localstorage.available.images.directory'), '/');
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$availableImage->path;
-
-        return FileResponse::view(
-            $disk,
-            $storagePath
-        );
+        return new InlineImageResponse($availableImage);
     }
 
     /**
@@ -63,18 +55,7 @@ class AvailableImageController extends Controller
      */
     public function download(AvailableImage $availableImage)
     {
-        $disk = config('localstorage.available.images.disk');
-        $directory = trim(config('localstorage.available.images.directory'), '/');
-        $filename = basename($availableImage->path);
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$availableImage->path;
-
-        return FileResponse::download(
-            $disk,
-            $storagePath,
-            $filename
-        );
+        return new DownloadImageResponse($availableImage);
     }
 
     /**

--- a/app/Http/Controllers/Web/CollectionImageController.php
+++ b/app/Http/Controllers/Web/CollectionImageController.php
@@ -7,7 +7,8 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Web\IndexCollectionImageRequest;
 use App\Http\Requests\Web\StoreCollectionImageRequest;
 use App\Http\Requests\Web\UpdateCollectionImageRequest;
-use App\Http\Responses\FileResponse;
+use App\Http\Responses\Image\DownloadImageResponse;
+use App\Http\Responses\Image\InlineImageResponse;
 use App\Models\AvailableImage;
 use App\Models\Collection;
 use App\Models\CollectionImage;
@@ -159,24 +160,11 @@ class CollectionImageController extends Controller
      */
     public function download(Collection $collection, CollectionImage $collectionImage)
     {
-        // Ensure the image belongs to the collection
         if ($collectionImage->collection_id !== $collection->id) {
             abort(404);
         }
 
-        $disk = config('localstorage.pictures.disk');
-        $directory = trim(config('localstorage.pictures.directory'), '/');
-        $filename = $collectionImage->original_name ?: basename($collectionImage->path);
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$collectionImage->path;
-
-        return FileResponse::download(
-            $disk,
-            $storagePath,
-            $filename,
-            $collectionImage->mime_type
-        );
+        return new DownloadImageResponse($collectionImage);
     }
 
     /**
@@ -184,21 +172,10 @@ class CollectionImageController extends Controller
      */
     public function view(Collection $collection, CollectionImage $collectionImage)
     {
-        // Ensure the image belongs to the collection
         if ($collectionImage->collection_id !== $collection->id) {
             abort(404);
         }
 
-        $disk = config('localstorage.pictures.disk');
-        $directory = trim(config('localstorage.pictures.directory'), '/');
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$collectionImage->path;
-
-        return FileResponse::view(
-            $disk,
-            $storagePath,
-            $collectionImage->mime_type
-        );
+        return new InlineImageResponse($collectionImage);
     }
 }

--- a/app/Http/Controllers/Web/ItemImageController.php
+++ b/app/Http/Controllers/Web/ItemImageController.php
@@ -7,7 +7,8 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Web\IndexItemImageRequest;
 use App\Http\Requests\Web\StoreItemImageRequest;
 use App\Http\Requests\Web\UpdateItemImageRequest;
-use App\Http\Responses\FileResponse;
+use App\Http\Responses\Image\DownloadImageResponse;
+use App\Http\Responses\Image\InlineImageResponse;
 use App\Models\AvailableImage;
 use App\Models\Item;
 use App\Models\ItemImage;
@@ -159,24 +160,11 @@ class ItemImageController extends Controller
      */
     public function download(Item $item, ItemImage $itemImage)
     {
-        // Ensure the image belongs to the item
         if ($itemImage->item_id !== $item->id) {
             abort(404);
         }
 
-        $disk = config('localstorage.pictures.disk');
-        $directory = trim(config('localstorage.pictures.directory'), '/');
-        $filename = $itemImage->original_name ?: basename($itemImage->path);
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$itemImage->path;
-
-        return FileResponse::download(
-            $disk,
-            $storagePath,
-            $filename,
-            $itemImage->mime_type
-        );
+        return new DownloadImageResponse($itemImage);
     }
 
     /**
@@ -184,21 +172,10 @@ class ItemImageController extends Controller
      */
     public function view(Item $item, ItemImage $itemImage)
     {
-        // Ensure the image belongs to the item
         if ($itemImage->item_id !== $item->id) {
             abort(404);
         }
 
-        $disk = config('localstorage.pictures.disk');
-        $directory = trim(config('localstorage.pictures.directory'), '/');
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$itemImage->path;
-
-        return FileResponse::view(
-            $disk,
-            $storagePath,
-            $itemImage->mime_type
-        );
+        return new InlineImageResponse($itemImage);
     }
 }

--- a/app/Http/Controllers/Web/PartnerImageController.php
+++ b/app/Http/Controllers/Web/PartnerImageController.php
@@ -7,7 +7,8 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Web\IndexPartnerImageRequest;
 use App\Http\Requests\Web\StorePartnerImageRequest;
 use App\Http\Requests\Web\UpdatePartnerImageRequest;
-use App\Http\Responses\FileResponse;
+use App\Http\Responses\Image\DownloadImageResponse;
+use App\Http\Responses\Image\InlineImageResponse;
 use App\Models\AvailableImage;
 use App\Models\Partner;
 use App\Models\PartnerImage;
@@ -159,24 +160,11 @@ class PartnerImageController extends Controller
      */
     public function download(Partner $partner, PartnerImage $partnerImage)
     {
-        // Ensure the image belongs to the partner
         if ($partnerImage->partner_id !== $partner->id) {
             abort(404);
         }
 
-        $disk = config('localstorage.pictures.disk');
-        $directory = trim(config('localstorage.pictures.directory'), '/');
-        $filename = $partnerImage->original_name ?: basename($partnerImage->path);
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$partnerImage->path;
-
-        return FileResponse::download(
-            $disk,
-            $storagePath,
-            $filename,
-            $partnerImage->mime_type
-        );
+        return new DownloadImageResponse($partnerImage);
     }
 
     /**
@@ -184,21 +172,10 @@ class PartnerImageController extends Controller
      */
     public function view(Partner $partner, PartnerImage $partnerImage)
     {
-        // Ensure the image belongs to the partner
         if ($partnerImage->partner_id !== $partner->id) {
             abort(404);
         }
 
-        $disk = config('localstorage.pictures.disk');
-        $directory = trim(config('localstorage.pictures.directory'), '/');
-
-        // Prepend directory to path
-        $storagePath = $directory.'/'.$partnerImage->path;
-
-        return FileResponse::view(
-            $disk,
-            $storagePath,
-            $partnerImage->mime_type
-        );
+        return new InlineImageResponse($partnerImage);
     }
 }

--- a/app/Http/Responses/Image/DownloadImageResponse.php
+++ b/app/Http/Responses/Image/DownloadImageResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Responses\Image;
+
+use App\Contracts\StreamableImageFile;
+use App\Http\Responses\FileResponse;
+use Illuminate\Contracts\Support\Responsable;
+
+class DownloadImageResponse implements Responsable
+{
+    public function __construct(private readonly StreamableImageFile $image) {}
+
+    public function toResponse($request)
+    {
+        return FileResponse::download(
+            $this->image->imageDisk(),
+            $this->image->imageStoragePath(),
+            $this->image->imageDownloadFilename(),
+            $this->image->imageMimeType(),
+        )->toResponse($request);
+    }
+}

--- a/app/Http/Responses/Image/InlineImageResponse.php
+++ b/app/Http/Responses/Image/InlineImageResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Responses\Image;
+
+use App\Contracts\StreamableImageFile;
+use App\Http\Responses\FileResponse;
+use Illuminate\Contracts\Support\Responsable;
+
+class InlineImageResponse implements Responsable
+{
+    public function __construct(private readonly StreamableImageFile $image) {}
+
+    public function toResponse($request)
+    {
+        return FileResponse::view(
+            $this->image->imageDisk(),
+            $this->image->imageStoragePath(),
+            $this->image->imageMimeType(),
+        )->toResponse($request);
+    }
+}

--- a/app/Models/AvailableImage.php
+++ b/app/Models/AvailableImage.php
@@ -2,11 +2,12 @@
 
 namespace App\Models;
 
+use App\Contracts\StreamableImageFile;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class AvailableImage extends Model
+class AvailableImage extends Model implements StreamableImageFile
 {
     use HasFactory;
     use HasUuids;
@@ -24,5 +25,25 @@ class AvailableImage extends Model
     public function uniqueIds(): array
     {
         return ['id'];
+    }
+
+    public function imageDisk(): string
+    {
+        return config('localstorage.available.images.disk');
+    }
+
+    public function imageStoragePath(): string
+    {
+        return trim(config('localstorage.available.images.directory'), '/').'/'.$this->path;
+    }
+
+    public function imageMimeType(): ?string
+    {
+        return null;
+    }
+
+    public function imageDownloadFilename(): string
+    {
+        return basename($this->path);
     }
 }

--- a/app/Models/CollectionImage.php
+++ b/app/Models/CollectionImage.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Contracts\StreamableImageFile;
 use App\Traits\HasDisplayOrder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -12,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
-class CollectionImage extends Model
+class CollectionImage extends Model implements StreamableImageFile
 {
     use HasDisplayOrder, HasFactory, HasUuids;
 
@@ -195,5 +196,25 @@ class CollectionImage extends Model
 
             return $availableImage;
         });
+    }
+
+    public function imageDisk(): string
+    {
+        return config('localstorage.pictures.disk');
+    }
+
+    public function imageStoragePath(): string
+    {
+        return trim(config('localstorage.pictures.directory'), '/').'/'.$this->path;
+    }
+
+    public function imageMimeType(): ?string
+    {
+        return $this->mime_type;
+    }
+
+    public function imageDownloadFilename(): string
+    {
+        return $this->original_name ?: basename($this->path);
     }
 }

--- a/app/Models/ItemImage.php
+++ b/app/Models/ItemImage.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Contracts\StreamableImageFile;
 use App\Traits\HasDisplayOrder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -12,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
-class ItemImage extends Model
+class ItemImage extends Model implements StreamableImageFile
 {
     use HasDisplayOrder, HasFactory, HasUuids;
 
@@ -195,5 +196,25 @@ class ItemImage extends Model
 
             return $availableImage;
         });
+    }
+
+    public function imageDisk(): string
+    {
+        return config('localstorage.pictures.disk');
+    }
+
+    public function imageStoragePath(): string
+    {
+        return trim(config('localstorage.pictures.directory'), '/').'/'.$this->path;
+    }
+
+    public function imageMimeType(): ?string
+    {
+        return $this->mime_type;
+    }
+
+    public function imageDownloadFilename(): string
+    {
+        return $this->original_name ?: basename($this->path);
     }
 }

--- a/app/Models/PartnerImage.php
+++ b/app/Models/PartnerImage.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Contracts\StreamableImageFile;
 use App\Traits\HasDisplayOrder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -11,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
-class PartnerImage extends Model
+class PartnerImage extends Model implements StreamableImageFile
 {
     use HasDisplayOrder, HasFactory, HasUuids;
 
@@ -164,5 +165,25 @@ class PartnerImage extends Model
 
             return $availableImage;
         });
+    }
+
+    public function imageDisk(): string
+    {
+        return config('localstorage.pictures.disk');
+    }
+
+    public function imageStoragePath(): string
+    {
+        return trim(config('localstorage.pictures.directory'), '/').'/'.$this->path;
+    }
+
+    public function imageMimeType(): ?string
+    {
+        return $this->mime_type;
+    }
+
+    public function imageDownloadFilename(): string
+    {
+        return $this->original_name ?: basename($this->path);
     }
 }

--- a/tests/Unit/Http/Responses/Image/DownloadImageResponseTest.php
+++ b/tests/Unit/Http/Responses/Image/DownloadImageResponseTest.php
@@ -5,13 +5,15 @@ namespace Tests\Unit\Http\Responses\Image;
 use App\Contracts\StreamableImageFile;
 use App\Http\Responses\Image\DownloadImageResponse;
 use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Tests\TestCase;
 
 class DownloadImageResponseTest extends TestCase
 {
     private function makeImageFile(string $disk, string $storagePath, ?string $mimeType, string $downloadFilename): StreamableImageFile
     {
-        return new class($disk, $storagePath, $mimeType, $downloadFilename) implements StreamableImageFile {
+        return new class($disk, $storagePath, $mimeType, $downloadFilename) implements StreamableImageFile
+        {
             public function __construct(
                 private string $disk,
                 private string $storagePath,
@@ -54,7 +56,7 @@ class DownloadImageResponseTest extends TestCase
         $this->assertStringContainsString('my-photo.jpg', $response->headers->get('Content-Disposition'));
     }
 
-    public function test_download_filename_from_imageDownloadFilename_is_used(): void
+    public function test_download_filename_from_image_download_filename_is_used(): void
     {
         Storage::fake('public');
         Storage::disk('public')->put('pictures/uuid-filename.jpg', 'fake-image-content');
@@ -72,7 +74,7 @@ class DownloadImageResponseTest extends TestCase
 
         $image = $this->makeImageFile('public', 'pictures/missing.jpg', 'image/jpeg', 'missing.jpg');
 
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+        $this->expectException(HttpException::class);
 
         (new DownloadImageResponse($image))->toResponse(request());
     }

--- a/tests/Unit/Http/Responses/Image/DownloadImageResponseTest.php
+++ b/tests/Unit/Http/Responses/Image/DownloadImageResponseTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Unit\Http\Responses\Image;
+
+use App\Contracts\StreamableImageFile;
+use App\Http\Responses\Image\DownloadImageResponse;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class DownloadImageResponseTest extends TestCase
+{
+    private function makeImageFile(string $disk, string $storagePath, ?string $mimeType, string $downloadFilename): StreamableImageFile
+    {
+        return new class($disk, $storagePath, $mimeType, $downloadFilename) implements StreamableImageFile {
+            public function __construct(
+                private string $disk,
+                private string $storagePath,
+                private ?string $mimeType,
+                private string $downloadFilename,
+            ) {}
+
+            public function imageDisk(): string
+            {
+                return $this->disk;
+            }
+
+            public function imageStoragePath(): string
+            {
+                return $this->storagePath;
+            }
+
+            public function imageMimeType(): ?string
+            {
+                return $this->mimeType;
+            }
+
+            public function imageDownloadFilename(): string
+            {
+                return $this->downloadFilename;
+            }
+        };
+    }
+
+    public function test_returns_attachment_response_with_correct_filename(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('pictures/photo.jpg', 'fake-image-content');
+
+        $image = $this->makeImageFile('public', 'pictures/photo.jpg', 'image/jpeg', 'my-photo.jpg');
+        $response = (new DownloadImageResponse($image))->toResponse(request());
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('attachment', $response->headers->get('Content-Disposition'));
+        $this->assertStringContainsString('my-photo.jpg', $response->headers->get('Content-Disposition'));
+    }
+
+    public function test_download_filename_from_imageDownloadFilename_is_used(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('pictures/uuid-filename.jpg', 'fake-image-content');
+
+        $downloadFilename = 'original-upload-name.jpg';
+        $image = $this->makeImageFile('public', 'pictures/uuid-filename.jpg', 'image/jpeg', $downloadFilename);
+        $response = (new DownloadImageResponse($image))->toResponse(request());
+
+        $this->assertStringContainsString($downloadFilename, $response->headers->get('Content-Disposition'));
+    }
+
+    public function test_returns_404_when_file_does_not_exist(): void
+    {
+        Storage::fake('public');
+
+        $image = $this->makeImageFile('public', 'pictures/missing.jpg', 'image/jpeg', 'missing.jpg');
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+
+        (new DownloadImageResponse($image))->toResponse(request());
+    }
+}

--- a/tests/Unit/Http/Responses/Image/InlineImageResponseTest.php
+++ b/tests/Unit/Http/Responses/Image/InlineImageResponseTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit\Http\Responses\Image;
+
+use App\Contracts\StreamableImageFile;
+use App\Http\Responses\Image\InlineImageResponse;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class InlineImageResponseTest extends TestCase
+{
+    private function makeImageFile(string $disk, string $storagePath, ?string $mimeType, string $downloadFilename): StreamableImageFile
+    {
+        return new class($disk, $storagePath, $mimeType, $downloadFilename) implements StreamableImageFile {
+            public function __construct(
+                private string $disk,
+                private string $storagePath,
+                private ?string $mimeType,
+                private string $downloadFilename,
+            ) {}
+
+            public function imageDisk(): string
+            {
+                return $this->disk;
+            }
+
+            public function imageStoragePath(): string
+            {
+                return $this->storagePath;
+            }
+
+            public function imageMimeType(): ?string
+            {
+                return $this->mimeType;
+            }
+
+            public function imageDownloadFilename(): string
+            {
+                return $this->downloadFilename;
+            }
+        };
+    }
+
+    public function test_returns_inline_response_with_correct_disposition(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('images/test.jpg', 'fake-image-content');
+
+        $image = $this->makeImageFile('public', 'images/test.jpg', 'image/jpeg', 'test.jpg');
+        $response = (new InlineImageResponse($image))->toResponse(request());
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('inline', $response->headers->get('Content-Disposition'));
+    }
+
+    public function test_returns_inline_response_with_null_mime_type(): void
+    {
+        Storage::fake('public');
+        Storage::disk('public')->put('images/test.png', 'fake-image-content');
+
+        $image = $this->makeImageFile('public', 'images/test.png', null, 'test.png');
+        $response = (new InlineImageResponse($image))->toResponse(request());
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('inline', $response->headers->get('Content-Disposition'));
+    }
+
+    public function test_returns_404_when_file_does_not_exist(): void
+    {
+        Storage::fake('public');
+
+        $image = $this->makeImageFile('public', 'images/missing.jpg', 'image/jpeg', 'missing.jpg');
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+
+        (new InlineImageResponse($image))->toResponse(request());
+    }
+}

--- a/tests/Unit/Http/Responses/Image/InlineImageResponseTest.php
+++ b/tests/Unit/Http/Responses/Image/InlineImageResponseTest.php
@@ -5,13 +5,15 @@ namespace Tests\Unit\Http\Responses\Image;
 use App\Contracts\StreamableImageFile;
 use App\Http\Responses\Image\InlineImageResponse;
 use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Tests\TestCase;
 
 class InlineImageResponseTest extends TestCase
 {
     private function makeImageFile(string $disk, string $storagePath, ?string $mimeType, string $downloadFilename): StreamableImageFile
     {
-        return new class($disk, $storagePath, $mimeType, $downloadFilename) implements StreamableImageFile {
+        return new class($disk, $storagePath, $mimeType, $downloadFilename) implements StreamableImageFile
+        {
             public function __construct(
                 private string $disk,
                 private string $storagePath,
@@ -71,7 +73,7 @@ class InlineImageResponseTest extends TestCase
 
         $image = $this->makeImageFile('public', 'images/missing.jpg', 'image/jpeg', 'missing.jpg');
 
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+        $this->expectException(HttpException::class);
 
         (new InlineImageResponse($image))->toResponse(request());
     }


### PR DESCRIPTION
## Summary

Eliminates the duplicated disk/directory/path/filename/mime resolution body that previously appeared **16 times** across the four image models × {API, Web} × {view, download} controller methods.

## What changed

### New files
- `app/Contracts/StreamableImageFile.php` — interface exposing `imageDisk()`, `imageStoragePath()`, `imageMimeType()`, `imageDownloadFilename()`
- `app/Http/Responses/Image/InlineImageResponse.php` — `Responsable` wrapper for inline (view) responses
- `app/Http/Responses/Image/DownloadImageResponse.php` — `Responsable` wrapper for attachment (download) responses
- `tests/Unit/Http/Responses/Image/InlineImageResponseTest.php`
- `tests/Unit/Http/Responses/Image/DownloadImageResponseTest.php`

### Modified files
- `app/Models/{AvailableImage,ItemImage,CollectionImage,PartnerImage}.php` — implement `StreamableImageFile`
- `app/Http/Controllers/{AvailableImage,ItemImage,CollectionImage,PartnerImage}Controller.php` — `view()` / `download()` collapsed to one-liners
- `app/Http/Controllers/Web/{AvailableImage,ItemImage,CollectionImage,PartnerImage}Controller.php` — same, with parent-ownership `abort(404)` guards preserved

## No contract changes
- Routes, route names, middleware, HTTP status codes, response headers, and body bytes are unchanged.
- No test files were modified — existing tests are the acceptance gate.

## Filament-readiness
A follow-up Filament controller can return `new InlineImageResponse($itemImage)` / `new DownloadImageResponse($itemImage)` without any further changes to this story's code.

Closes #911