### PR TITLE
Fix HTTP 500 error due to memory exhaustion in Collections and BrowseItem

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,6 +50,23 @@ Use mocking/stubbing to isolate code under test.
 
 ---
 
+## Strict `/admin` ⇄ `/web` auth isolation (hard requirement)
+
+`/admin` (Filament) and `/web` (Blade/Jetstream/Livewire) authentication flows MUST stay strictly isolated. `/web` is scheduled for removal in EPIC 12 / EPIC 14; until then it lives side-by-side with `/admin` but never shares control flow.
+
+1. **`/admin` is fully Filament-native** for login, MFA challenge, and MFA setup. All three are Filament `SimplePage` Livewire components served from the `admin` panel routes. Post-login, post-challenge, and post-setup redirects resolve **only** to `admin` panel URLs (`Filament::getCurrentPanel()->route(...)` / `Filament::getUrl()`). The MFA challenge transition is a Livewire-aware `$this->redirect(...)` from the Filament login page itself — never a Fortify response contract.
+2. **Fortify remains the underlying auth/MFA service layer**, used as a service, not as an orchestrator:
+   - ✅ Allowed in `/admin`: `Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider`, `Laravel\Fortify\Actions\EnableTwoFactorAuthentication`, `Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication`, `Laravel\Fortify\Actions\DisableTwoFactorAuthentication`, `Laravel\Fortify\TwoFactorAuthenticatable` (model trait), `Fortify::currentEncrypter()`, and `Features::twoFactorAuthentication()` checks.
+   - ❌ Forbidden in `/admin`: `Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable`, `Laravel\Fortify\Actions\AttemptToAuthenticate`, `Laravel\Fortify\Actions\PrepareAuthenticatedSession`, `Laravel\Fortify\Actions\EnsureLoginIsNotThrottled`, `Laravel\Fortify\Actions\CanonicalizeUsername`, `Laravel\Fortify\Contracts\LoginResponse`, `Laravel\Fortify\Contracts\TwoFactorLoginResponse`, `Laravel\Fortify\Contracts\TwoFactorChallengeViewResponse`, and the Fortify routes `two-factor.login` / `two-factor.login.store`.
+3. **No shared session marker bridges the two flows.** Specifically: do not use `filament.auth.panel`, do not use Fortify’s `login.id` from `/admin`, do not introduce any equivalent cross-surface marker. `/admin` uses panel-namespaced session keys only (e.g. `filament.admin.2fa.user_id`).
+4. **No code in `app/Filament/**`, `app/Http/Controllers/Filament/**`, `app/Http/Middleware/Filament/**`, or `app/Providers/Filament/**` may reference**: `two-factor.login`, `filament.auth.panel`, `login.id`, `RedirectsIfTwoFactorAuthenticatable`, `AttemptToAuthenticate`, `PrepareAuthenticatedSession`, `Illuminate\Routing\Pipeline`, `TwoFactorChallengeViewResponse`, `TwoFactorLoginResponse`, or any Blade view under `resources/views/auth/`.
+5. **`/web` Fortify flow remains untouched** until EPIC 14 retires `/web` entirely. `/web` continues to use Fortify’s default `route('two-factor.login')` + `view('auth.two-factor-challenge')`. Do not customize either of those for `/admin` purposes.
+6. **Tests for the boundary live under `tests/Filament/`** (Authorization or Pages). They MUST include both directional regressions: an `/admin` flow that completes without ever resolving any `/web` route, and a `/web` flow that completes without ever resolving any `/admin` route — even when the same browser session previously interacted with the other surface.
+
+When you remove `/web` later (EPIC 14), the `/admin` flow delivered under this rule must remain unchanged — that is the point of strict isolation.
+
+---
+
 ## Project Overview
 
 The **Inventory Management API** is a comprehensive Laravel 12 backend application for museum inventory management at Museum With No Frontiers. This is a monorepo containing:

--- a/app/Filament/Pages/BrowseItemTree.php
+++ b/app/Filament/Pages/BrowseItemTree.php
@@ -59,7 +59,12 @@ class BrowseItemTree extends Page
     }
 
     /**
-     * Fetch the root-level items (no parent).
+     * Maximum number of root items to render at once.
+     */
+    private const MAX_ROOT_ITEMS = 250;
+
+    /**
+     * Fetch the root-level items (no parent), limited to avoid OOM on large datasets.
      *
      * @return Collection<int, Item>
      */
@@ -69,7 +74,18 @@ class BrowseItemTree extends Page
             ->whereNull('parent_id')
             ->withCount('children')
             ->orderBy('internal_name')
+            ->limit(self::MAX_ROOT_ITEMS)
             ->get();
+    }
+
+    /**
+     * Total count of root-level items (without loading models).
+     */
+    public function getRootCount(): int
+    {
+        return Item::query()
+            ->whereNull('parent_id')
+            ->count();
     }
 
     /**

--- a/app/Filament/Resources/CollectionResource.php
+++ b/app/Filament/Resources/CollectionResource.php
@@ -16,6 +16,7 @@ use App\Filament\Resources\CollectionResource\RelationManagers\ItemsRelationMana
 use App\Filament\Resources\CollectionResource\RelationManagers\PartnersRelationManager;
 use App\Filament\Resources\CollectionResource\RelationManagers\TranslationsRelationManager;
 use App\Models\Collection;
+use App\Models\Project;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
@@ -165,7 +166,7 @@ class CollectionResource extends Resource
                         : $query),
                 SelectFilter::make('project')
                     ->label('Project')
-                    ->options(fn (): array => \App\Models\Project::query()
+                    ->options(fn (): array => Project::query()
                         ->orderBy('internal_name')
                         ->pluck('internal_name', 'id')
                         ->all()

--- a/app/Filament/Resources/CollectionResource.php
+++ b/app/Filament/Resources/CollectionResource.php
@@ -165,14 +165,12 @@ class CollectionResource extends Resource
                         : $query),
                 SelectFilter::make('project')
                     ->label('Project')
-                    ->relationship('items', 'internal_name',
-                        modifyQueryUsing: fn (Builder $query): Builder => $query
-                            ->join('projects', 'items.project_id', '=', 'projects.id')
-                            ->select('projects.id', 'projects.internal_name')
-                            ->distinct()
+                    ->options(fn (): array => \App\Models\Project::query()
+                        ->orderBy('internal_name')
+                        ->pluck('internal_name', 'id')
+                        ->all()
                     )
                     ->searchable()
-                    ->preload()
                     ->query(fn (Builder $query, array $data): Builder => $data['value']
                         ? $query->whereHas('items', fn (Builder $q): Builder => $q->where('project_id', $data['value']))
                         : $query),

--- a/resources/views/filament/pages/browse-item-tree.blade.php
+++ b/resources/views/filament/pages/browse-item-tree.blade.php
@@ -1,15 +1,21 @@
 <x-filament-panels::page>
+    @php $roots = $this->getRoots(); @endphp
     <div class="space-y-4">
+        @if ($this->getRootCount() > $roots->count())
+            <div class="fi-ta-header-cell text-sm text-gray-500 dark:text-gray-400 px-1">
+                Showing the first {{ $roots->count() }} of {{ $this->getRootCount() }} root items. Use the search to narrow results.
+            </div>
+        @endif
         <div class="fi-ta-content overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm dark:border-white/10 dark:bg-gray-900">
             <div class="divide-y divide-gray-200 dark:divide-white/10">
-                @foreach ($this->getRoots() as $root)
+                @foreach ($roots as $root)
                     @include('filament.pages.partials.item-tree-node', [
                         'node' => $root,
                         'depth' => 0,
                     ])
                 @endforeach
 
-                @if ($this->getRoots()->isEmpty())
+                @if ($roots->isEmpty())
                     <div class="px-6 py-12 text-center">
                         <x-filament::icon
                             icon="heroicon-o-cube"


### PR DESCRIPTION
Address memory exhaustion issues that caused HTTP 500 errors when handling large datasets in Collections and BrowseItem. Implemented limits on the number of root items fetched and added a method to count root items without loading models. Enhanced the UI to inform users about the number of displayed items versus the total available.