### PR TITLE
fix: prevent infinite recursion when including translations on item (6.12.10)

### DIFF
--- a/app/Http/Resources/ItemTranslationResource.php
+++ b/app/Http/Resources/ItemTranslationResource.php
@@ -77,7 +77,7 @@ class ItemTranslationResource extends JsonResource
             'updated_at' => $this->updated_at,
 
             // The item relationship (ItemResource)
-            'item' => new ItemResource($this->whenLoaded('item')),
+            'item' => new ItemResource($this->whenLoaded('item', fn ($item) => $item->withoutRelations())),
             // The language relationship (LanguageResource)
             'language' => new LanguageResource($this->whenLoaded('language')),
             // The context relationship (ContextResource)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "inventory-app",
-    "version": "6.12.9",
+    "version": "6.12.10",
     "private": true,
     "type": "module",
     "scripts": {

--- a/tests/Api/Resources/ItemTest.php
+++ b/tests/Api/Resources/ItemTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Api\Resources;
 
 use App\Models\Item;
+use App\Models\ItemTranslation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Api\Traits\AuthenticatesApiRequests;
 use Tests\Api\Traits\TestsApiCrud;
@@ -24,5 +25,17 @@ class ItemTest extends TestCase
     protected function getModelClass(): string
     {
         return Item::class;
+    }
+
+    public function test_show_with_include_translations_returns_200_without_infinite_recursion(): void
+    {
+        $item = Item::factory()->create();
+        ItemTranslation::factory()->create(['item_id' => $item->id]);
+
+        $response = $this->getJson(route('item.show', $item).'?include=translations');
+
+        $response->assertOk()
+            ->assertJsonPath('data.id', $item->id)
+            ->assertJsonStructure(['data' => ['translations']]);
     }
 }


### PR DESCRIPTION
## Problem

`GET /api/item/{uuid}?include=translations` returns HTTP 502 on the production Windows host.

### Root cause — infinite recursive serialization

Eloquent's `chaperone('item')` on the `translations()` relation automatically sets the `item` back-reference on every loaded `ItemTranslation`. This causes a circular serialization chain:

```
ItemResource::toArray()
  └─ ItemTranslationResource::collection($this->whenLoaded('translations'))
       └─ ItemTranslationResource::toArray()   [for each translation]
            └─ new ItemResource($this->whenLoaded('item'))   ← chaperone injected this!
                 └─ ItemResource::toArray()
                      └─ ... ∞
```

PHP's thread stack overflows at C level (Windows MPM). No PHP error is logged, no access log entry is written, the TCP connection is reset — the reverse proxy logs `AH01102: error reading status line` and returns 502.

## Fix

Strip the loaded relations from the chaperone-injected `$item` before wrapping it in `ItemResource`, breaking the cycle at depth 2:

```php
// Before
'item' => new ItemResource($this->whenLoaded('item')),

// After
'item' => new ItemResource($this->whenLoaded('item', fn ($item) => $item->withoutRelations())),
```

`withoutRelations()` returns a clone with the loaded-relations map cleared. The `item` field in `ItemTranslationResource` still works correctly (e.g. `GET /api/item-translation/{id}?include=item`), it just won't re-nest translations inside it — which would be circular data anyway.

## Changes

- `app/Http/Resources/ItemTranslationResource.php` — one-line fix
- `tests/Api/Resources/ItemTest.php` — regression test: `include=translations` returns 200 with `translations` key
- `package.json` — version bump `6.12.9` → `6.12.10`

## Deployment notes

- This branch targets `release/6.12` (based on tag `6.12.9.152`), **not** `main`.
- After merge: trigger `Build` workflow manually on `release/6.12` via `workflow_dispatch`.
- The build will produce release tag `6.12.10.<run_number>` with `inventory-app.zip`.
- OVH deployment is **not** triggered (deploy-ovh.yml only fires on builds from `main`).
- Windows deployment: trigger `Deploy` workflow manually with the generated tag.

> ⚠️ `ci-build-test.yml` does not run on PRs to `release/6.12` (it only targets `main`). Tests were verified locally — the regression test passes.