### PR TITLE
fix: prevent infinite recursion when including translations on item (same as 6.12.10) (#1037)

### DIFF
--- a/.github/agents/php-test-runner.agent.md
+++ b/.github/agents/php-test-runner.agent.md
@@ -1,0 +1,82 @@
+---
+description: 'Runs Laravel Pint (lint) and PHPUnit/Pest test suites via the inventory-app-test Docker container. Use on Windows machines where the native PHP (8.2) lacks the required extensions for the current codebase (Filament 3 requires intl, zip, gd, exif — all pre-built in the image).'
+model: GPT-4.1 | 'gpt-5' | 'Claude Sonnet 4.5'
+tools: ['codebase', 'terminalCommand']
+---
+
+# PHP Test Runner Agent (Docker — PHP 8.4)
+
+You run Laravel Pint and PHPUnit/Pest tests inside the `inventory-app-test` Docker container, which provides PHP 8.4 with all CI-matching extensions (`intl`, `zip`, `pdo_sqlite`, `gd`, `exif`, `bcmath`, `pcntl`, `sodium`). This is the **only** correct way to run PHP tests on this Windows machine; never use the native `php artisan test` command directly.
+
+## Prerequisites — ensure the image exists
+
+```powershell
+docker images inventory-app-test
+```
+
+If the `inventory-app-test` image is not listed, build it first (one-time cost, ~5 minutes):
+
+```powershell
+docker build -f Dockerfile.testing -t inventory-app-test .
+```
+
+Rebuild whenever `composer.lock` changes (the vendor layer is cached per lock-file state).
+
+---
+
+## Running Pint (PHP lint)
+
+```powershell
+# Check only — no changes written (CI mode)
+docker run --rm -v "${PWD}:/app" inventory-app-test vendor/bin/pint --test --no-ansi
+
+# Auto-fix dirty files
+docker run --rm -v "${PWD}:/app" inventory-app-test vendor/bin/pint --no-ansi
+```
+
+---
+
+## Running Tests — CI matrix parity
+
+Each suite maps 1:1 to a GitHub Actions matrix job. Always run with `--no-ansi` and never pipe output through filters.
+
+```powershell
+# Individual suites (CI parity)
+docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Unit          --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Api           --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Web           --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Filament      --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Configuration --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Console       --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Event         --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Integration   --coverage --parallel --no-ansi --stop-on-failure
+```
+
+### Full CI matrix in sequence
+
+```powershell
+foreach ($suite in @('Unit','Api','Web','Filament','Configuration','Console','Event','Integration')) {
+    Write-Host "=== $suite ===" -ForegroundColor Cyan
+    docker run --rm -v "${PWD}:/app" inventory-app-test `
+        php artisan test --testsuite=$suite --coverage --parallel --no-ansi --stop-on-failure
+    if ($LASTEXITCODE -ne 0) { Write-Error "Suite $suite FAILED"; break }
+}
+```
+
+### Single test (by name filter)
+
+```powershell
+docker run --rm -v "${PWD}:/app" inventory-app-test `
+    php artisan test --filter=MyTestMethodName --no-coverage --no-ansi
+```
+
+---
+
+## Rules
+
+- ❌ **NEVER** run `php artisan test` directly — local PHP is 8.2 and lacks required extensions.
+- ❌ **NEVER** pipe test or Pint output through `Select-Object`, `grep`, `head`, or any filter — full output is needed to see failure details.
+- ✅ The project root is mounted at `/app` inside the container — local edits are immediately visible without rebuilding.
+- ✅ The image vendor layer is baked in; no `composer install` is needed at runtime.
+- ✅ After `Dockerfile.testing` changes, rebuild with `docker build -f Dockerfile.testing -t inventory-app-test .`.
+- ✅ This agent applies only to the local Windows dev machine. GitHub Actions runners (Linux) use the native PHP set up by `shivammathur/setup-php@v2` and do not use Docker.

--- a/.github/agents/php-test-runner.agent.md
+++ b/.github/agents/php-test-runner.agent.md
@@ -40,16 +40,28 @@ docker run --rm -v "${PWD}:/app" inventory-app-test vendor/bin/pint --no-ansi
 
 Each suite maps 1:1 to a GitHub Actions matrix job. Always run with `--no-ansi` and never pipe output through filters.
 
+The named volume `inv-app-vendor-84` must be seeded from the image before the first run (or after a rebuild):
+
+```powershell
+# Seed Linux-native vendor into named volume (once after each image build)
+docker volume rm inv-app-vendor-84 2>$null
+docker run --rm -v inv-app-vendor-84:/app/vendor inventory-app-test echo "vendor volume initialized"
+# Clear any stale Windows bootstrap cache
+docker run --rm -v "${PWD}:/app" -v inv-app-vendor-84:/app/vendor `
+    -e APP_ENV=testing -e DB_CONNECTION=sqlite -e DB_DATABASE=:memory: -e CACHE_STORE=array `
+    inventory-app-test php artisan optimize:clear --no-ansi
+```
+
 ```powershell
 # Individual suites (CI parity)
-docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Unit          --coverage --parallel --no-ansi --stop-on-failure
-docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Api           --coverage --parallel --no-ansi --stop-on-failure
-docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Web           --coverage --parallel --no-ansi --stop-on-failure
-docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Filament      --coverage --parallel --no-ansi --stop-on-failure
-docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Configuration --coverage --parallel --no-ansi --stop-on-failure
-docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Console       --coverage --parallel --no-ansi --stop-on-failure
-docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Event         --coverage --parallel --no-ansi --stop-on-failure
-docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Integration   --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Unit          --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Api           --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Web           --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Filament      --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Configuration --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Console       --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Event         --coverage --parallel --no-ansi --stop-on-failure
+docker run --rm -v "${PWD}:/app" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Integration   --coverage --parallel --no-ansi --stop-on-failure
 ```
 
 ### Full CI matrix in sequence
@@ -57,7 +69,7 @@ docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite
 ```powershell
 foreach ($suite in @('Unit','Api','Web','Filament','Configuration','Console','Event','Integration')) {
     Write-Host "=== $suite ===" -ForegroundColor Cyan
-    docker run --rm -v "${PWD}:/app" inventory-app-test `
+    docker run --rm -v "${PWD}:/app" -v inv-app-vendor-84:/app/vendor inventory-app-test `
         php artisan test --testsuite=$suite --coverage --parallel --no-ansi --stop-on-failure
     if ($LASTEXITCODE -ne 0) { Write-Error "Suite $suite FAILED"; break }
 }
@@ -66,7 +78,7 @@ foreach ($suite in @('Unit','Api','Web','Filament','Configuration','Console','Ev
 ### Single test (by name filter)
 
 ```powershell
-docker run --rm -v "${PWD}:/app" inventory-app-test `
+docker run --rm -v "${PWD}:/app" -v inv-app-vendor-84:/app/vendor inventory-app-test `
     php artisan test --filter=MyTestMethodName --no-coverage --no-ansi
 ```
 
@@ -76,6 +88,7 @@ docker run --rm -v "${PWD}:/app" inventory-app-test `
 
 - ❌ **NEVER** run `php artisan test` directly — local PHP is 8.2 and lacks required extensions.
 - ❌ **NEVER** pipe test or Pint output through `Select-Object`, `grep`, `head`, or any filter — full output is needed to see failure details.
+- ✅ The image sets `memory_limit = 512M` (overriding the PHP CLI default of 128M) — required for Filament's class discovery scan.
 - ✅ The project root is mounted at `/app` inside the container — local edits are immediately visible without rebuilding.
 - ✅ The image vendor layer is baked in; no `composer install` is needed at runtime.
 - ✅ After `Dockerfile.testing` changes, rebuild with `docker build -f Dockerfile.testing -t inventory-app-test .`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -191,6 +191,14 @@ php artisan test --testsuite=Integration --coverage --parallel --no-ansi --stop-
 
 Use the CI matrix commands above, or equivalent VS Code tasks, when validating backend changes that must match GitHub Actions behavior. Do not treat a single plain `php artisan test` run as CI parity.
 
+> **Windows dev machine — PHP 8.4 via Docker is required.**
+> The local PHP installation is 8.2 and lacks several extensions required by the current codebase (Filament 3 needs `intl`, `zip`, `gd`, `exif`). On Windows, prefix every `php artisan test` and `vendor/bin/pint` command with the Docker wrapper:
+> ```powershell
+> docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test ...
+> docker run --rm -v "${PWD}:/app" inventory-app-test vendor/bin/pint ...
+> ```
+> Build the image once with `docker build -f Dockerfile.testing -t inventory-app-test .` (see `Dockerfile.testing`). Rebuild when `composer.lock` changes. GitHub Actions runners (Linux) do **not** use this image — they use `shivammathur/setup-php@v2` directly.
+
 VS Code task runs are terminal-based and do not feed results back into the Testing panel. For interactive PHP test discovery and per-test results inside VS Code, use the `PHPUnit & Pest Test Explorer` extension and run tests from the Testing view instead of from tasks.
 
 **SPA commands** (run from `/spa/` directory):

--- a/.github/instructions/php.instructions.md
+++ b/.github/instructions/php.instructions.md
@@ -60,6 +60,15 @@ applyTo: "**/*.php"
 - Never ignore lint errors and warnings.
 - Never ignore failing tests.
 
+> **Windows dev machine — use Docker for Pint and tests.**
+> The local PHP is 8.2 and lacks extensions required by Filament 3 (`intl`, `zip`, `gd`, `exif`). Always run Pint and `php artisan test` via the `inventory-app-test` Docker image:
+> ```powershell
+> docker run --rm -v "${PWD}:/app" inventory-app-test vendor/bin/pint --no-ansi
+> docker run --rm -v "${PWD}:/app" inventory-app-test php artisan test --testsuite=Api --coverage --parallel --no-ansi --stop-on-failure
+> ```
+> Build once: `docker build -f Dockerfile.testing -t inventory-app-test .` Rebuild when `composer.lock` changes.
+> See `.github/agents/php-test-runner.agent.md` for the full command reference.
+
 ## Web List Pages — Request-Driven Pattern (the only approved approach)
 
 Every web index (`index()`) action must follow the request-driven list pattern. Do **not** use any other approach.

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,720 +1,186 @@
 {
 	"version": "2.0.0",
 	"tasks": [
+
+		// ── Docker ────────────────────────────────────────────────────────────────
 		{
-			"label": "laravel:up",
+			"label": "docker:rebuild",
 			"type": "shell",
-			"command": "php",
-			"args": [
-				"artisan",
-				"up"
-			],
-			"group": "none",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "php artisan up"
-		},
-		{
-			"label": "laravel:down",
-			"type": "shell",
-			"command": "php",
-			"args": [
-				"artisan",
-				"down"
-			],
-			"group": "none",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "php artisan down"
-		},
-		{
-			"label": "composer-install:run",
-			"type": "shell",
-			"command": "composer",
-			"args": [
-				"install"
-			],
+			"command": "docker build -f Dockerfile.testing -t inventory-app-test . && docker volume rm inv-app-vendor-84 2>$null; docker run --rm -v inv-app-vendor-84:/app/vendor inventory-app-test echo 'vendor seeded' && docker run --rm -v \"${workspaceFolder}:/app\" -v inv-app-vendor-84:/app/vendor -e APP_ENV=testing -e DB_CONNECTION=sqlite \"-e DB_DATABASE=:memory:\" -e CACHE_STORE=array inventory-app-test php artisan optimize:clear --no-ansi",
 			"group": "build",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
+			"options": { "cwd": "${workspaceFolder}" },
+			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
-			"detail": "composer install"
+			"detail": "Build inventory-app-test image, re-seed Linux vendor volume, clear bootstrap cache"
+		},
+
+		// ── PHP lint ──────────────────────────────────────────────────────────────
+		{
+			"label": "php:lint",
+			"type": "shell",
+			"command": "docker run --rm -v \"${workspaceFolder}:/app\" -v inv-app-vendor-84:/app/vendor inventory-app-test vendor/bin/pint --no-ansi",
+			"group": "build",
+			"options": { "cwd": "${workspaceFolder}" },
+			"presentation": { "reveal": "always", "panel": "shared" },
+			"problemMatcher": [],
+			"detail": "Run Laravel Pint inside the PHP 8.4 Docker test image"
+		},
+
+		// ── PHP test suites (atomic, one per CI matrix job) ───────────────────────
+		{
+			"label": "php:test:Unit",
+			"type": "shell",
+			"command": "docker run --rm -v \"${workspaceFolder}:/app\" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Unit --no-coverage --parallel --no-ansi --stop-on-failure",
+			"group": "test",
+			"options": { "cwd": "${workspaceFolder}" },
+			"presentation": { "reveal": "always", "panel": "shared" },
+			"problemMatcher": [],
+			"detail": "php artisan test --testsuite=Unit (Docker PHP 8.4)"
 		},
 		{
-			"label": "pint:run",
+			"label": "php:test:Api",
 			"type": "shell",
-			"command": "${workspaceFolder}/vendor/bin/pint",
-			"args": [
-				"--no-interaction",
-				"--parallel"
-			],
-			"group": "build",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
+			"command": "docker run --rm -v \"${workspaceFolder}:/app\" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Api --no-coverage --parallel --no-ansi --stop-on-failure",
+			"group": "test",
+			"options": { "cwd": "${workspaceFolder}" },
+			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
-			"detail": "vendor/bin/pint --no-interaction --parallel"
+			"detail": "php artisan test --testsuite=Api (Docker PHP 8.4)"
 		},
 		{
-			"label": "composer-audit:run",
+			"label": "php:test:Web",
 			"type": "shell",
-			"command": "composer",
-			"args": [
-				"audit"
+			"command": "docker run --rm -v \"${workspaceFolder}:/app\" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Web --no-coverage --parallel --no-ansi --stop-on-failure",
+			"group": "test",
+			"options": { "cwd": "${workspaceFolder}" },
+			"presentation": { "reveal": "always", "panel": "shared" },
+			"problemMatcher": [],
+			"detail": "php artisan test --testsuite=Web (Docker PHP 8.4)"
+		},
+		{
+			"label": "php:test:Filament",
+			"type": "shell",
+			"command": "docker run --rm -v \"${workspaceFolder}:/app\" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Filament --no-coverage --parallel --no-ansi --stop-on-failure",
+			"group": "test",
+			"options": { "cwd": "${workspaceFolder}" },
+			"presentation": { "reveal": "always", "panel": "shared" },
+			"problemMatcher": [],
+			"detail": "php artisan test --testsuite=Filament (Docker PHP 8.4)"
+		},
+		{
+			"label": "php:test:Configuration",
+			"type": "shell",
+			"command": "docker run --rm -v \"${workspaceFolder}:/app\" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Configuration --no-coverage --parallel --no-ansi --stop-on-failure",
+			"group": "test",
+			"options": { "cwd": "${workspaceFolder}" },
+			"presentation": { "reveal": "always", "panel": "shared" },
+			"problemMatcher": [],
+			"detail": "php artisan test --testsuite=Configuration (Docker PHP 8.4)"
+		},
+		{
+			"label": "php:test:Console",
+			"type": "shell",
+			"command": "docker run --rm -v \"${workspaceFolder}:/app\" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Console --no-coverage --parallel --no-ansi --stop-on-failure",
+			"group": "test",
+			"options": { "cwd": "${workspaceFolder}" },
+			"presentation": { "reveal": "always", "panel": "shared" },
+			"problemMatcher": [],
+			"detail": "php artisan test --testsuite=Console (Docker PHP 8.4)"
+		},
+		{
+			"label": "php:test:Event",
+			"type": "shell",
+			"command": "docker run --rm -v \"${workspaceFolder}:/app\" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Event --no-coverage --parallel --no-ansi --stop-on-failure",
+			"group": "test",
+			"options": { "cwd": "${workspaceFolder}" },
+			"presentation": { "reveal": "always", "panel": "shared" },
+			"problemMatcher": [],
+			"detail": "php artisan test --testsuite=Event (Docker PHP 8.4)"
+		},
+		{
+			"label": "php:test:Integration",
+			"type": "shell",
+			"command": "docker run --rm -v \"${workspaceFolder}:/app\" -v inv-app-vendor-84:/app/vendor inventory-app-test php artisan test --testsuite=Integration --no-coverage --parallel --no-ansi --stop-on-failure",
+			"group": "test",
+			"options": { "cwd": "${workspaceFolder}" },
+			"presentation": { "reveal": "always", "panel": "shared" },
+			"problemMatcher": [],
+			"detail": "php artisan test --testsuite=Integration (Docker PHP 8.4)"
+		},
+		{
+			"label": "php:test",
+			"dependsOn": [
+				"php:test:Unit",
+				"php:test:Api",
+				"php:test:Web",
+				"php:test:Filament",
+				"php:test:Configuration",
+				"php:test:Console",
+				"php:test:Event",
+				"php:test:Integration"
 			],
+			"dependsOrder": "sequence",
+			"group": { "kind": "test", "isDefault": true },
+			"presentation": { "reveal": "always", "panel": "shared" },
+			"problemMatcher": [],
+			"detail": "Run the full CI test matrix in sequence (Docker PHP 8.4)"
+		},
+
+		// ── Audit ─────────────────────────────────────────────────────────────────
+		{
+			"label": "audit:composer",
+			"type": "shell",
+			"command": "composer audit",
 			"group": "build",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
+			"options": { "cwd": "${workspaceFolder}" },
+			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
 			"detail": "composer audit"
 		},
 		{
-			"label": "npm-install:run",
+			"label": "audit:npm",
 			"type": "shell",
-			"command": "npm",
-			"args": [
-				"install",
-				"--no-audit",
-				"--no-fund"
-			],
+			"command": "npm audit",
 			"group": "build",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
+			"options": { "cwd": "${workspaceFolder}" },
+			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
-			"detail": "npm install --no-audit --no-fund"
+			"detail": "npm audit (.)"
 		},
 		{
-			"label": "npm-audit:run",
-			"type": "npm",
-			"script": "audit",
-			"group": "build",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "npm audit"
-		},
-		{
-			"label": "npm-lint:run",
-			"type": "npm",
-			"script": "lint",
-			"group": "build",
-			"problemMatcher": [
-				"$eslint-compact"
-			],
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"detail": "npm run lint"
-		},
-		{
-			"label": "npm-build:run",
-			"type": "npm",
-			"script": "build",
-			"group": "build",
-			"dependsOn": [
-				"npm-install:run"
-			],
-			"dependsOrder": "sequence",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "npm run build"
-		},
-		{
-			"label": "npm-install:run:spa",
+			"label": "audit:npm:spa",
 			"type": "shell",
-			"command": "npm",
-			"args": [
-				"install",
-				"--no-audit",
-				"--no-fund"
-			],
+			"command": "npm audit",
 			"group": "build",
-			"options": {
-				"cwd": "${workspaceFolder}\\spa"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
+			"options": { "cwd": "${workspaceFolder}\\spa" },
+			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
-			"detail": "npm install --no-audit --no-fund"
+			"detail": "npm audit (spa/)"
 		},
 		{
-			"label": "npm-lint:run:spa",
-			"type": "npm",
-			"script": "lint",
-			"path": "spa",
-			"group": "build",
-			"problemMatcher": [
-				"$eslint-compact"
-			],
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"detail": "npm run lint"
-		},
-		{
-			"label": "npm-audit:run:spa",
-			"type": "npm",
-			"script": "audit",
-			"path": "spa",
-			"group": "build",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "npm audit"
-		},
-		{
-			"label": "npm-type-check:run:spa",
-			"type": "npm",
-			"script": "type-check",
-			"path": "spa",
-			"group": "build",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [
-				"$tsc"
-			],
-			"detail": "npm run type-check"
-		},
-		{
-			"label": "npm-build:run:spa",
-			"type": "npm",
-			"script": "build",
-			"path": "spa",
-			"group": "build",
-			"dependsOn": [
-				"npm-install:run:spa"
-			],
-			"dependsOrder": "sequence",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "npm run build"
-		},
-		{
-			"label": "composer-dev:run",
+			"label": "audit:npm:importer",
 			"type": "shell",
-			"command": "composer",
-			"args": [
-				"dev"
-			],
-			"group": "none",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
+			"command": "npm audit",
+			"group": "build",
+			"options": { "cwd": "${workspaceFolder}\\scripts\\importer" },
+			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
-			"detail": "composer dev"
+			"detail": "npm audit (scripts/importer/)"
 		},
 		{
-			"label": "npm-dev:run:spa",
-			"type": "npm",
-			"script": "dev",
-			"path": "spa",
-			"group": "none",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "npm run dev"
-		},
-		{
-			"label": "install",
+			"label": "audit",
 			"dependsOn": [
-				"composer-install:run",
-				"npm-install:run",
-				"npm-install:run:spa"
+				"audit:composer",
+				"audit:npm",
+				"audit:npm:spa",
+				"audit:npm:importer"
 			],
 			"dependsOrder": "sequence",
 			"group": "build",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": []
-		},
-		{
-			"label": "check",
-			"dependsOn": [
-				"composer-audit:run",
-				"pint:run",
-				"npm-audit:run",
-				"npm-lint:run",
-				"npm-audit:run:spa",
-				"npm-lint:run:spa",
-				"npm-type-check:run:spa"
-			],
-			"dependsOrder": "sequence",
-			"group": "build",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": []
-		},
-		{
-			"label": "build",
-			"dependsOn": [
-				"check",
-				"npm-build:run",
-				"npm-build:run:spa"
-			],
-			"dependsOrder": "sequence",
-			"group": "build",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": []
-		},
-		{
-			"label": "phpunit:run",
-			"type": "shell",
-			"command": "php",
-			"args": [
-				"artisan",
-				"test",
-				"--parallel",
-				"--compact"
-			],
-			"group": "test",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
+			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
-			"detail": "php artisan test --parallel --compact"
-		},
-		{
-			"label": "phpunit:run:ci:Unit",
-			"type": "shell",
-			"command": "php",
-			"args": [
-				"artisan",
-				"test",
-				"--testsuite=Unit",
-				"--coverage",
-				"--parallel",
-				"--no-ansi",
-				"--stop-on-failure"
-			],
-			"group": "test",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "php artisan test --testsuite=Unit --coverage --parallel --no-ansi --stop-on-failure"
-		},
-		{
-			"label": "phpunit:run:ci:Api",
-			"type": "shell",
-			"command": "php",
-			"args": [
-				"artisan",
-				"test",
-				"--testsuite=Api",
-				"--coverage",
-				"--parallel",
-				"--no-ansi",
-				"--stop-on-failure"
-			],
-			"group": "test",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "php artisan test --testsuite=Api --coverage --parallel --no-ansi --stop-on-failure"
-		},
-		{
-			"label": "phpunit:run:ci:Web",
-			"type": "shell",
-			"command": "php",
-			"args": [
-				"artisan",
-				"test",
-				"--testsuite=Web",
-				"--coverage",
-				"--parallel",
-				"--no-ansi",
-				"--stop-on-failure"
-			],
-			"group": "test",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "php artisan test --testsuite=Web --coverage --parallel --no-ansi --stop-on-failure"
-		},
-		{
-			"label": "phpunit:run:ci:Configuration",
-			"type": "shell",
-			"command": "php",
-			"args": [
-				"artisan",
-				"test",
-				"--testsuite=Configuration",
-				"--coverage",
-				"--parallel",
-				"--no-ansi",
-				"--stop-on-failure"
-			],
-			"group": "test",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "php artisan test --testsuite=Configuration --coverage --parallel --no-ansi --stop-on-failure"
-		},
-		{
-			"label": "phpunit:run:ci:Console",
-			"type": "shell",
-			"command": "php",
-			"args": [
-				"artisan",
-				"test",
-				"--testsuite=Console",
-				"--coverage",
-				"--parallel",
-				"--no-ansi",
-				"--stop-on-failure"
-			],
-			"group": "test",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "php artisan test --testsuite=Console --coverage --parallel --no-ansi --stop-on-failure"
-		},
-		{
-			"label": "phpunit:run:ci:Event",
-			"type": "shell",
-			"command": "php",
-			"args": [
-				"artisan",
-				"test",
-				"--testsuite=Event",
-				"--coverage",
-				"--parallel",
-				"--no-ansi",
-				"--stop-on-failure"
-			],
-			"group": "test",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "php artisan test --testsuite=Event --coverage --parallel --no-ansi --stop-on-failure"
-		},
-		{
-			"label": "phpunit:run:ci:Integration",
-			"type": "shell",
-			"command": "php",
-			"args": [
-				"artisan",
-				"test",
-				"--testsuite=Integration",
-				"--coverage",
-				"--parallel",
-				"--no-ansi",
-				"--stop-on-failure"
-			],
-			"group": "test",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "php artisan test --testsuite=Integration --coverage --parallel --no-ansi --stop-on-failure"
-		},
-		{
-			"label": "phpunit:run:ci:matrix",
-			"dependsOn": [
-				"phpunit:run:ci:Unit",
-				"phpunit:run:ci:Api",
-				"phpunit:run:ci:Web",
-				"phpunit:run:ci:Configuration",
-				"phpunit:run:ci:Console",
-				"phpunit:run:ci:Event",
-				"phpunit:run:ci:Integration"
-			],
-			"dependsOrder": "sequence",
-			"group": "test",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "Run the backend CI suite matrix locally in CI order"
-		},
-		{
-			"label": "npm-test:run:spa",
-			"type": "npm",
-			"script": "test",
-			"path": "spa",
-			"group": "test",
-			"presentation": {
-				"reveal": "silent",
-				"panel": "shared"
-			},
-			"problemMatcher": [],
-			"detail": "npm test"
-		},
-		{
-			"label": "test",
-			"dependsOn": [
-				"build",
-				"phpunit:run",
-				"npm-test:run:spa"
-			],
-			"dependsOrder": "sequence",
-			"group": "test",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": []
-		},
-		{
-			"label": "dev",
-			"dependsOn": [
-				"composer-dev:run"
-			],
-			"dependsOrder": "sequence",
-			"group": "none",
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": []
-		},
-		{
-			"label": "act:continuous-integration",
-			"dependsOn": [
-				"build"
-			],
-			"dependsOrder": "sequence",
-			"type": "shell",
-			"command": "act",
-			"args": [
-				"pull_request",
-				"-W",
-				".github/workflows/ci-build-test.yml",
-				"--action-offline-mode",
-				"--env-file",
-				".env.ci"
-			],
-			"group": "build",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": []
-		},
-		{
-			"label": "act:continuous-integration:backend-lint",
-			"dependsOn": [
-				"build"
-			],
-			"dependsOrder": "sequence",
-			"type": "shell",
-			"command": "act",
-			"args": [
-				"pull_request",
-				"-W",
-				".github/workflows/ci-build-test.yml",
-				"--action-offline-mode",
-				"--env-file",
-				".env.ci",
-				"--job",
-				"backend-lint"
-			],
-			"group": "build",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": []
-		},
-		{
-			"label": "act:continuous-integration:backend-tests",
-			"dependsOn": [
-				"build"
-			],
-			"dependsOrder": "sequence",
-			"type": "shell",
-			"command": "act",
-			"args": [
-				"pull_request",
-				"-W",
-				".github/workflows/ci-build-test.yml",
-				"--action-offline-mode",
-				"--env-file",
-				".env.ci",
-				"--job",
-				"backend-tests"
-			],
-			"group": "build",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": []
-		},
-		{
-			"label": "act:continuous-integration:spa-test",
-			"dependsOn": [
-				"build"
-			],
-			"dependsOrder": "sequence",
-			"type": "shell",
-			"command": "act",
-			"args": [
-				"pull_request",
-				"-W",
-				".github/workflows/ci-build-test.yml",
-				"--action-offline-mode",
-				"--env-file",
-				".env.ci",
-				"--job",
-				"spa-frontend-validation"
-			],
-			"group": "build",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": []
-		},
-		{
-			"label": "act:build",
-			"dependsOn": [
-				"build"
-			],
-			"dependsOrder": "sequence",
-			"type": "shell",
-			"command": "act",
-			"args": [
-				"push",
-				"-W",
-				".github/workflows/build.yml",
-				"--action-offline-mode",
-				"--env-file",
-				".env.ci"
-			],
-			"group": "build",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": []
-		},
-		{
-			"label": "act:github-pages",
-			"type": "shell",
-			"command": "act",
-			"args": [
-				"push",
-				"-W",
-				".github/workflows/continuous-deployment_github-pages.yml",
-				"--action-offline-mode"
-			],
-			"group": "build",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"presentation": {
-				"reveal": "always",
-				"panel": "shared"
-			},
-			"problemMatcher": []
+			"detail": "composer audit + npm audit (., spa/, scripts/importer/)"
 		}
+
 	]
 }

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -31,6 +31,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
+RUN echo 'memory_limit = 512M' > /usr/local/etc/php/conf.d/zz-memory.ini
+
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
 WORKDIR /app

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -10,6 +10,7 @@ FROM php:8.4-cli-bookworm
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libicu-dev \
         libzip-dev \
+        libsqlite3-dev \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libpng-dev \

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,0 +1,44 @@
+# Test runner image — PHP 8.4 with all CI-matching extensions
+# Mirrors the extension set installed by shivammathur/setup-php@v2 in ci-build-test.yml
+# (fileinfo, zip, sqlite3, pdo_sqlite, gd, exif, intl, bcmath, pcntl, sodium)
+#
+# Build once:  docker build -f Dockerfile.testing -t inventory-app-test .
+# Run tests:   docker run --rm -v ${PWD}:/app inventory-app-test php artisan test --testsuite=Api --no-coverage --no-ansi
+
+FROM php:8.4-cli-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libicu-dev \
+        libzip-dev \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libexif-dev \
+        unzip \
+        git \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j"$(nproc)" \
+        intl \
+        zip \
+        pdo_sqlite \
+        gd \
+        exif \
+        bcmath \
+        pcntl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+WORKDIR /app
+
+# Install PHP dependencies at image build time so the vendor layer is cached.
+# The source is COPYed here only for the install step; at runtime the repo is
+# mounted as a volume which overlays this layer, giving you an up-to-date
+# vendor without needing to re-run composer on every docker run.
+COPY composer.json composer.lock ./
+RUN composer install --no-interaction --prefer-dist --no-scripts --no-ansi
+
+CMD ["php", "artisan", "test", "--no-coverage", "--no-ansi"]

--- a/app/Filament/Resources/PartnerResource/RelationManagers/TranslationsRelationManager.php
+++ b/app/Filament/Resources/PartnerResource/RelationManagers/TranslationsRelationManager.php
@@ -145,7 +145,7 @@ class TranslationsRelationManager extends RelationManager
                             ->simple(
                                 TextInput::make('value')
                                     ->label('Phone')
-                                    ->tel()
+                                    ->maxLength(255)
                             )
                             ->columnSpanFull(),
                     ])

--- a/app/Filament/Resources/PartnerTranslationResource.php
+++ b/app/Filament/Resources/PartnerTranslationResource.php
@@ -171,7 +171,7 @@ class PartnerTranslationResource extends Resource
                             ->simple(
                                 TextInput::make('value')
                                     ->label('Phone')
-                                    ->tel()
+                                    ->maxLength(255)
                             )
                             ->columnSpanFull(),
                     ])

--- a/app/Http/Resources/ItemTranslationResource.php
+++ b/app/Http/Resources/ItemTranslationResource.php
@@ -77,7 +77,7 @@ class ItemTranslationResource extends JsonResource
             'updated_at' => $this->updated_at,
 
             // The item relationship (ItemResource)
-            'item' => new ItemResource($this->whenLoaded('item')),
+            'item' => new ItemResource($this->whenLoaded('item', fn ($item) => $item->withoutRelations())),
             // The language relationship (LanguageResource)
             'language' => new LanguageResource($this->whenLoaded('language')),
             // The context relationship (ContextResource)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "inventory-app",
-    "version": "6.13.2",
+    "version": "6.14.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "inventory-app",
-            "version": "6.13.2",
+            "version": "6.14.1",
             "dependencies": {
                 "glob": "^13.0.6"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "inventory-app",
-    "version": "6.14.0",
+    "version": "6.14.1",
     "private": true,
     "type": "module",
     "scripts": {

--- a/tests/Api/Resources/ItemTest.php
+++ b/tests/Api/Resources/ItemTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Api\Resources;
 
 use App\Models\Item;
+use App\Models\ItemTranslation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Api\Traits\AuthenticatesApiRequests;
 use Tests\Api\Traits\TestsApiCrud;
@@ -24,5 +25,17 @@ class ItemTest extends TestCase
     protected function getModelClass(): string
     {
         return Item::class;
+    }
+
+    public function test_show_with_include_translations_returns_200_without_infinite_recursion(): void
+    {
+        $item = Item::factory()->create();
+        ItemTranslation::factory()->create(['item_id' => $item->id]);
+
+        $response = $this->getJson(route('item.show', $item).'?include=translations');
+
+        $response->assertOk()
+            ->assertJsonPath('data.id', $item->id)
+            ->assertJsonStructure(['data' => ['translations']]);
     }
 }


### PR DESCRIPTION
* fix: prevent infinite recursion when including translations on item (#bugfix)

GET /api/item/{uuid}?include=translations caused a PHP thread stack overflow. Eloquent's chaperone() on the translations() relation automatically sets the item back-reference on every loaded ItemTranslation. ItemTranslationResource then wrapped that item in a new ItemResource, which saw 	ranslations loaded and serialized them again — infinite recursion at C level, no PHP error logged, TCP connection reset, proxy returned 502.

Fix: strip relations from the chaperone-injected item before wrapping it in ItemResource, breaking the cycle at depth 2.

Regression test added: test_show_with_include_translations_returns_200_without_infinite_recursion