### PR TITLE
Enhance websites import gap analysis

### DIFF
--- a/scripts/importer/gap_analysis/BAROQUE_ART_IMPORT_VALIDATION_REPORT.md
+++ b/scripts/importer/gap_analysis/BAROQUE_ART_IMPORT_VALIDATION_REPORT.md
@@ -18,17 +18,17 @@ Relevant internal references:
 
 The Baroque Art import is credible for the main text of sampled objects, monuments, project context, and exhibition titles. The imported records keep consistent legacy identities such as `mwnf3:objects:BAR:pt:Mus11_A:13` and `mwnf3:monuments:BAR:pt:Mon11:23`.
 
-The most important gaps are supporting website experience data: image sets are incomplete, item-to-timeline links are missing in the sample, partner detail is thinner than the live page, and monument special-feature content is not clearly represented.
+The most important gaps are supporting website experience data: item-to-timeline links are missing in the sample, partner detail is thinner than the live page, and monument special-feature content is not clearly represented. The sampled multi-image object and monument pages are not image-import gaps: their extra images exist as child `picture` items.
 
 ## Samples Checked
 
 | Website area | Sampled website page | Website facts checked | Inventory result |
 |---|---|---|---|
 | Homepage and highlight | `https://baroqueart.museumwnf.org/` | Website title; navigation to Permanent Collection, Database, Exhibitions, Timeline; highlighted object `object;BAR;pt;Mus11_A;13;en` | BAR project context exists as `mwnf3:projects:BAR`. Highlighted object exists. |
-| Object detail | `database_item.php?id=object;BAR;pt;Mus11_A;13;en` | `Portrait of the Marquis of Pombal`; Oeiras, Lisbon, Portugal; holder Oeiras Town Hall; date 1766; oil on canvas; 6 visible object images; timeline link; portrait category | Item `mwnf3:objects:BAR:pt:Mus11_A:13` exists. Type, country, partner, English title, date, location, holder, and description match. Only 1 imported image was found for the sampled object. |
+| Object detail | `database_item.php?id=object;BAR;pt;Mus11_A;13;en` | `Portrait of the Marquis of Pombal`; Oeiras, Lisbon, Portugal; holder Oeiras Town Hall; date 1766; oil on canvas; 6 visible object images; timeline link; portrait category | Item `mwnf3:objects:BAR:pt:Mus11_A:13` exists. Type, country, partner, English title, date, location, holder, and description match. The parent has 1 image and 6 child `picture` items (`mwnf3:objects_pictures:bar:pt:Mus11_A:13:1..6`). |
 | Partner list/detail | `pm_partner_list.php?type=museum&`; `pm_partner.php?id=Mus11_A;pt&type=museum&theme=BAR` | Country-grouped partner list; Portugal includes associated museums; detail page displays `Further Associated Museums`, Portugal, image, logo, and a visible list of Portuguese institutions | Partner `mwnf3:museums:Mus11_A:pt` exists with name and country. The sampled detail is flatter than the website: city and website are null, and one image is imported. |
 | Permanent collection | `pclist_all.php?country=pt&lang=en` | Portugal has 50 objects and 35 monuments; includes monument `Church of St. Francis, Oporto` and object links | Sampled object and monument records exist. Project collection `mwnf3:projects:BAR` has 597 item links, matching the portal Baroque count sampled separately. |
-| Monument detail | `database_item.php?id=monument;BAR;pt;Mon11;23;en` | `Church of St. Francis, Oporto`; 13th-14th and 17th-18th century date text; Parish of St. Nicolau, Oporto, Portugal; 5 main images plus special features; timeline link | Item `mwnf3:monuments:BAR:pt:Mon11:23` exists. Title, date, location, country, and description match. Only 1 imported image was found, and no sampled timeline links were found. |
+| Monument detail | `database_item.php?id=monument;BAR;pt;Mon11;23;en` | `Church of St. Francis, Oporto`; 13th-14th and 17th-18th century date text; Parish of St. Nicolau, Oporto, Portugal; 5 main images plus special features; timeline link | Item `mwnf3:monuments:BAR:pt:Mon11:23` exists. Title, date, location, country, and description match. The parent has 1 image and 5 child `picture` items (`mwnf3:monuments_pictures:bar:pt:Mon11:23:1..5`). No sampled timeline links were found. |
 | Exhibition index | `exhibitions/BAR/index.php` | Exhibitions include `Absolutism`, `Devotion and Pilgrimage`, `The Age of Enlightenment`, and others | Imported collection titles match sampled BAR exhibition roots such as `mwnf3:exhibitions:43`, `44`, `45`, `46`, `47`, `50`, and `51`. |
 
 ## Legacy Source Mapping
@@ -47,30 +47,26 @@ Core text import is good for the sampled object and monument. The public identit
 
 The exhibition root import also looks strong in the sample. The public exhibition titles are present as Inventory collections.
 
-The import is weaker for the material that turns a database record into the full website page: multiple images, special-feature images, partner profile richness, and timeline relations.
+The import is weaker for the material that turns a database record into the full website page: partner profile richness, timeline relations, and the structured special-feature content shown on monument pages.
 
 ## Gaps To Address
 
-1. **Media completeness gap**
-
-   The sampled object has 6 visible website images but only 1 imported item image. The sampled monument has 5 main images plus special-feature images but only 1 imported item image. This is the most visible Baroque gap.
-
-2. **Timeline relationship gap**
+1. **Timeline relationship gap**
 
    The sampled object and monument pages expose `Timeline for this item`, but no `timeline_event_item` links were found for those records.
 
-3. **Partner detail gap**
+2. **Partner detail gap**
 
    The sampled associated-museum partner exists, but the imported row is sparse compared with the live page. City, website, richer associated-museum structure, and some image/logo presentation data need review.
 
-4. **Monument special-feature gap**
+3. **Monument special-feature gap**
 
-   The live monument page exposes structured special features with detail-level images and text. The sampled imported item/media rows did not show equivalent content.
+   The live monument page exposes structured special features with detail-level images and text. The main monument images are present as child `picture` items, but the sampled imported rows did not show the structured special-feature text/detail grouping.
 
-5. **Context duplication requires deliberate filtering**
+4. **Context duplication requires deliberate filtering**
 
    Sampled BAR item translations also appear under an EPM context. That may be legitimate reuse, but validation and future screens must filter by the intended context.
 
 ## Business Assessment
 
-The Baroque Art import is good enough for validating the main object, monument, and exhibition text. It is not yet good enough to reproduce the public website experience for image-rich pages, timeline navigation, and partner profiles.
+The Baroque Art import is good enough for validating the main object, monument, exhibition text, and sampled multi-image records through the parent plus child-picture model. It is not yet good enough to reproduce the public website experience for timeline navigation, partner profiles, and structured monument special features.

--- a/scripts/importer/gap_analysis/GALLERY_IMPORT_VALIDATION_REPORT.md
+++ b/scripts/importer/gap_analysis/GALLERY_IMPORT_VALIDATION_REPORT.md
@@ -18,7 +18,7 @@ Relevant internal references:
 
 The Amulets gallery import is strong for the core object and partner records sampled from the public site. Dates, holders, locations, object descriptions, partner descriptions, coordinates, and related object links are mostly preserved.
 
-The gallery-level import is weaker: the collection exists and membership is present, but the sampled gallery collection has no English title/description. Multi-image object coverage and image rights/caption preservation also need attention.
+The gallery-level import is weaker: the collection exists and membership is present, but the sampled gallery collection has no English title/description. Image rights/caption preservation also needs attention. The sampled two-image object is not an image-import gap because the second image exists as a child `picture` item.
 
 ## Samples Checked
 
@@ -28,7 +28,7 @@ The gallery-level import is weaker: the collection exists and membership is pres
 | Collection results | `/collection-results`; `/api/v2/items?hash=2e356d8` | 46 total objects across 3 pages; first samples include `ISL/jo/Mus01/4`, `EPM/gr/Mus21/25`, `ISL/tr/Mus01/18` | Sampled object items exist. They are linked to the gallery or related contexts. |
 | Search | `/search?q=kufic`; `/api/v2/items?hash=2e356d8&q=kufic` | 7 results including `Inscription stone`, `Bronze mirror with sphinxes and kufic inscription`, `Amulet`, and `Amulet case` | Sampled objects exist with matching names and fields. Search behavior itself is not directly validated by Inventory rows. |
 | Item detail | `/database-item/mwnf3/objects/ISL/jo/Mus01/4/en` | `Inscription stone`; date 700-750; holder Jordan Archaeological Museum; long and short descriptions; one image; 5 related objects; source URL to Islamic Art | Item `mwnf3:objects:ISL:jo:Mus01:4` exists. Core fields, image, and related object links match. It has multiple English translations across contexts. |
-| Item detail | `/database-item/mwnf3/objects/ISL/tr/Mus01/18/en` | `Talismanic shirt`; date 1375-1425; two live/legacy images; one related object; exhibition link to `Echoes of Paradise` | Item `mwnf3:objects:ISL:tr:Mus01:18` exists with matching core fields and related link. Only one imported image was found, while the website has two. |
+| Item detail | `/database-item/mwnf3/objects/ISL/tr/Mus01/18/en` | `Talismanic shirt`; date 1375-1425; two live/legacy images; one related object; exhibition link to `Echoes of Paradise` | Item `mwnf3:objects:ISL:tr:Mus01:18` exists with matching core fields and related link. The parent has 1 image and 2 child `picture` items (`mwnf3:objects_pictures:isl:tr:Mus01:18:1..2`). |
 | Partner profiles | `/partner/ISL/jo/Mus01/en`; `/partner/EPM/gr/Mus21/en` | Jordan Archaeological Museum and Benaki Museum include descriptions, contact/map data, logos, and three partner photos each | Partners `mwnf3:museums:Mus01:jo` and `mwnf3:museums:Mus21:gr` exist with names, cities, phone/website where available, map coordinates, descriptions, contact data, and three images. |
 | Timeline | `/timeline-results?c=jo&start=700&end=750` | Four Jordan events: HCR 673-676, years 728, 743-744, 747, and 749 | Events `mwnf3:hcr:673` through `mwnf3:hcr:676` exist with matching years, country, and English descriptions. |
 
@@ -55,22 +55,18 @@ The imported collection shell is present, but the public gallery name and descri
 
    Collection `mwnf3_thematic_gallery:thg_gallery:4` exists, but the English title `Amulets and Talismans` was not found as a collection translation.
 
-2. **Multi-image object coverage is incomplete**
-
-   The `Talismanic shirt` page has two live/legacy images, while Inventory has one image in the sampled query.
-
-3. **Context-scoped translations need clear display rules**
+2. **Context-scoped translations need clear display rules**
 
    Sampled items have multiple English translations from project and gallery contexts. This can be correct, but future screens must select the intended context.
 
-4. **Image credits and captions need broader review**
+3. **Image credits and captions need broader review**
 
    Some live/legacy image records include copyright or credit data. The sampled imported image fields did not clearly preserve all such values.
 
-5. **Source action links are not fully first-class**
+4. **Source action links are not fully first-class**
 
    The live gallery exposes source-site actions such as remote object, collection, book, and travel links. Inventory preserves some relationships and extra data, but these actions are not clearly structured as user-facing links.
 
 ## Business Assessment
 
-The Amulets import is good for object and partner validation, but gallery-level metadata and complete media coverage need work before the public gallery experience can be reproduced from Inventory alone.
+The Amulets import is good for object and partner validation, including sampled multi-image object records through the parent plus child-picture model. Gallery-level metadata, image credit/caption coverage, and source action links need work before the public gallery experience can be reproduced from Inventory alone.

--- a/scripts/importer/gap_analysis/IMPORT_GAP_ROOT_CAUSE_ANALYSIS.md
+++ b/scripts/importer/gap_analysis/IMPORT_GAP_ROOT_CAUSE_ANALYSIS.md
@@ -1,6 +1,6 @@
 # Import Gap Root-Cause Analysis
 
-Date: 2026-05-02
+Date: 2026-05-03
 
 ## Scope
 
@@ -9,44 +9,46 @@ This document correlates the import validation reports with:
 - the full import log at `scripts/importer/logs/import-2026-04-20T11-14-12-177Z.log`;
 - importer source under `scripts/importer/src`;
 - read-only production legacy database checks on the Windows server;
-- read-only imported Inventory checks on production Inventory databases.
+- read-only imported Inventory checks on production Inventory databases;
+- confirmed importer conventions for timelines, monument details, Explore references, Sharing History national context, and THG galleries/exhibitions.
 
-The purpose is to distinguish legacy data quality issues from importer logic bugs, and to capture fixable importer issues as implementation stories.
+The purpose is to distinguish importer logic bugs from legacy data gaps and to capture fixable importer issues as implementation stories.
 
 ## Executive Summary
 
-Several reported gaps are real importer issues, not legacy data problems:
+The reassessment keeps the provenance and Travels findings, but changes several conclusions:
 
 - `item_translations.provenance` is dropped by the SQL writer even when `object-transformer.ts` computes it.
-- Travels country/child coverage is broken by global `collections.internal_name` collisions, which cause parent locations to be missing and cascade into skipped monuments and image errors.
+- Baroque timelines must be materialized by the importer. No explicit BAR item-HCR pivot was found, so the importer needs to implement the legacy dynamic logic using `mwnf3.hcr` and `mwnf3.hcr_events` and bind the resulting timeline to the Baroque Art collection.
+- Monument details are valid `Item` records of type `detail`. Missing parent monuments must not block importing the detail; the importer must set `parent_id = NULL` and raise a warning.
 - Sharing History partner profile photos are not imported because only SH partner logos have an importer.
-- Explore public monument pages rely on cross-source fallback descriptions/images that the Explore importer does not import or resolve.
-- THG/Colours timeline and several exhibition-level media/contributor/link families are either missing importers or incomplete importers.
-
-Some gaps are legacy data issues or scope decisions:
-
-- THG gallery English translations for galleries 4 and 34 are absent from `mwnf3_thematic_gallery.exhibition_i18n`.
-- Sharing History national-context text for exhibition 3 is absent from `sh_national_context_exhibition_texts`.
-- Portal CMS content, Travels tours, and travel agencies are not currently retained as first-class Inventory model concepts.
+- Sharing History national-context import must ignore `sh_national_context_exhibition_texts`. The relevant legacy tables are `sh_national_context_exhibitions` and `sh_national_context_exhibition_images`.
+- Explore references must resolve to already-imported source items instead of creating duplicate Explore monument items. Explore-native monuments stay as native Explore items.
+- THG galleries and exhibitions share the same base collection model. `exhibition_i18n` is exhibition-only data; absence of `exhibition_i18n` means the row is a gallery, not missing gallery translation data.
+- THG theme item contextual descriptions are currently written as `item_translations`; that is the wrong target. Theme contextual text belongs to the theme collection or collection-item relationship, not to the item name or base item metadata.
+- THG collection partners, exhibition logos, collection images, and related documents fit the current model and need importer support. `CollectionMedia` also needs document support for related PDFs.
+- Travels country/child coverage is broken by global `collections.internal_name` collisions, which cascade into skipped monuments and media errors.
 
 ## Classification Matrix
 
-| Area | Reported issue | Current classification | Evidence summary | Story |
+| Area | Reported issue | Revised classification | Evidence summary | Story |
 |---|---|---|---|---|
 | Islamic Art / `mwnf3` objects | Provenance missing for `mwnf3:objects:ISL:eg:Mus01:1` | Importer logic bug | Legacy row contains `Egypt, probably Cairo.`; `object-transformer.ts` computes `provenanceMarkdown`; `sql-strategy.ts` omits `provenance` from the `INSERT INTO item_translations` columns. | Story 1 |
-| Baroque | Item timeline links absent for sampled BAR object/monument | Importer gap or presentation-scope gap | `writeTimelineEventItem()` exists, but importer usage is for Sharing History HCR images. No importer was found for BAR/mwnf3 item-to-timeline pivots. The legacy site needs a source-code check to determine whether item timelines are explicit pivots or dynamic country/date results. | Story 2 |
-| Baroque | Monument special features/detail grouping not represented | Mixed: importer has detail importer, but failures are missing-parent cascades for Czech; UI grouping remains model/design work | Log lines around 692-814 show many `BAR:cz:Mon11:*` monument detail failures due to parent monument not found. The sampled Portuguese parent has child picture items, but structured special-feature grouping is not represented as such. | Story 3 |
+| Baroque | Timeline links absent for sampled BAR object/monument | Importer logic gap | No explicit BAR item-HCR relation table was found. Core `mwnf3.hcr` and `mwnf3.hcr_events` contain chronology events by country/date. The importer must materialize the dynamic Baroque Art timeline and bind it to the parent collection. | Story 2 |
+| Baroque | Monument special features/detail grouping not represented | Importer logic bug | `MonumentDetailImporter` throws when parent monument is missing. Project convention requires detail items to import anyway with nullable `parent_id` and a warning. | Story 3 |
 | Sharing History | Partner profile/gallery images missing for AT_01/DZ_01 | Importer logic gap | Phase 03 has `sh-partner-logo-importer.ts`; no SH partner picture importer is exported or run. | Story 4 |
-| Sharing History | National-context child translations missing for exhibition 3 | Legacy data issue | Production legacy check found no `sh_national_context_exhibition_texts` rows for exhibition 3. Importer can only synthesize translations when `context` rows exist. | No importer story; document data gap |
-| Explore | Monuments 300/299 missing visible fallback descriptions/images | Importer logic gap | `ExploreMonumentImporter` reads only `exploremonument` fields and `exploremonumentext.name`; transformer stores only identity and coordinates. The live site uses fallback sources for VM/Travels/SH-backed content. | Story 5 |
-| Explore | Itinerary title/description/duration generic/missing | Importer gap / needs targeted verification | Existing itinerary importers do not import the full live itinerary presentation model. Relation pivots need inspection for extra data, and visible titles/duration/text need first-class collection translations or extra fields. | Story 6 |
-| Thematic Gallery | Galleries 4 and 34 missing English title/description | Legacy data issue, with optional fallback story | Production legacy check found no `exhibition_i18n` rows for galleries 4 and 34. The importer only imports `exhibition_i18n`. | Optional Story 7 |
-| Colours / THG | EXHCOLOUR base item translation has blank name/date/holder/location/dimensions | Importer logic gap | `thg-theme-item-translation-importer.ts` creates contextual item translations with `name: ''` and description only. Base EXHCOLOUR object metadata needs to come from the normal object import or contextual translation must not masquerade as the base object translation. | Story 8 |
-| Colours / THG | Gallery 47 timeline not imported | Importer gap | THG HCR/timeline data is not imported as timeline rows. Existing timeline importer focuses on mwnf3/SH chronology. | Story 9 |
-| THG / Portal | Collection partners, contributors, related PDFs/authors/logos/media incomplete | Mixed importer gaps and scope decisions | Contributor importer has undefined-language warnings; collection media importer skips theme media when theme collections are missing. No collection-partner importer was found. Portal CMS data is outside current Inventory scope. | Stories 10-12 |
-| Travels | Algeria/Syria missing child hierarchy; Portugal partial | Importer logic bug | Legacy rows exist and no status/filter columns exclude them. Log shows 351 location errors from duplicate internal names, then 946 monument skips due to missing parent locations. | Story 13 |
-| Travels | Media much lower than legacy | Importer logic bug, mostly cascading from missing parents | Travel picture importers exist. Log shows `Travels Location Pictures: 18 imported, 204 errors` and `Travels Monument Pictures: 231 imported, 2163 errors`, mostly parent not found. | Story 13 |
-| Travels | Tours and travel agencies absent | Intentionally out of current model unless scope changes | Legacy data exists, but these entities are not retained as first-class Inventory records. | No importer story unless scope changes |
+| Sharing History | National-context child collections missing content | Importer logic bug | The current importer uses `sh_national_context_exhibition_texts`, but that table has only 3 dummy rows and must be ignored. Collections come from `sh_national_context_exhibitions`; ordered item images come from `sh_national_context_exhibition_images`. | Story 5 |
+| Explore | Referenced monuments create shells instead of using source items | Importer logic bug | Explore has reference tables/columns for VM, Travels, and SH monuments. Referenced monuments must resolve to source items and use them in Explore collections. Explore-native monuments are already properly imported and must remain native. | Story 6 |
+| Explore | Itinerary title/description/duration generic/missing | Importer logic gap | Generic `Itinerary {id}` titles must not be used when source titles exist. Explore itineraries contain both Explore-native monuments and resolved source monuments. | Story 7 |
+| THG | Galleries 4/34 treated as missing `exhibition_i18n` translations | Analysis correction / importer scope clarification | `thg_gallery_lang` supplies gallery titles. `exhibition_i18n` exists only for exhibition collections. Galleries 4 and 34 are galleries; gallery 47 is an exhibition. | Story 8 |
+| Colours / THG | EXHCOLOUR contextual text masks item metadata | Importer logic bug | `ThgThemeItemTranslationImporter` writes `theme_item_i18n.contextual_description` as `item_translations` with `name: ''`. Contextual theme text belongs to the theme collection or collection-item association, not to the item. | Story 9 |
+| Colours / THG | Gallery 47 timeline not imported | Importer logic gap | THG timeline/HCR data is not imported as timeline rows. THG exhibition timelines must be materialized by the importer. | Story 10 |
+| THG | Contributor translation crashes | Importer logic bug | Log contains `translation (undefined) failed: Cannot read properties of undefined (reading 'toLowerCase')`. The importer must validate expected language values before lookup and raise explicit warnings/errors. | Story 11 |
+| THG | Theme media parent skips | Importer logic bug or orphan data | Collection media importer skips theme media when theme collections are missing. Valid media must import; orphan references must raise explicit warning/error. No fallback behavior is allowed. | Story 12 |
+| THG | Collection partners, logos, images, related PDFs incomplete | Importer logic gap | Legacy `exhibition_partner`, `exhibition_logo`, `exhibition_related_content`, and `exhibition_related_content_i18n` fit `CollectionPartner`, `CollectionImage`, and `CollectionMedia` after document support is added. Portal CMS remains out of scope. | Story 13 |
+| Travels | Algeria/Syria missing child hierarchy; Portugal partial | Importer logic bug | Legacy rows exist and no status/filter columns exclude them. Log shows 351 location errors from duplicate internal names, then 946 monument skips due to missing parent locations. | Story 14 |
+| Travels | Media much lower than legacy | Importer logic bug, mostly cascading from missing parents | Travel picture importers exist. Log shows `Travels Location Pictures: 18 imported, 204 errors` and `Travels Monument Pictures: 231 imported, 2163 errors`, mostly parent not found. | Story 14 |
+| Travels / Portal CMS | Tours, travel agencies, portal panels, menus, newsletter/legal/CMS pages | Out of scope | These are not currently retained as first-class Inventory model concepts. | No importer story unless scope changes |
 
 ## Detailed Findings
 
@@ -71,9 +73,9 @@ This explains why all mwnf3 object provenance can be lost even when the source r
 **Implementation notes:**
 
 - Update `writeItemTranslation()` in `scripts/importer/src/strategies/sql-strategy.ts` to include the `provenance` column and `safeNull(sanitized.provenance)` value.
-- Verify `ItemTranslationData` already includes `provenance`; the transformer path does.
-- Add or update a unit/integration test around a transformed object row with provenance.
-- Re-run the import path for objects or a focused import fixture.
+- Verify `ItemTranslationData` includes `provenance`; the transformer path does.
+- Add or update a self-contained importer test around a transformed object row with provenance.
+- Re-run the object import path or a focused import fixture.
 
 **Acceptance criteria:**
 
@@ -81,62 +83,69 @@ This explains why all mwnf3 object provenance can be lost even when the source r
 - The sampled key `mwnf3:objects:ISL:eg:Mus01:1` imports English provenance.
 - Existing item translation fields still map in the same order and no column/value mismatch is introduced.
 
-### 2. Baroque Item Timeline Links Are Not Imported For `mwnf3` Items
+### 2. Baroque Timeline Must Be Materialized By The Importer
 
 The BAR report found no sampled `timeline_event_item` links for `mwnf3:objects:BAR:pt:Mus11_A:13` and `mwnf3:monuments:BAR:pt:Mon11:23`.
 
-Importer evidence:
+Read-only legacy checks found:
 
-- `writeTimelineEventItem()` exists in `scripts/importer/src/strategies/sql-strategy.ts`.
-- `scripts/importer/src/importers/phase-05/timeline-importer.ts` uses it for Sharing History `sh_hcr_images` item-linked chronology rows.
-- No equivalent importer was found for `mwnf3` object/monument timeline links.
+- `mwnf3.hcr` has 1,075 chronology rows with `hcr_id`, `country_id`, `name`, `from_ad`, `to_ad`, `from_ah`, and `to_ah`.
+- `mwnf3.hcr_events` has 4,415 translated event rows with `hcr_id`, `lang_id`, `name`, `description`, `datedesc_ah`, and `datedesc_ad`.
+- No core `mwnf3` table was found that explicitly links BAR objects or monuments to HCR events.
+- The sampled BAR object and monument carry date ranges and country data, and Portugal HCR rows exist in the relevant date windows.
 
-This is an importer gap if the legacy BAR website stores explicit item-event relationships. It is a presentation-scope gap if the legacy page derives the item timeline dynamically from item country/date and a country HCR search.
+The dedicated Baroque Art website calculates this dynamically because its UI knows the legacy rules. Inventory must not rely on that future UI behavior. The importer must create a timeline bound to the Baroque Art parent collection and feed it with the events selected by the legacy dynamic logic.
 
-#### Story 2: Decide And Implement `mwnf3` Item Timeline Relations
+#### Story 2: Materialize Baroque Art Timeline From Legacy HCR
 
-**Goal:** Make item timeline behavior explicit for `mwnf3` object and monument pages.
-
-**Implementation notes:**
-
-- Inspect the BAR/Islamic legacy item timeline code and identify whether explicit relation tables exist or whether the site calculates timeline events by country/project/date range.
-- If explicit relation tables exist, add a focused importer that resolves:
-  - event BC, likely `mwnf3:hcr:{event_id}`;
-  - item BC, e.g. `mwnf3:objects:{project}:{country}:{museum}:{number}` or `mwnf3:monuments:{project}:{country}:{institution}:{number}`;
-  - `timeline_event_item` rows using `writeTimelineEventItem()`.
-- If the legacy site calculates timeline dynamically, document this as a future API/UI query requirement rather than an import defect.
-
-**Acceptance criteria:**
-
-- The implementation decision is documented with legacy code/table evidence.
-- If importer-based, sampled BAR object/monument records have expected `timeline_event_item` rows after import.
-- If query-based, no report labels this as missing imported data; public API/UI requirements describe the dynamic timeline behavior.
-
-### 3. Baroque Monument Details Fail When Parent Monuments Are Missing
-
-The BAR special-feature/detail issue is not simply a missing image problem. The import log shows many detail rows failing because parent monuments are missing, especially Czech BAR rows:
-
-- `Monument detail mwnf3:monument_details:BAR:cz:Mon11:23:1: Parent monument not found: mwnf3:monuments:BAR:cz:Mon11:23`
-- Similar errors cover `BAR:cz:Mon11:*` in the log around the Monument Details phase.
-
-The sampled Portuguese monument parent exists and has child picture items. What remains is structured detail/special-feature representation and missing-parent cascades for language/country variants.
-
-#### Story 3: Stabilize Monument Detail Parent Resolution And Representation
-
-**Goal:** Import valid monument details whenever their source parent exists, and define how special-feature groupings appear in Inventory.
+**Goal:** Create a Baroque Art collection-bound timeline and import the actual events used by the legacy Baroque Art website.
 
 **Implementation notes:**
 
-- Audit `MonumentImporter` and `MonumentDetailImporter` for case normalization and language handling in backward-compatibility keys.
-- Verify whether `mwnf3.monuments` contains parent Czech BAR rows. If not, classify those Czech errors as legacy orphaned details.
-- If parent rows exist but use different key casing or language grouping, normalize parent lookup to the canonical parent item key.
-- Decide whether monument details are child `Item` records, child `picture` records, or collection/pivot metadata in the current model.
+- Inspect the legacy Baroque Art timeline code and document the event-selection rules.
+- Implement those rules in an importer over `mwnf3.hcr` and `mwnf3.hcr_events`.
+- Create or reuse a `timelines` row bound to the Baroque Art collection.
+- Import `timeline_events` and `timeline_event_translations` for the selected HCR rows.
+- Materialize item-to-event associations in `timeline_event_item` when the legacy item-page behavior requires item-specific event links. Do not leave that responsibility to rendering layers.
 
 **Acceptance criteria:**
 
-- Detail rows with valid source parents import without `Parent monument not found` errors.
-- Orphaned detail rows are logged as data-quality skips with a concise reason.
-- The sampled `BAR:pt:Mon11:23` special-feature behavior is documented and test-covered according to the chosen representation.
+- The Baroque Art collection has a timeline after import.
+- The timeline contains the HCR events selected by the legacy Baroque Art dynamic rules.
+- Sampled events around the BAR Portugal object/monument date ranges are imported with translated text.
+- Any item-specific timeline pivots required by the legacy behavior are imported into `timeline_event_item`.
+- The importer logs the applied rule and counts of imported/skipped events.
+
+### 3. Monument Details Must Import Even When Parent Is Missing
+
+Project convention defines monument details as `Item` records of type `detail` with a parent `Item` of type `monument`. The parent foreign key is nullable. The first image of a detail becomes the detail item image; all detail images also become child `Item` records of type `picture` under the detail item.
+
+Current importer behavior does not follow this convention:
+
+- `MonumentDetailImporter` resolves the parent monument and throws when it is missing.
+- The log shows many BAR Czech detail failures such as `Parent monument not found: mwnf3:monuments:BAR:cz:Mon11:23`.
+- `MonumentDetailPictureImporter` creates child `picture` items and attaches the first image to the parent detail item, but this phase cannot run for details that fail earlier.
+
+Missing parent monuments must still be visible as import warnings/errors, but they must not prevent detail item import.
+
+#### Story 3: Import Orphan Monument Details With Nullable Parent
+
+**Goal:** Import valid monument detail records as `detail` items even when the parent monument is missing.
+
+**Implementation notes:**
+
+- Update `MonumentDetailImporter` to treat missing parent monument as a warning and set `parent_id = NULL`.
+- Keep hard failures for missing project context, collection, partner, or invalid required detail data.
+- Preserve all detail translations and artist/tag handling.
+- Ensure `MonumentDetailPictureImporter` still attaches the first image to the detail item and creates child `picture` items for all images.
+- Review SH monument detail importers for the same parent-hard-fail pattern and apply the same convention where applicable.
+
+**Acceptance criteria:**
+
+- BAR Czech detail rows import as `Item` records with `type = detail` and `parent_id = NULL` when the parent monument is missing.
+- The importer emits explicit warnings naming the missing parent BC key.
+- Details with present parent monuments import with `parent_id` set.
+- Detail images import after their detail item exists, including first-image attachment and child picture items.
 
 ### 4. Sharing History Partner Profile Photos Have No Importer
 
@@ -158,212 +167,293 @@ This is a logic gap: the source content is public and image-bearing, but only lo
 
 - Create a `ShPartnerPictureImporter` in `scripts/importer/src/importers/phase-03/`.
 - Follow the pattern of `scripts/importer/src/importers/phase-02/partner-picture-importer.ts` for normal MWNF partner pictures.
-- Query the SH partner picture table(s) used by the legacy partner pages.
+- Query the SH partner picture table or source used by the legacy partner pages.
 - Resolve partner BC keys such as `mwnf3_sharing_history:sh_partners:at_01` and `mwnf3_sharing_history:sh_partners:dz_01`.
 - Write `partner_images` with caption/copyright/alt text where available.
-- Export the importer and add it to the phase order after SH partner import and before image sync validation.
+- Export the importer and add it to the phase order after SH partner import and before validation.
 
 **Acceptance criteria:**
 
 - Sampled partners AT_01 and DZ_01 have imported `partner_images` matching the visible profile photos.
 - SH partner logos continue to import into the logo table.
-- Missing parent partner rows are skipped with explicit data-quality warnings.
+- Missing parent partner rows are reported with explicit warnings or errors.
 
-### 5. SH National Context Exhibition 3 Has No Source Text Rows
+### 5. SH National Context Must Ignore The Dummy Text Table
 
-The report noted missing title/description for national-context child collections under SH exhibition 3. Production legacy checks found link rows for countries, but no `sh_national_context_exhibition_texts` rows for exhibition 3, including English.
+The previous analysis was wrong: `sh_national_context_exhibition_texts` is not a valid source for national context import. Read-only legacy checks found only 3 dummy rows in that table.
 
-`ShNationalContextImporter` imports text only from rows where `context IS NOT NULL AND context != ''`. It synthesizes the title and maps `context` to the translation description. With no source text rows, there is nothing to import.
+Relevant tables:
 
-Classification: legacy data gap. No importer fix is recommended unless the business wants generated placeholder translations for empty national-context overlays.
+- `sh_national_context_exhibitions` defines the national-context exhibition/country pivot. For exhibition 3, countries are `fr`, `jo`, `pt`, `rm`, and `tn`.
+- `sh_national_context_exhibition_images` attaches ordered representative item references using `item_type`, `image_item`, and `sort_order`.
 
-### 6. Explore Monuments Missing Cross-Source Public Content
+Mapping rule:
 
-The Explore report found that monuments 300 and 299 exist as shells with names/coordinates but lack the public descriptions/images shown by the website.
+- `item_type = 'obj'` plus `image_item = 'AWE;tn;90'` maps to the imported SH object BC for project/country/number.
+- `item_type = 'mon'` maps to the imported SH monument BC for project/country/number.
+- `sort_order` maps to the `collection_item.display_order`.
 
-Importer evidence:
+Current `ShNationalContextImporter` imports collections, then reads the dummy text table, then links images/items. It must stop treating missing rows in `sh_national_context_exhibition_texts` as missing translation data.
 
-- `ExploreMonumentImporter` queries `mwnf3_explore.exploremonument` and `mwnf3_explore.exploremonumentext` name only.
-- `explore-monument-transformer.ts` writes item identity, coordinates, zoom, and type only.
-- It does not import descriptions, fallback source references, or images.
+#### Story 5: Rework SH National Context Import Around Exhibition And Image Tables
 
-The live Explore site resolves content from multiple sources when Explore-native fields are sparse: Virtual Museum, Exhibition Trails/Travels, Sharing History, and Explore-native tables. Because those fallback joins are not modeled in the importer, valid website content is lost.
-
-#### Story 5: Import Explore Monument Public Detail Content
-
-**Goal:** Preserve the public description and image content used by Explore monument pages.
+**Goal:** Import national-context collections and their ordered representative items from the two real source tables.
 
 **Implementation notes:**
 
-- Inspect the legacy Explore page/API resource that resolves monuments and document its fallback order.
-- Extend Explore monument import to either:
-  - import fallback description/image data directly into Explore item translations/images; or
-  - link the Explore monument item to the source item and expose fallback resolution in the future API/UI.
-- Cover at least these samples:
-  - `mwnf3_explore:monument:300` Aqmar Mosque, VM-backed content;
-  - `mwnf3_explore:monument:299` Amir Bashtak Palace, Travels/Exhibition Trails-backed content;
-  - `mwnf3_explore:monument:1780` Explore-native content, which already imports better.
+- Keep `importNCCollections()` based on `sh_national_context_exhibitions`.
+- Remove or disable `importNCTexts()` against `sh_national_context_exhibition_texts`.
+- Import `sh_national_context_exhibition_images` as ordered `collection_item` links.
+- Parse `image_item` into project/country/number and resolve item BC by `item_type`.
+- Do not synthesize fake descriptions from the dummy text table.
+- Add explicit warning/error behavior for invalid `image_item`, unknown `item_type`, missing item, and duplicate collection-item links.
 
 **Acceptance criteria:**
 
-- Monuments 300 and 299 have the public description available through the chosen model path.
-- Their visible images are available either as item images or resolvable source-linked images.
-- Explore-native monument 1780 continues to import successfully.
-- The fallback strategy is documented so validators know whether content is duplicated or linked.
+- Exhibition 3 national-context child collections are created for the five source countries.
+- The 13 source rows in `sh_national_context_exhibition_images` for exhibition 3 resolve to imported items when those items exist.
+- `sort_order` is preserved on `collection_item`.
+- The importer ignores `sh_national_context_exhibition_texts` and does not report absent rows from that table as content loss.
 
-### 7. Explore Itinerary Presentation Is Under-Modeled
+### 6. Explore References Must Reuse Source Items, Not Create Duplicates
 
-The Explore report found generic or wrong itinerary titles and missing duration/description for sampled itinerary 6 and sub-itinerary 7. The current import captures structural collections and item links, but not all website presentation fields.
+Explore monuments fall into two categories:
 
-#### Story 6: Complete Explore Itinerary Translation And Duration Import
+- Explore-native monuments, which are real Explore items and are already properly imported.
+- References to already-imported VM/mwnf3, Travels, or SH monument items, which must resolve to the source item and use that item in Explore collections.
 
-**Goal:** Import the visible itinerary and sub-itinerary content needed for public Explore pages.
+The importer currently creates Explore monument shell items for all rows and then creates item-item cross-reference links through `ExploreMonumentCrossRefImporter`. That preserves relationships, but it still leaves unwanted duplicate Explore items for referenced monuments.
+
+Read-only checks found that sampled IDs 299, 300, and 1780 are standalone Explore rows with no reference fields populated. ID 1780 has native description/image data; IDs 299 and 300 have sparse source text/image data. These sample facts do not change the rule: referenced Explore monuments must not become duplicate items, and Explore-native monuments must continue to import as native items.
+
+When a referenced Explore monument has text data in `mwnf3_explore.exploremonumentext`, the importer must add that text to the looked-up source item under the Explore master context.
+
+#### Story 6: Resolve Explore Monument References To Existing Items
+
+**Goal:** Prevent duplicate Explore item shells for monuments that reference already-imported source items, while preserving Explore-native monuments.
+
+**Implementation notes:**
+
+- Identify reference fields/tables in `mwnf3_explore.exploremonument`, `exploremonument_vm`, `exploremonument_tr`, and `exploremonument_sh` before creating an Explore item.
+- For referenced monuments, resolve the target item BC and use that target item in Explore location/thematic-cycle/itinerary collection links.
+- Do not create a duplicate `mwnf3_explore:monument:{id}` item for referenced monuments.
+- Store mapping metadata so later Explore import phases can resolve the Explore monument ID to the target item ID.
+- If `exploremonumentext` has text for a referenced monument, write an `item_translation` for the target item using the Explore context.
+- Keep Explore-native monument import unchanged for rows without source references.
+
+**Acceptance criteria:**
+
+- Referenced VM/Travels/SH Explore monuments link the existing source item into Explore collections.
+- Explore-native monuments such as the verified native sample 1780 continue to import as `mwnf3_explore:monument:{id}` items.
+- No duplicate item exists solely because Explore references an existing monument.
+- Explore-context text for referenced monuments is imported onto the looked-up source item.
+- Missing target references raise explicit warnings/errors; no fallback item is created.
+
+### 7. Explore Itinerary Presentation And Membership Are Under-Modeled
+
+The Explore report found generic or wrong itinerary titles and missing duration/description for sampled itinerary 6 and sub-itinerary 7. Generic `Itinerary {id}` titles must never be used when source titles exist.
+
+Explore itineraries also contain a mixed set of Explore-native monuments and monuments from other sources. The importer must resolve each member using the same rule as Story 6: native rows use native Explore items; referenced rows use already-imported source items.
+
+#### Story 7: Complete Explore Itinerary Translation And Member Resolution
+
+**Goal:** Import visible Explore itinerary content and include every itinerary monument through the correct item identity.
 
 **Implementation notes:**
 
 - Inspect the legacy itinerary tables and API response used by `/itineraries/c-eg/i-6` and `/itineraries/c-eg/i-6/si-7`.
-- Map public title, description, duration, route/local-team content, and ordering into `collection_translations`, `extra`, and/or related collections.
-- Avoid using generic `Itinerary {id}` titles when a legacy title exists.
+- Import public title, description, duration, route/local-team content, and ordering into `collection_translations`, `extra`, and collection hierarchy fields.
+- Replace generic title behavior with warning/error behavior when a required title is missing.
+- Resolve itinerary monument membership through the native/reference mapping from Story 6.
 
 **Acceptance criteria:**
 
-- `mwnf3_explore:itinerary:6` imports the public title `Mamluk Art. Splendour and Magic of the Sultans` or a documented canonical title from the source row.
-- `mwnf3_explore:itinerary:7` imports `The Seat of the Sultanate`, duration `One day`, and visible descriptive text.
-- Parent/child itinerary hierarchy and linked monuments remain intact.
+- `mwnf3_explore:itinerary:6` imports the real source title rather than `Itinerary 6`.
+- `mwnf3_explore:itinerary:7` imports `The Seat of the Sultanate`, duration `One day`, and visible descriptive text when those values exist in source.
+- Explore itinerary collections include both Explore-native monument items and resolved source monument items.
+- Missing required title/member data produces explicit warnings/errors.
 
-### 8. THG Gallery 4 And 34 English Translations Are Absent In Source
+### 8. THG Gallery And Exhibition Processing Must Share Common Ground And Add Exhibition Extras
 
-Production legacy checks found `exhibition_i18n` rows for gallery 47, but no English rows for galleries 4 or 34. The importer correctly imports from `mwnf3_thematic_gallery.exhibition_i18n`; it cannot create translations that do not exist there.
+The previous analysis incorrectly treated missing `exhibition_i18n` rows for galleries 4 and 34 as missing gallery translations.
 
-Classification: legacy translation gap. If the live gallery API has display names from another table, an optional fallback importer can be added, but that is a product decision because it changes the source-of-truth rule.
+Verified source model:
 
-#### Optional Story 7: Add THG Gallery Title Fallbacks For Sparse `exhibition_i18n`
+- `thg_gallery` contains both galleries and exhibitions.
+- `thg_gallery_lang` supplies base gallery titles and descriptive text.
+- `exhibition_i18n` exists only for exhibitions and supplies extra exhibition-specific data.
+- Absence of `exhibition_i18n` means the collection is a gallery.
+- Presence of `exhibition_i18n` means the collection is an exhibition with all gallery features plus additional exhibition features.
 
-**Goal:** Provide usable collection titles for high-value galleries when `exhibition_i18n` lacks rows.
+Current importer issues:
+
+- `ThgGalleryImporter` classifies exhibitions through `project_id = 'EXH'` rather than directly using the presence of `exhibition_i18n`.
+- `ThgGalleryTranslationImporter` imports only `exhibition_i18n`, so normal gallery translations from `thg_gallery_lang` are not represented as collection translations.
+- Gallery and exhibition common processing is split incorrectly.
+
+#### Story 8: Rework THG Gallery And Exhibition Collection Import
+
+**Goal:** Import all THG collections with shared gallery processing and exhibition-only enrichment.
 
 **Implementation notes:**
 
-- Identify the table/API source that supplies `Amulets and Talismans` and `Scientific objects` on the live sites.
-- If approved, update `ThgGalleryTranslationImporter` to create fallback translations from that source only when no `exhibition_i18n` translation exists.
-- Mark fallback translations in `extra` so editors know they are not full curated exhibition translations.
+- Import every `thg_gallery` row as a collection.
+- Determine `type = exhibition` from the presence of `exhibition_i18n` rows; otherwise use `type = gallery`.
+- Import common collection translations from `thg_gallery_lang` for both galleries and exhibitions.
+- Import exhibition-specific translations and extra fields from `exhibition_i18n` only for exhibitions.
+- Preserve gallery/exhibition URLs from `thg_gallery_url` where the model supports them.
+- Keep themes, theme translations, item associations, tags, and media behavior common to both galleries and exhibitions unless a table is explicitly exhibition-only.
 
 **Acceptance criteria:**
 
-- Galleries 4 and 34 have English collection titles after import.
-- Fallback translations are distinguishable from curated `exhibition_i18n` rows.
-- Gallery 47 continues to use its real `exhibition_i18n` translation.
+- Galleries 4 and 34 import titles from `thg_gallery_lang`, not from `exhibition_i18n`.
+- Gallery 47 imports common gallery data plus exhibition-specific data from `exhibition_i18n`.
+- Collection type reflects the presence or absence of exhibition-specific rows.
+- Validators no longer report galleries without `exhibition_i18n` as missing exhibition translations.
 
-### 9. EXHCOLOUR Contextual Item Translation Masks Base Metadata
+### 9. THG Theme Item Contextual Descriptions Are Imported To The Wrong Target
 
-The Colours report found `mwnf3:objects:EXHCOLOUR:us:Mus51:15` with `internal_name = Brush Washer`, but a sampled English `item_translation` row had blank `name` and missing object metadata. `ThgThemeItemTranslationImporter` intentionally writes contextual descriptions with `name: ''` because `theme_item_i18n` only supplies contextual text.
+The Colours report found `mwnf3:objects:EXHCOLOUR:us:Mus51:15` with `internal_name = Brush Washer`, but a sampled English contextual translation row had blank `name` and missing object metadata.
 
-This is not a legacy data issue. It is a modeling/query/import issue: contextual THG translations should complement, not replace or masquerade as, base object translations.
+The current importer explains the problem:
 
-#### Story 8: Preserve Base EXHCOLOUR Object Metadata Beside THG Contextual Text
+- `ThgThemeItemTranslationImporter` reads `theme_item_i18n.contextual_description`.
+- It writes that value as an `item_translations` row for the resolved item.
+- It writes `name: ''`, which is invalid importer behavior.
 
-**Goal:** Ensure EXHCOLOUR item detail pages can show base object metadata and THG contextual descriptions without field loss.
+This is a target-model bug, not a UI/API issue. Theme item contextual text is about the item in a theme collection. The theme itself is a child collection of the gallery/exhibition, and its translation is handled by `ThgThemeTranslationImporter`. The item should keep its base object translation. The contextual text must be stored where the importer models the item-in-theme relation, not as a replacement item translation.
+
+#### Story 9: Move THG Item Contextual Text Out Of Item Translations
+
+**Goal:** Preserve THG contextual descriptions without overwriting or masquerading as base item metadata.
 
 **Implementation notes:**
 
-- Verify whether the normal object importer creates a base translation for `mwnf3:objects:EXHCOLOUR:us:Mus51:15` in the project/default context.
-- If base translation is missing, fix object import coverage for `EXHCOLOUR` project rows.
-- If base translation exists but validation/UI selects the THG contextual row, update querying rules to prefer base metadata for object fields and contextual translation for gallery narrative.
-- Consider changing `ThgThemeItemTranslationImporter` to avoid writing empty-string `name`; use `NULL` if allowed, or preserve base name in contextual row.
+- Stop writing `theme_item_i18n.contextual_description` as `item_translations` with an empty name.
+- If contextual text describes the theme collection, merge it into the relevant `collection_translations` for the theme only when the legacy semantics confirm that target.
+- If contextual text describes the specific item-in-theme occurrence, store it on the `collection_item` pivot `extra` or a dedicated relation translation structure if one exists.
+- When the target field cannot accept the data without loss, raise a clear importer error and document the missing model support.
+- Never write empty string as an item translation `name`. Use `NULL` only if the schema allows it; otherwise raise a warning/error.
 
 **Acceptance criteria:**
 
-- The sampled `Brush Washer` item has a base English translation with name, date, holder, location, dimensions, and description where source data provides them.
-- THG contextual description remains available under gallery 47/theme 8 context.
-- UI/API selection rules are documented and tested for base-versus-contextual item translations.
+- No `item_translations` row is created with `name = ''` from `theme_item_i18n`.
+- Base item translations for EXHCOLOUR objects remain the source of object name/date/holder/location/dimensions.
+- Contextual descriptions remain imported in the correct collection/relation target.
+- If a model change is needed to retain contextual item-in-theme text, the importer fails loudly instead of storing it in the wrong table.
 
-### 10. Colours / THG Timeline Is Not Imported
+### 10. THG Exhibition Timelines Must Be Imported
 
-The live Colours timeline for gallery 47 has 45 events. The importer has generic timeline support and a Sharing History HCR image/link importer, but no importer for THG HCR/timeline rows was found.
+The live Colours timeline for gallery 47 has timeline events. The importer has generic timeline support and a Sharing History HCR image/link importer, but no importer for THG exhibition timeline rows was found.
 
-#### Story 9: Import THG Gallery Timelines
+Like the Baroque timeline, this must be importer work. Rendering layers must receive imported timeline data; they must not reimplement legacy timeline selection logic.
 
-**Goal:** Import thematic-gallery timeline events and translations for gallery-based public timelines.
+#### Story 10: Import THG Exhibition Timelines
+
+**Goal:** Import thematic-gallery exhibition timeline events and translations for gallery/exhibition timelines.
 
 **Implementation notes:**
 
-- Identify the THG legacy HCR/timeline tables used by the Colours timeline endpoint.
+- Identify the THG legacy timeline/HCR tables or query rules used by the Colours timeline endpoint.
 - Create a THG timeline importer that writes `timelines`, `timeline_events`, and `timeline_event_translations` with BC keys under `mwnf3_thematic_gallery:*`.
-- Link events to the gallery collection where appropriate.
-- Import event images if the legacy timeline exposes them.
+- Bind each imported timeline to the relevant THG collection.
+- Import event images or event-item relations if the legacy timeline exposes them.
 
 **Acceptance criteria:**
 
-- Gallery 47 has a timeline with the expected 45 events or a documented filtered count.
-- Sampled live events 39 and 42 are imported with date and English text.
-- Existing mwnf3 and SH timelines still import unchanged.
+- Gallery/exhibition 47 has an imported timeline with the expected legacy event set.
+- Sampled live timeline events import with date and English text.
+- Existing mwnf3 and SH timeline import behavior remains unchanged.
 
-### 11. THG Contributors And Media Importers Have Fixable Gaps
+### 11. THG Contributor Import Must Validate Required Language Values
 
-The log shows contributor translation warnings around the THG contributor phase:
+The log shows contributor translation warnings such as:
 
 - `Contributor 14: translation (undefined) failed: Cannot read properties of undefined (reading 'toLowerCase')`
 - Similar warnings for other contributors and exhibition partners.
 
-The log also shows collection-media skips for galleries 52 and 54 because theme collections are not found:
+This is a real importer bug. The code must verify expected values before calling `toLowerCase()` or language lookup helpers. Missing expected values must produce explicit warnings or errors consistently across all similar cases.
 
-- `Skipping theme audio: theme collection not found for BC=mwnf3_thematic_gallery:thg_theme:54:6`
-- Similar skips for gallery 52/54 theme media.
+#### Story 11: Harden THG Contributor And Partner Translation Validation
 
-#### Story 10: Harden THG Contributor Translation Import
-
-**Goal:** Import contributors and exhibition partners without crashing on undefined translation language values.
+**Goal:** Replace undefined language crashes with explicit validation and consistent warning/error reporting.
 
 **Implementation notes:**
 
-- Add guards before `.toLowerCase()` in `thg-contributor-importer.ts` translation handling.
-- Log contributor ID, source table, and missing language field when a translation is skipped.
-- Import the contributor shell even if optional translations are missing.
+- Review `thg-contributor-importer.ts` and helper calls used by contributor and exhibition-partner translations.
+- Add explicit checks for missing/empty language values before any `.toLowerCase()` or language lookup.
+- Search the import log for similar `undefined` and `toLowerCase` failures and handle those code paths consistently.
+- Do not invent fallback languages or placeholder translations.
+- Import the contributor shell only when required contributor data is valid; otherwise report a clear error.
 
 **Acceptance criteria:**
 
 - The THG contributor phase produces no `Cannot read properties of undefined` warnings.
-- Contributors with valid translations still import translated names/descriptions.
-- Contributors with missing translation language are either skipped with clear data-quality logs or imported with documented fallback text.
+- Missing translation language values are logged with source table, primary key, and reason.
+- Valid contributor and exhibition-partner translations still import.
+- No fallback language or degraded translation behavior is introduced.
 
-#### Story 11: Resolve THG Theme Media Parent Collections
+### 12. THG Theme Media Must Import Valid Rows And Report Orphans
 
-**Goal:** Attach THG theme audio/video records when the referenced theme collection exists, and clearly classify orphaned media when it does not.
+The log shows collection-media skips for galleries 52 and 54 because theme collections are not found:
 
-**Implementation notes:**
+- `Skipping theme audio: theme collection not found for BC=mwnf3_thematic_gallery:thg_theme:54:6`
+- Similar skips for gallery 52/54 theme media.
 
-- Query legacy theme rows for galleries 52 and 54 and compare them with collections imported by `thg-theme-importer.ts`.
-- If theme rows exist, fix theme collection import so BC keys like `mwnf3_thematic_gallery:thg_theme:54:6` resolve.
-- If media references orphan themes, log them as legacy data quality skips with source IDs.
+No fallback is allowed. When the source media references a valid theme, the theme collection import must be fixed. When the source media references an orphan theme, the importer must raise a warning or error that names the orphan source row.
 
-**Acceptance criteria:**
+#### Story 12: Resolve THG Theme Media Parent Collections
 
-- Collection media import for galleries 52/54 either imports all valid media or emits explicit orphan-media warnings.
-- No valid media is skipped because a theme collection failed to import due to importer logic.
-
-### 12. THG Collection Partners / Related PDFs / Logos / Portal CMS Need Scope Decisions
-
-No importer was found for `collection_partner` links for THG exhibitions. Related PDFs, author/article metadata, logos, and portal CMS features are also not consistently imported into Inventory.
-
-Classification: mixed feature gap and scope decision. These are public website concerns, and the team needs to mark each family as Inventory scope or external CMS scope.
-
-#### Story 12: Decide Scope For Exhibition-Level Partner And Related Content Imports
-
-**Goal:** Decide which exhibition-level presentation entities belong in Inventory, then implement the chosen importers.
+**Goal:** Import all valid THG audio/video media and explicitly report orphaned theme references.
 
 **Implementation notes:**
 
-- Inventory model already has collection relationships such as partners/contributors/media. Confirm which legacy THG tables should populate them.
-- List legacy sources for exhibition partners, related PDFs/articles/authors, footer logos, and portal curation cards.
-- For in-scope entities, implement importers with stable BC keys and tests.
-- For out-of-scope entities, record the decision so future portal/exhibition rebuilds do not treat absence as accidental data loss.
+- Query legacy theme rows for galleries 52 and 54 and compare them with collections imported by `ThgThemeImporter`.
+- Fix backward-compatibility naming mismatches between `ThgThemeImporter` and `CollectionMediaImporter` if present.
+- Import valid `exhibition_audio`/`theme_audio` and `exhibition_video`/`theme_video` rows into `collection_media`.
+- Report orphan media as warnings/errors with media ID, gallery ID, and theme ID.
 
 **Acceptance criteria:**
 
-- A scope matrix lists each legacy entity family as Inventory, external CMS, or intentionally retired.
-- In-scope collection partner/media/contributor records import for gallery 47.
-- Out-of-scope portal CMS records are removed from importer-gap tracking.
+- Valid theme media imports into `collection_media`.
+- Orphan media does not silently skip and does not attach to a fallback collection.
+- The importer logs exact source IDs for every missing parent collection.
 
-### 13. Travels Coverage And Media Failures Cascade From Non-Unique Collection Internal Names
+### 13. THG Collection Partners, Logos, Images, And Related Documents Are In Scope
+
+The previous analysis was too vague. Several THG exhibition presentation entities fit current model concepts and must be imported:
+
+- `exhibition_partner` fits `CollectionPartner` when it represents an organization associated with a collection.
+- `exhibition_logo` and gallery/exhibition image/banner fields fit `CollectionImage`.
+- `exhibition_audio` and `exhibition_video` fit `CollectionMedia`.
+- `exhibition_related_content` and `exhibition_related_content_i18n` fit `CollectionMedia` when they are URL-like related media.
+- Uploaded related PDFs need document support. `MediaType` and the `collection_media.type` enum currently only support `audio` and `video`; add `document` before importing PDF URLs/paths into `CollectionMedia`.
+
+Portal CMS content remains out of scope for the importer.
+
+#### Story 13: Import THG Collection Partners, Logos, Images, And Related Content
+
+**Goal:** Import THG exhibition-level partner, logo, image, audio/video, and related document data into existing Inventory models.
+
+**Implementation notes:**
+
+- Add `DOCUMENT` to `App\Enums\MediaType` and create a database-agnostic migration to allow `collection_media.type = 'document'`.
+- Extend importer `CollectionMediaData` and strategy typing to accept `document`.
+- Import `exhibition_logo` and gallery/exhibition image fields into `collection_images` with explicit source BC keys.
+- Import partner associations into `collection_partner` when the legacy row represents a partner organization. Contributor/person entries remain contributors.
+- Import URL-like related content rows as `CollectionMedia` records with appropriate type.
+- Import uploaded related PDFs as `document` media when they are collection-level resources.
+- Keep Portal CMS menus/panels/newsletter/legal/video/learning pages out of importer scope.
+
+**Acceptance criteria:**
+
+- Gallery/exhibition 47 imports its exhibition partner association as `CollectionPartner` where the source represents a partner organization.
+- Gallery/exhibition 47 imports logo/image assets as `CollectionImage`.
+- Audio/video URLs import as existing collection media types.
+- Related PDF URLs or uploaded document paths import as `document` collection media after enum and database support exist.
+- Portal CMS-only data remains excluded and documented as out of scope.
+
+### 14. Travels Coverage And Media Failures Cascade From Non-Unique Collection Internal Names
 
 The Travels report found missing Algeria/Syria child hierarchy, partial Portugal coverage, and much lower media counts. Read-only production checks confirmed the legacy data exists and is not filtered by status columns. The log reveals the root cause pattern.
 
@@ -386,15 +476,13 @@ The failure is that collection `internal_name` is globally unique, while Travels
 
 The current production Inventory contains at least one corrected namespaced itinerary internal name for `mwnf3_travels:itinerary:IAM:pt:1:I`, so the code or data has changed since the logged duplicate error. The log under analysis still documents the bug pattern that explains the missing pieces in the validation reports.
 
-#### Story 13: Namespace Travels Collection Internal Names And Re-import Child Hierarchy
+#### Story 14: Namespace Travels Collection Internal Names And Re-import Child Hierarchy
 
 **Goal:** Import all valid Travels trails, itineraries, locations, monuments, and media without global `internal_name` collisions.
 
 **Implementation notes:**
 
 - Update Travels collection importers to generate stable unique internal names from BC components, not only display titles.
-  - Example itinerary internal name: `itin_{project}_{country}_{trail}_{number}_{slug}`.
-  - Example location internal name: `loc_{project}_{country}_{trail}_{itinerary}_{number}_{slug}`.
 - Keep public titles in `collection_translations.title`; do not use title uniqueness as identity.
 - Apply the same principle to travel monument item internal names if needed.
 - Re-run Travels phases from itinerary onward after clearing or idempotently updating failed rows.
@@ -410,13 +498,13 @@ The current production Inventory contains at least one corrected namespaced itin
 
 ## Out-Of-Scope Or Retained-Model Decisions
 
-The gap reports mention some public website entities that are not currently retained as Inventory model concepts. These should not be treated as importer bugs unless the product scope changes.
+The gap reports mention some public website entities that are not currently retained as Inventory model concepts. These are not importer bugs unless the product scope changes.
 
 | Entity family | Current recommendation |
 |---|---|
 | Travels tours | Keep out of importer bug list unless Inventory is explicitly expanded to travel packages/tours. |
 | Travels travel agencies | Keep out of importer bug list unless partner scope expands to travel agencies. |
-| Portal panels, menus, newsletters, legal pages, videos, learning pages | Treat as portal CMS scope, not Inventory content, unless a portal-rebuild epic chooses to model them. |
+| Portal panels, menus, newsletters, legal pages, videos, learning pages | Treat as Portal CMS scope, not Inventory content. |
 | Display-time punctuation differences | Do not track as import bugs when the legacy column value is preserved. |
 | Parent item plus child picture model | Do not track as missing multi-image data when child `type = picture` items or item images exist according to the chosen Inventory model. |
 
@@ -424,7 +512,10 @@ The gap reports mention some public website entities that are not currently reta
 
 1. Fix `item_translations.provenance` persistence. This is small, high-confidence, and affects all imported object provenance.
 2. Fix Travels internal-name collisions and re-run Travels child phases. This explains the largest missing-data surface.
-3. Add SH partner picture importer. This is targeted and follows an existing normal partner-picture pattern.
-4. Decide BAR/mwnf3 timeline behavior: explicit import versus dynamic query.
-5. Implement Explore fallback detail strategy for VM/Travels/SH-backed monuments.
-6. Decide THG exhibition-level scope, then implement timeline/partner/media/contributor fixes in smaller stories.
+3. Rework SH national context to ignore the dummy text table and import ordered item images from the real source tables.
+4. Add SH partner picture importer.
+5. Materialize Baroque timelines from HCR dynamic logic and bind them to the Baroque Art collection.
+6. Fix monument detail orphan handling so details import with nullable parent and warnings.
+7. Rework Explore referenced monuments to reuse source items while preserving Explore-native monuments.
+8. Rework THG gallery/exhibition common processing and move contextual item text to the correct collection/relation target.
+9. Import THG timelines, partners, logos, collection images, and document media after adding `document` collection media support.

--- a/scripts/importer/gap_analysis/IMPORT_GAP_ROOT_CAUSE_ANALYSIS.md
+++ b/scripts/importer/gap_analysis/IMPORT_GAP_ROOT_CAUSE_ANALYSIS.md
@@ -1,0 +1,430 @@
+# Import Gap Root-Cause Analysis
+
+Date: 2026-05-02
+
+## Scope
+
+This document correlates the import validation reports with:
+
+- the full import log at `scripts/importer/logs/import-2026-04-20T11-14-12-177Z.log`;
+- importer source under `scripts/importer/src`;
+- read-only production legacy database checks on the Windows server;
+- read-only imported Inventory checks on production Inventory databases.
+
+The purpose is to distinguish legacy data quality issues from importer logic bugs, and to capture fixable importer issues as implementation stories.
+
+## Executive Summary
+
+Several reported gaps are real importer issues, not legacy data problems:
+
+- `item_translations.provenance` is dropped by the SQL writer even when `object-transformer.ts` computes it.
+- Travels country/child coverage is broken by global `collections.internal_name` collisions, which cause parent locations to be missing and cascade into skipped monuments and image errors.
+- Sharing History partner profile photos are not imported because only SH partner logos have an importer.
+- Explore public monument pages rely on cross-source fallback descriptions/images that the Explore importer does not import or resolve.
+- THG/Colours timeline and several exhibition-level media/contributor/link families are either missing importers or incomplete importers.
+
+Some gaps are legacy data issues or scope decisions:
+
+- THG gallery English translations for galleries 4 and 34 are absent from `mwnf3_thematic_gallery.exhibition_i18n`.
+- Sharing History national-context text for exhibition 3 is absent from `sh_national_context_exhibition_texts`.
+- Portal CMS content, Travels tours, and travel agencies are not currently retained as first-class Inventory model concepts.
+
+## Classification Matrix
+
+| Area | Reported issue | Current classification | Evidence summary | Story |
+|---|---|---|---|---|
+| Islamic Art / `mwnf3` objects | Provenance missing for `mwnf3:objects:ISL:eg:Mus01:1` | Importer logic bug | Legacy row contains `Egypt, probably Cairo.`; `object-transformer.ts` computes `provenanceMarkdown`; `sql-strategy.ts` omits `provenance` from the `INSERT INTO item_translations` columns. | Story 1 |
+| Baroque | Item timeline links absent for sampled BAR object/monument | Importer gap or presentation-scope gap | `writeTimelineEventItem()` exists, but importer usage is for Sharing History HCR images. No importer was found for BAR/mwnf3 item-to-timeline pivots. The legacy site needs a source-code check to determine whether item timelines are explicit pivots or dynamic country/date results. | Story 2 |
+| Baroque | Monument special features/detail grouping not represented | Mixed: importer has detail importer, but failures are missing-parent cascades for Czech; UI grouping remains model/design work | Log lines around 692-814 show many `BAR:cz:Mon11:*` monument detail failures due to parent monument not found. The sampled Portuguese parent has child picture items, but structured special-feature grouping is not represented as such. | Story 3 |
+| Sharing History | Partner profile/gallery images missing for AT_01/DZ_01 | Importer logic gap | Phase 03 has `sh-partner-logo-importer.ts`; no SH partner picture importer is exported or run. | Story 4 |
+| Sharing History | National-context child translations missing for exhibition 3 | Legacy data issue | Production legacy check found no `sh_national_context_exhibition_texts` rows for exhibition 3. Importer can only synthesize translations when `context` rows exist. | No importer story; document data gap |
+| Explore | Monuments 300/299 missing visible fallback descriptions/images | Importer logic gap | `ExploreMonumentImporter` reads only `exploremonument` fields and `exploremonumentext.name`; transformer stores only identity and coordinates. The live site uses fallback sources for VM/Travels/SH-backed content. | Story 5 |
+| Explore | Itinerary title/description/duration generic/missing | Importer gap / needs targeted verification | Existing itinerary importers do not import the full live itinerary presentation model. Relation pivots need inspection for extra data, and visible titles/duration/text need first-class collection translations or extra fields. | Story 6 |
+| Thematic Gallery | Galleries 4 and 34 missing English title/description | Legacy data issue, with optional fallback story | Production legacy check found no `exhibition_i18n` rows for galleries 4 and 34. The importer only imports `exhibition_i18n`. | Optional Story 7 |
+| Colours / THG | EXHCOLOUR base item translation has blank name/date/holder/location/dimensions | Importer logic gap | `thg-theme-item-translation-importer.ts` creates contextual item translations with `name: ''` and description only. Base EXHCOLOUR object metadata needs to come from the normal object import or contextual translation must not masquerade as the base object translation. | Story 8 |
+| Colours / THG | Gallery 47 timeline not imported | Importer gap | THG HCR/timeline data is not imported as timeline rows. Existing timeline importer focuses on mwnf3/SH chronology. | Story 9 |
+| THG / Portal | Collection partners, contributors, related PDFs/authors/logos/media incomplete | Mixed importer gaps and scope decisions | Contributor importer has undefined-language warnings; collection media importer skips theme media when theme collections are missing. No collection-partner importer was found. Portal CMS data is outside current Inventory scope. | Stories 10-12 |
+| Travels | Algeria/Syria missing child hierarchy; Portugal partial | Importer logic bug | Legacy rows exist and no status/filter columns exclude them. Log shows 351 location errors from duplicate internal names, then 946 monument skips due to missing parent locations. | Story 13 |
+| Travels | Media much lower than legacy | Importer logic bug, mostly cascading from missing parents | Travel picture importers exist. Log shows `Travels Location Pictures: 18 imported, 204 errors` and `Travels Monument Pictures: 231 imported, 2163 errors`, mostly parent not found. | Story 13 |
+| Travels | Tours and travel agencies absent | Intentionally out of current model unless scope changes | Legacy data exists, but these entities are not retained as first-class Inventory records. | No importer story unless scope changes |
+
+## Detailed Findings
+
+### 1. `mwnf3` Object Provenance Is Dropped By The SQL Writer
+
+Validation found provenance missing for `mwnf3:objects:ISL:eg:Mus01:1`. A read-only legacy check confirmed that the English source row contains `Egypt, probably Cairo.`. The imported Inventory translation has `provenance = NULL`.
+
+The transformer already maps provenance:
+
+- `scripts/importer/src/domain/transformers/object-transformer.ts` computes `const provenanceMarkdown = obj.provenance ? convertHtmlToMarkdown(obj.provenance) : null;` and assigns `provenance: provenanceMarkdown`.
+
+The SQL writer omits the destination column:
+
+- `scripts/importer/src/strategies/sql-strategy.ts` inserts `item_translations` columns through `method_for_provenance`, then `obtention`, but not `provenance`.
+
+This explains why all mwnf3 object provenance can be lost even when the source row is valid.
+
+#### Story 1: Persist Item Translation Provenance
+
+**Goal:** Preserve legacy object provenance in `item_translations.provenance`.
+
+**Implementation notes:**
+
+- Update `writeItemTranslation()` in `scripts/importer/src/strategies/sql-strategy.ts` to include the `provenance` column and `safeNull(sanitized.provenance)` value.
+- Verify `ItemTranslationData` already includes `provenance`; the transformer path does.
+- Add or update a unit/integration test around a transformed object row with provenance.
+- Re-run the import path for objects or a focused import fixture.
+
+**Acceptance criteria:**
+
+- Given a legacy object row with `provenance = 'Egypt, probably Cairo.'`, the imported `item_translations.provenance` contains the Markdown-converted value.
+- The sampled key `mwnf3:objects:ISL:eg:Mus01:1` imports English provenance.
+- Existing item translation fields still map in the same order and no column/value mismatch is introduced.
+
+### 2. Baroque Item Timeline Links Are Not Imported For `mwnf3` Items
+
+The BAR report found no sampled `timeline_event_item` links for `mwnf3:objects:BAR:pt:Mus11_A:13` and `mwnf3:monuments:BAR:pt:Mon11:23`.
+
+Importer evidence:
+
+- `writeTimelineEventItem()` exists in `scripts/importer/src/strategies/sql-strategy.ts`.
+- `scripts/importer/src/importers/phase-05/timeline-importer.ts` uses it for Sharing History `sh_hcr_images` item-linked chronology rows.
+- No equivalent importer was found for `mwnf3` object/monument timeline links.
+
+This is an importer gap if the legacy BAR website stores explicit item-event relationships. It is a presentation-scope gap if the legacy page derives the item timeline dynamically from item country/date and a country HCR search.
+
+#### Story 2: Decide And Implement `mwnf3` Item Timeline Relations
+
+**Goal:** Make item timeline behavior explicit for `mwnf3` object and monument pages.
+
+**Implementation notes:**
+
+- Inspect the BAR/Islamic legacy item timeline code and identify whether explicit relation tables exist or whether the site calculates timeline events by country/project/date range.
+- If explicit relation tables exist, add a focused importer that resolves:
+  - event BC, likely `mwnf3:hcr:{event_id}`;
+  - item BC, e.g. `mwnf3:objects:{project}:{country}:{museum}:{number}` or `mwnf3:monuments:{project}:{country}:{institution}:{number}`;
+  - `timeline_event_item` rows using `writeTimelineEventItem()`.
+- If the legacy site calculates timeline dynamically, document this as a future API/UI query requirement rather than an import defect.
+
+**Acceptance criteria:**
+
+- The implementation decision is documented with legacy code/table evidence.
+- If importer-based, sampled BAR object/monument records have expected `timeline_event_item` rows after import.
+- If query-based, no report labels this as missing imported data; public API/UI requirements describe the dynamic timeline behavior.
+
+### 3. Baroque Monument Details Fail When Parent Monuments Are Missing
+
+The BAR special-feature/detail issue is not simply a missing image problem. The import log shows many detail rows failing because parent monuments are missing, especially Czech BAR rows:
+
+- `Monument detail mwnf3:monument_details:BAR:cz:Mon11:23:1: Parent monument not found: mwnf3:monuments:BAR:cz:Mon11:23`
+- Similar errors cover `BAR:cz:Mon11:*` in the log around the Monument Details phase.
+
+The sampled Portuguese monument parent exists and has child picture items. What remains is structured detail/special-feature representation and missing-parent cascades for language/country variants.
+
+#### Story 3: Stabilize Monument Detail Parent Resolution And Representation
+
+**Goal:** Import valid monument details whenever their source parent exists, and define how special-feature groupings appear in Inventory.
+
+**Implementation notes:**
+
+- Audit `MonumentImporter` and `MonumentDetailImporter` for case normalization and language handling in backward-compatibility keys.
+- Verify whether `mwnf3.monuments` contains parent Czech BAR rows. If not, classify those Czech errors as legacy orphaned details.
+- If parent rows exist but use different key casing or language grouping, normalize parent lookup to the canonical parent item key.
+- Decide whether monument details are child `Item` records, child `picture` records, or collection/pivot metadata in the current model.
+
+**Acceptance criteria:**
+
+- Detail rows with valid source parents import without `Parent monument not found` errors.
+- Orphaned detail rows are logged as data-quality skips with a concise reason.
+- The sampled `BAR:pt:Mon11:23` special-feature behavior is documented and test-covered according to the chosen representation.
+
+### 4. Sharing History Partner Profile Photos Have No Importer
+
+The SH report found partner logos but no partner profile/gallery photos for sampled partners AT_01 and DZ_01.
+
+Importer evidence:
+
+- `scripts/importer/src/importers/phase-03/sh-partner-logo-importer.ts` imports SH partner logos.
+- `scripts/importer/src/importers/phase-03/index.ts` exports `ShPartnerLogoImporter` but no SH partner picture importer.
+- The CLI imports SH partner logos, but no SH partner pictures step was found.
+
+This is a logic gap: the source content is public and image-bearing, but only logos are imported.
+
+#### Story 4: Add Sharing History Partner Picture Importer
+
+**Goal:** Import SH partner profile/gallery photos into `partner_images`.
+
+**Implementation notes:**
+
+- Create a `ShPartnerPictureImporter` in `scripts/importer/src/importers/phase-03/`.
+- Follow the pattern of `scripts/importer/src/importers/phase-02/partner-picture-importer.ts` for normal MWNF partner pictures.
+- Query the SH partner picture table(s) used by the legacy partner pages.
+- Resolve partner BC keys such as `mwnf3_sharing_history:sh_partners:at_01` and `mwnf3_sharing_history:sh_partners:dz_01`.
+- Write `partner_images` with caption/copyright/alt text where available.
+- Export the importer and add it to the phase order after SH partner import and before image sync validation.
+
+**Acceptance criteria:**
+
+- Sampled partners AT_01 and DZ_01 have imported `partner_images` matching the visible profile photos.
+- SH partner logos continue to import into the logo table.
+- Missing parent partner rows are skipped with explicit data-quality warnings.
+
+### 5. SH National Context Exhibition 3 Has No Source Text Rows
+
+The report noted missing title/description for national-context child collections under SH exhibition 3. Production legacy checks found link rows for countries, but no `sh_national_context_exhibition_texts` rows for exhibition 3, including English.
+
+`ShNationalContextImporter` imports text only from rows where `context IS NOT NULL AND context != ''`. It synthesizes the title and maps `context` to the translation description. With no source text rows, there is nothing to import.
+
+Classification: legacy data gap. No importer fix is recommended unless the business wants generated placeholder translations for empty national-context overlays.
+
+### 6. Explore Monuments Missing Cross-Source Public Content
+
+The Explore report found that monuments 300 and 299 exist as shells with names/coordinates but lack the public descriptions/images shown by the website.
+
+Importer evidence:
+
+- `ExploreMonumentImporter` queries `mwnf3_explore.exploremonument` and `mwnf3_explore.exploremonumentext` name only.
+- `explore-monument-transformer.ts` writes item identity, coordinates, zoom, and type only.
+- It does not import descriptions, fallback source references, or images.
+
+The live Explore site resolves content from multiple sources when Explore-native fields are sparse: Virtual Museum, Exhibition Trails/Travels, Sharing History, and Explore-native tables. Because those fallback joins are not modeled in the importer, valid website content is lost.
+
+#### Story 5: Import Explore Monument Public Detail Content
+
+**Goal:** Preserve the public description and image content used by Explore monument pages.
+
+**Implementation notes:**
+
+- Inspect the legacy Explore page/API resource that resolves monuments and document its fallback order.
+- Extend Explore monument import to either:
+  - import fallback description/image data directly into Explore item translations/images; or
+  - link the Explore monument item to the source item and expose fallback resolution in the future API/UI.
+- Cover at least these samples:
+  - `mwnf3_explore:monument:300` Aqmar Mosque, VM-backed content;
+  - `mwnf3_explore:monument:299` Amir Bashtak Palace, Travels/Exhibition Trails-backed content;
+  - `mwnf3_explore:monument:1780` Explore-native content, which already imports better.
+
+**Acceptance criteria:**
+
+- Monuments 300 and 299 have the public description available through the chosen model path.
+- Their visible images are available either as item images or resolvable source-linked images.
+- Explore-native monument 1780 continues to import successfully.
+- The fallback strategy is documented so validators know whether content is duplicated or linked.
+
+### 7. Explore Itinerary Presentation Is Under-Modeled
+
+The Explore report found generic or wrong itinerary titles and missing duration/description for sampled itinerary 6 and sub-itinerary 7. The current import captures structural collections and item links, but not all website presentation fields.
+
+#### Story 6: Complete Explore Itinerary Translation And Duration Import
+
+**Goal:** Import the visible itinerary and sub-itinerary content needed for public Explore pages.
+
+**Implementation notes:**
+
+- Inspect the legacy itinerary tables and API response used by `/itineraries/c-eg/i-6` and `/itineraries/c-eg/i-6/si-7`.
+- Map public title, description, duration, route/local-team content, and ordering into `collection_translations`, `extra`, and/or related collections.
+- Avoid using generic `Itinerary {id}` titles when a legacy title exists.
+
+**Acceptance criteria:**
+
+- `mwnf3_explore:itinerary:6` imports the public title `Mamluk Art. Splendour and Magic of the Sultans` or a documented canonical title from the source row.
+- `mwnf3_explore:itinerary:7` imports `The Seat of the Sultanate`, duration `One day`, and visible descriptive text.
+- Parent/child itinerary hierarchy and linked monuments remain intact.
+
+### 8. THG Gallery 4 And 34 English Translations Are Absent In Source
+
+Production legacy checks found `exhibition_i18n` rows for gallery 47, but no English rows for galleries 4 or 34. The importer correctly imports from `mwnf3_thematic_gallery.exhibition_i18n`; it cannot create translations that do not exist there.
+
+Classification: legacy translation gap. If the live gallery API has display names from another table, an optional fallback importer can be added, but that is a product decision because it changes the source-of-truth rule.
+
+#### Optional Story 7: Add THG Gallery Title Fallbacks For Sparse `exhibition_i18n`
+
+**Goal:** Provide usable collection titles for high-value galleries when `exhibition_i18n` lacks rows.
+
+**Implementation notes:**
+
+- Identify the table/API source that supplies `Amulets and Talismans` and `Scientific objects` on the live sites.
+- If approved, update `ThgGalleryTranslationImporter` to create fallback translations from that source only when no `exhibition_i18n` translation exists.
+- Mark fallback translations in `extra` so editors know they are not full curated exhibition translations.
+
+**Acceptance criteria:**
+
+- Galleries 4 and 34 have English collection titles after import.
+- Fallback translations are distinguishable from curated `exhibition_i18n` rows.
+- Gallery 47 continues to use its real `exhibition_i18n` translation.
+
+### 9. EXHCOLOUR Contextual Item Translation Masks Base Metadata
+
+The Colours report found `mwnf3:objects:EXHCOLOUR:us:Mus51:15` with `internal_name = Brush Washer`, but a sampled English `item_translation` row had blank `name` and missing object metadata. `ThgThemeItemTranslationImporter` intentionally writes contextual descriptions with `name: ''` because `theme_item_i18n` only supplies contextual text.
+
+This is not a legacy data issue. It is a modeling/query/import issue: contextual THG translations should complement, not replace or masquerade as, base object translations.
+
+#### Story 8: Preserve Base EXHCOLOUR Object Metadata Beside THG Contextual Text
+
+**Goal:** Ensure EXHCOLOUR item detail pages can show base object metadata and THG contextual descriptions without field loss.
+
+**Implementation notes:**
+
+- Verify whether the normal object importer creates a base translation for `mwnf3:objects:EXHCOLOUR:us:Mus51:15` in the project/default context.
+- If base translation is missing, fix object import coverage for `EXHCOLOUR` project rows.
+- If base translation exists but validation/UI selects the THG contextual row, update querying rules to prefer base metadata for object fields and contextual translation for gallery narrative.
+- Consider changing `ThgThemeItemTranslationImporter` to avoid writing empty-string `name`; use `NULL` if allowed, or preserve base name in contextual row.
+
+**Acceptance criteria:**
+
+- The sampled `Brush Washer` item has a base English translation with name, date, holder, location, dimensions, and description where source data provides them.
+- THG contextual description remains available under gallery 47/theme 8 context.
+- UI/API selection rules are documented and tested for base-versus-contextual item translations.
+
+### 10. Colours / THG Timeline Is Not Imported
+
+The live Colours timeline for gallery 47 has 45 events. The importer has generic timeline support and a Sharing History HCR image/link importer, but no importer for THG HCR/timeline rows was found.
+
+#### Story 9: Import THG Gallery Timelines
+
+**Goal:** Import thematic-gallery timeline events and translations for gallery-based public timelines.
+
+**Implementation notes:**
+
+- Identify the THG legacy HCR/timeline tables used by the Colours timeline endpoint.
+- Create a THG timeline importer that writes `timelines`, `timeline_events`, and `timeline_event_translations` with BC keys under `mwnf3_thematic_gallery:*`.
+- Link events to the gallery collection where appropriate.
+- Import event images if the legacy timeline exposes them.
+
+**Acceptance criteria:**
+
+- Gallery 47 has a timeline with the expected 45 events or a documented filtered count.
+- Sampled live events 39 and 42 are imported with date and English text.
+- Existing mwnf3 and SH timelines still import unchanged.
+
+### 11. THG Contributors And Media Importers Have Fixable Gaps
+
+The log shows contributor translation warnings around the THG contributor phase:
+
+- `Contributor 14: translation (undefined) failed: Cannot read properties of undefined (reading 'toLowerCase')`
+- Similar warnings for other contributors and exhibition partners.
+
+The log also shows collection-media skips for galleries 52 and 54 because theme collections are not found:
+
+- `Skipping theme audio: theme collection not found for BC=mwnf3_thematic_gallery:thg_theme:54:6`
+- Similar skips for gallery 52/54 theme media.
+
+#### Story 10: Harden THG Contributor Translation Import
+
+**Goal:** Import contributors and exhibition partners without crashing on undefined translation language values.
+
+**Implementation notes:**
+
+- Add guards before `.toLowerCase()` in `thg-contributor-importer.ts` translation handling.
+- Log contributor ID, source table, and missing language field when a translation is skipped.
+- Import the contributor shell even if optional translations are missing.
+
+**Acceptance criteria:**
+
+- The THG contributor phase produces no `Cannot read properties of undefined` warnings.
+- Contributors with valid translations still import translated names/descriptions.
+- Contributors with missing translation language are either skipped with clear data-quality logs or imported with documented fallback text.
+
+#### Story 11: Resolve THG Theme Media Parent Collections
+
+**Goal:** Attach THG theme audio/video records when the referenced theme collection exists, and clearly classify orphaned media when it does not.
+
+**Implementation notes:**
+
+- Query legacy theme rows for galleries 52 and 54 and compare them with collections imported by `thg-theme-importer.ts`.
+- If theme rows exist, fix theme collection import so BC keys like `mwnf3_thematic_gallery:thg_theme:54:6` resolve.
+- If media references orphan themes, log them as legacy data quality skips with source IDs.
+
+**Acceptance criteria:**
+
+- Collection media import for galleries 52/54 either imports all valid media or emits explicit orphan-media warnings.
+- No valid media is skipped because a theme collection failed to import due to importer logic.
+
+### 12. THG Collection Partners / Related PDFs / Logos / Portal CMS Need Scope Decisions
+
+No importer was found for `collection_partner` links for THG exhibitions. Related PDFs, author/article metadata, logos, and portal CMS features are also not consistently imported into Inventory.
+
+Classification: mixed feature gap and scope decision. These are public website concerns, and the team needs to mark each family as Inventory scope or external CMS scope.
+
+#### Story 12: Decide Scope For Exhibition-Level Partner And Related Content Imports
+
+**Goal:** Decide which exhibition-level presentation entities belong in Inventory, then implement the chosen importers.
+
+**Implementation notes:**
+
+- Inventory model already has collection relationships such as partners/contributors/media. Confirm which legacy THG tables should populate them.
+- List legacy sources for exhibition partners, related PDFs/articles/authors, footer logos, and portal curation cards.
+- For in-scope entities, implement importers with stable BC keys and tests.
+- For out-of-scope entities, record the decision so future portal/exhibition rebuilds do not treat absence as accidental data loss.
+
+**Acceptance criteria:**
+
+- A scope matrix lists each legacy entity family as Inventory, external CMS, or intentionally retired.
+- In-scope collection partner/media/contributor records import for gallery 47.
+- Out-of-scope portal CMS records are removed from importer-gap tracking.
+
+### 13. Travels Coverage And Media Failures Cascade From Non-Unique Collection Internal Names
+
+The Travels report found missing Algeria/Syria child hierarchy, partial Portugal coverage, and much lower media counts. Read-only production checks confirmed the legacy data exists and is not filtered by status columns. The log reveals the root cause pattern.
+
+Key log evidence:
+
+- `Travels Itineraries: 108 imported, 1 errors`, with duplicate `Mudejar Art` for `IAM:pt:1:I`.
+- `Travels Locations: 54 imported, 5 skipped, 351 errors`, with many duplicate `collections_internal_name_unique` errors such as `SINTRA`, `SANTAREM`, `COIMBRA`, etc.
+- `Travels Monuments: 103 imported, 946 skipped`, mostly `Parent location not found`.
+- `Travels Location Pictures: 18 imported, 204 errors`, mostly `Parent location collection not found`.
+- `Travels Monument Pictures: 231 imported, 99 skipped, 2163 errors`, mostly `Parent monument item not found`.
+
+The importer reads the full source tables:
+
+- `travels-itinerary-importer.ts` queries all `mwnf3_travels.tr_itineraries` and groups by `(project_id, country, trail_id, number)`.
+- `travels-location-importer.ts` queries all `tr_locations` and groups by `(project_id, country, trail_id, itinerary_id, number)`.
+- `travels-monument-importer.ts` queries all `tr_monuments` and groups by `(project_id, country, trail_id, itinerary_id, location_id, number)`.
+- Travel picture importers exist and import from `tr_trails_pictures`, `tr_itineraries_pictures`, `tr_locations_pictures`, and `tr_monuments_pictures`.
+
+The failure is that collection `internal_name` is globally unique, while Travels location and itinerary titles repeat naturally across trails/countries. The importers select display titles such as `SINTRA` as `internal_name`, which collides with existing collections. Once parent locations fail, monuments and pictures cascade into missing-parent skips/errors.
+
+The current production Inventory contains at least one corrected namespaced itinerary internal name for `mwnf3_travels:itinerary:IAM:pt:1:I`, so the code or data has changed since the logged duplicate error. The log under analysis still documents the bug pattern that explains the missing pieces in the validation reports.
+
+#### Story 13: Namespace Travels Collection Internal Names And Re-import Child Hierarchy
+
+**Goal:** Import all valid Travels trails, itineraries, locations, monuments, and media without global `internal_name` collisions.
+
+**Implementation notes:**
+
+- Update Travels collection importers to generate stable unique internal names from BC components, not only display titles.
+  - Example itinerary internal name: `itin_{project}_{country}_{trail}_{number}_{slug}`.
+  - Example location internal name: `loc_{project}_{country}_{trail}_{itinerary}_{number}_{slug}`.
+- Keep public titles in `collection_translations.title`; do not use title uniqueness as identity.
+- Apply the same principle to travel monument item internal names if needed.
+- Re-run Travels phases from itinerary onward after clearing or idempotently updating failed rows.
+- Ensure case normalization for BC keys is consistent between parent and picture importers. Current log contains both uppercase and lowercase variants in parent-not-found messages.
+
+**Acceptance criteria:**
+
+- Travels Locations imports close to the 410 unique legacy groups without duplicate `collections_internal_name_unique` errors.
+- Travels Monuments imports close to the 1,049 unique legacy groups, except for explicitly documented orphan source rows.
+- Algeria and Syria have imported itineraries, locations, and monuments where legacy rows exist.
+- Travels Location Pictures and Monument Pictures no longer fail due to parent-not-found cascades for valid rows.
+- Public display titles remain unchanged in translations.
+
+## Out-Of-Scope Or Retained-Model Decisions
+
+The gap reports mention some public website entities that are not currently retained as Inventory model concepts. These should not be treated as importer bugs unless the product scope changes.
+
+| Entity family | Current recommendation |
+|---|---|
+| Travels tours | Keep out of importer bug list unless Inventory is explicitly expanded to travel packages/tours. |
+| Travels travel agencies | Keep out of importer bug list unless partner scope expands to travel agencies. |
+| Portal panels, menus, newsletters, legal pages, videos, learning pages | Treat as portal CMS scope, not Inventory content, unless a portal-rebuild epic chooses to model them. |
+| Display-time punctuation differences | Do not track as import bugs when the legacy column value is preserved. |
+| Parent item plus child picture model | Do not track as missing multi-image data when child `type = picture` items or item images exist according to the chosen Inventory model. |
+
+## Recommended Next Work Order
+
+1. Fix `item_translations.provenance` persistence. This is small, high-confidence, and affects all imported object provenance.
+2. Fix Travels internal-name collisions and re-run Travels child phases. This explains the largest missing-data surface.
+3. Add SH partner picture importer. This is targeted and follows an existing normal partner-picture pattern.
+4. Decide BAR/mwnf3 timeline behavior: explicit import versus dynamic query.
+5. Implement Explore fallback detail strategy for VM/Travels/SH-backed monuments.
+6. Decide THG exhibition-level scope, then implement timeline/partner/media/contributor fixes in smaller stories.

--- a/scripts/importer/gap_analysis/ISLAMIC_ART_IMPORT_VALIDATION_REPORT.md
+++ b/scripts/importer/gap_analysis/ISLAMIC_ART_IMPORT_VALIDATION_REPORT.md
@@ -18,7 +18,7 @@ Relevant internal references:
 
 The Islamic Art import is strong for the main public content families sampled here: object identity, partner identity, historical chronology records, exhibition hierarchy, and exhibition-item links. The sampled records keep stable `backward_compatibility` keys and recognizable business fields.
 
-The main gaps are not whole missing families. They are presentation and modeling issues that can affect public review: provenance can be missing, some objects have multiple same-language translations, and picture records can appear as standalone items if future screens do not filter them carefully.
+The main gaps are not whole missing families. They are presentation and modeling issues that can affect public review: provenance can be missing, and some objects have multiple same-language translations that need context-aware display rules.
 
 ## Samples Checked
 
@@ -56,14 +56,14 @@ Exhibition structure is also good in the sample. The root exhibition, page colle
 
    Some sampled objects have more than one English translation. This may preserve different source text fields or contexts, but it can create duplicate rows in lists unless every query is context-aware.
 
-3. **Picture rows can pollute object listings**
-
-   The sampled museum partner has real objects and imported `type = picture` items. Pictures are valid Inventory content, but public object lists must filter them intentionally so images do not appear as holdings.
-
-4. **Single-date timeline events use `year_to = 0`**
+3. **Single-date timeline events use `year_to = 0`**
 
    The sampled timeline import is otherwise strong. Future presentation should treat `0` as no end year, or the importer should normalize it if the model permits.
 
+## Image Model Note
+
+The presence of `type = picture` child items is intentional in the Inventory model. A parent object or monument keeps one main image, and additional images can exist as child picture items. This report does not treat child picture rows as an import gap.
+
 ## Business Assessment
 
-The Islamic Art import is suitable for validating the core museum collection, exhibition hierarchy, and historical chronology content. Reviewers should focus next on provenance coverage, duplicate/contextual translations, and list filtering rules for picture items.
+The Islamic Art import is suitable for validating the core museum collection, exhibition hierarchy, and historical chronology content. Reviewers should focus next on provenance coverage and duplicate/contextual translations.

--- a/scripts/importer/gap_analysis/SHARING_HISTORY_IMPORT_VALIDATION_REPORT.md
+++ b/scripts/importer/gap_analysis/SHARING_HISTORY_IMPORT_VALIDATION_REPORT.md
@@ -6,7 +6,7 @@ Date: 2026-05-02
 
 This report validates imported Inventory data against the public website `https://sharinghistory.museumwnf.org`, the supporting legacy codebase at `E:\mwnf-server\apps\sharinghistory.museumwnf.org`, the production legacy database, and the imported Inventory database.
 
-The website is the primary source. The sample covers project pages, exhibitions, objects, partners, timelines, historical profiles, media, and documents.
+The website is the primary source. The sample covers the public landing page, exhibitions, objects, partners, timelines, historical profiles, media, and documents.
 
 Relevant internal references:
 
@@ -16,28 +16,28 @@ Relevant internal references:
 
 ## Summary
 
-The Sharing History import is strong for the central public content: project identity, exhibition hierarchy, object records, partners, timelines, item-linked timeline pivots, media, and documents. Sampled records have stable `mwnf3_sharing_history:*` keys and recognizable fields.
+The Sharing History import is strong for the central public content: site identity, exhibition hierarchy, object records, partners, timelines, item-linked timeline pivots, media, and documents. Sampled records have stable `mwnf3_sharing_history:*` keys and recognizable fields.
 
-The main gaps are page-level presentation and profile richness: project/about copy is not carried into the sampled project collection, partner gallery photos are missing, some objects lose secondary images, and national-context child collections need further content review.
+The main gaps are page-level presentation and profile richness: partner gallery photos are missing, and national-context child collections need further content review. The sampled two-image object is not an image-import gap because the second image exists as a child `picture` item.
 
 ## Samples Checked
 
 | Website area | Sampled website page | Website facts checked | Inventory result |
 |---|---|---|---|
-| Project homepage | `index.php` | `Sharing History Arab World - Europe | 1815 - 1918`; ten virtual exhibitions | Project collection `mwnf3_sharing_history:sh_projects:awe` exists. Title is imported as `Sharing History - Arab-Ottoman-European relations in the 19th century.` Sampled project collection description is null. |
+| Public landing page | `index.php` | `Sharing History Arab World - Europe | 1815 - 1918`; ten virtual exhibitions | Collection `mwnf3_sharing_history:sh_projects:awe` exists with the site/project title. Its missing description is not treated here as an Inventory `Project` gap; long-form landing/about text needs a separate scope decision if it is required in the new public experience. |
 | Exhibition list and themes | `exhibitions/AWE/index.php`; `exh_items.php?eId=3&lan=en` | Exhibition `Cities and Urban Spaces`; subtopics include `The image of the city`, `Urban Planning and the Instruments of Planning`, `Architecture and Construction` | Collection `mwnf3_sharing_history:sh_exhibitions:3` exists with title and intro. Child theme collections `...:sh_exhibition_themes:6`, `7`, and `8` exist with matching titles. |
 | Object detail | `database_item.php?id=object;AWE;at;26;en&pageT=N` | `Mummy board and inner coffin for Nes-pauti-taui`; KHM Vienna; date `21st Dyn, c. 1000 BC`; image path under `sharing_history/sh_objects/awe/at/26/1.jpg` | Item `mwnf3_sharing_history:sh_objects:awe:at:26` exists with matching name, holder, date, and image. |
 | Object from timeline | `database_item.php?id=object;awe;tn;46;en` | `Portrait of Hammouda Pacha Bey`; Tunisia; 19th century; linked from timeline | Item `mwnf3_sharing_history:sh_objects:awe:tn:46` exists. Timeline link from sampled HCR record exists. |
 | Partners | `pm_partner.php?id=AT_01;at&shpro=AWE&`; `pm_partner.php?id=DZ_01;dz&shpro=AWE&` | Kunsthistorisches Museum, Vienna; Ministry of Culture, Algiers; rich descriptions, address/contact, websites, logos, partner photos | Partners `mwnf3_sharing_history:sh_partners:at_01` and `...:dz_01` exist with text, contact fields, country/type, and logos. Sampled partner profile photos were not imported as `partner_images`. |
 | Timeline | `hcr_result.php?country=eg&start_date=1815&end_date=1918` | Rows include First Saudi State, Hammouda Pacha Bey, Campo Formio; object links to `awe;tn;46` and `awe;at;2` | Events such as `mwnf3_sharing_history:sh_hcr:780`, `...:71`, and `...:420` exist. Item pivots such as `...:sh_hcr_images:55` and `...:258` exist. |
 | Historical profiles | `hb_result.php?country=eg&page=1` | Egypt page shows object-backed profiles including Colonel Ahmad Urabi Pasha, Opera House 1869, Alexandria Sporting Club, Women in the Revolution of 1919 | Sampled profile objects exist as imported items, including `eg:79`, `eg:96`, `eg:108`, and `eg:17`. |
-| Media and documents | `database_item.php?id=object;AWE;gr;50;en`; `database_item.php?id=object;awe;es;28;en` | Video links for `Mr. Byzantoine et ses amis`; PDF link for Spanish sample object; two visible images on `es;28` page | Video/audio rows for `gr:50` and `gr:51` are imported as item media. The PDF document for `es:28` is imported. The sampled `es:28` item has one imported image while the website shows two. |
+| Media and documents | `database_item.php?id=object;AWE;gr;50;en`; `database_item.php?id=object;awe;es;28;en` | Video links for `Mr. Byzantoine et ses amis`; PDF link for Spanish sample object; two visible images on `es;28` page | Video/audio rows for `gr:50` and `gr:51` are imported as item media. The PDF document for `es:28` is imported. The sampled `es:28` item has 1 parent image and 2 child `picture` items (`mwnf3_sharing_history:sh_object_images:awe:es:28:_:1..2`). |
 
 ## Legacy Source Mapping
 
 | Website content | Legacy source used by the site |
 |---|---|
-| Project | `mwnf3_sharing_history.sh_projects` and `sh_project_names`. |
+| Public site/project identity | `mwnf3_sharing_history.sh_projects` and `sh_project_names`. |
 | Exhibitions and themes | `sh_exhibitions`, `sh_exhibitionnames`, `sh_exhibition_themes`, and `sh_exhibition_themenames`. |
 | Objects | `sh_objects` and `sh_objects_texts`. |
 | Partners | `sh_partners`, `sh_partner_names`, and partner link tables. |
@@ -50,30 +50,22 @@ Sharing History is one of the stronger sampled imports. Core objects, exhibition
 
 The sampled import count for AWE objects was confirmed at 2,420 rows in both checked inventory environments. This supports the conclusion that the object family imported broadly, not only for isolated examples.
 
-Some presentation content remains outside the sampled Inventory rows, especially richer project landing text and partner photo galleries.
+Some presentation content remains outside the sampled Inventory rows, especially partner photo galleries. Landing/about text from the website should not be confused with the Inventory `Project` concept; if that text is required later, it should be assessed as collection/body content for the public experience.
 
 ## Gaps To Address
 
-1. **Project/about narrative gap**
-
-   The website exposes project introduction and about text from project-name tables. The sampled Inventory project collection exists, but its description is null.
-
-2. **Partner profile image gap**
+1. **Partner profile image gap**
 
    Sampled partner pages show profile/gallery photos in addition to logos. Inventory has logos, but sampled partner image counts are zero.
 
-3. **Multi-image object gap**
-
-   The sampled Spanish object page shows two images, while Inventory has one imported item image.
-
-4. **National-context child collections need review**
+2. **National-context child collections need review**
 
    Sampled national-context child collections under exhibition 3 had null English title/description. If these overlays are needed by the future read-only API or front end, they need focused validation.
 
-5. **Encoding should be checked through application responses**
+3. **Encoding should be checked through application responses**
 
    Terminal SQL output can distort curly quotes, dashes, and accents. The website renders these correctly. Encoding should be verified through Laravel/UI/API responses before treating it as an import defect.
 
 ## Business Assessment
 
-The Sharing History import is suitable for validating the main public collection, exhibition, object, timeline, media, and document content. The next validation round should focus on richer page-level presentation: project copy, partner galleries, multi-image objects, and national-context collections.
+The Sharing History import is suitable for validating the main public collection, exhibition, object, timeline, media, and document content. The next validation round should focus on richer page-level presentation: partner galleries, national-context collections, and any landing/about text that is explicitly in scope for the future public experience.

--- a/scripts/importer/gap_analysis/TRAVELS_IMPORT_VALIDATION_REPORT.md
+++ b/scripts/importer/gap_analysis/TRAVELS_IMPORT_VALIDATION_REPORT.md
@@ -1,0 +1,132 @@
+# Travels Import Validation Report
+
+Date: 2026-05-02
+
+## Scope
+
+This report validates imported Inventory data against the public website `https://travels.museumwnf.org`, the supporting legacy codebase at `E:\mwnf-server\apps\travels.museumwnf.org`, the production legacy database, and the imported Inventory database.
+
+The Travels activity is currently on hold, but the data remains relevant for the importer. The website is the primary source.
+
+Relevant internal references:
+
+- [Legacy Import](../../../docs/understanding/legacy-import.md)
+- [Validation Guide](../../../docs/understanding/validation-guide.md)
+- [Inventory Principles](../../../docs/understanding/inventory-principles.md)
+
+## Summary
+
+The Travels import is solid for the core Exhibition Trail hierarchy where rows exist. The sampled Portugal trail, itinerary, locations, and monument titles are traceable and match the public website and legacy tables.
+
+The business gaps are substantial: some visible countries are absent from the imported hierarchy, several countries have partial monument coverage, media coverage is much thinner than the website and legacy picture tables, and tour/agency/travel-service content is not represented as first-class Inventory data.
+
+## Samples Checked
+
+| Website area | Sampled website page | Website facts checked | Inventory result |
+|---|---|---|---|
+| Homepage/navigation | `https://travels.museumwnf.org/` | Countries include Egypt, Jordan, Italy, Morocco, Palestine, Portugal, Spain, Syria, Tunisia, and Turkiye; Exhibition Trails are prominent | Inventory contains a Travels context/root and imported trail/location/itinerary/monument data for some countries, but not all visible countries. |
+| Theme trail list | `travel_et_trail.php?tid=IAM` | `Eleven Exhibition Trails`; includes Algeria trail `UNE ARCHITECTURE DE LUMIERE`; links include `IAM;pt;1;en` | Trail collections exist for 12 imported trails overall, but sampled country coverage shows Algeria and Syria absent from imported itinerary/monument rows. |
+| Portugal trail list | `travel_et_trail.php?cid=pt` | `IN THE LANDS OF THE ENCHANTED MOORISH MAIDEN`; subtitle `Islamic Art in Portugal`; region `Central and Southern Portugal`; English, Spanish, French, Italian, Portuguese | Collection `mwnf3_travels:trail:IAM:pt:1` exists as an exhibition-trail collection with country `prt`. |
+| Portugal trail detail | `travel_et_trailDetail.php?id=IAM;pt;1;en&fl=its` | Ten itineraries, from `Mudejar Art` through itinerary X; each has main locations and image-gallery links | Portugal has 10 imported itinerary collections for the sampled trail, including `mwnf3_travels:itinerary:IAM:pt:1:I` and `...:V`. |
+| Itinerary detail | `travel_et_itenary.php?id=IAM;pt;I;en;1&fl=des&itrNo=10` | `ITINERARY I: Mudejar Art`; description begins with the Tagus estuary/fishing/vegetable garden text | Collection `mwnf3_travels:itinerary:IAM:pt:1:I` exists. Title and description match the sampled public/legacy text. |
+| Itinerary gallery | `travel_et_itenary.php?id=IAM;pt;I;en;1&fl=vl&itrNo=10` | Image gallery starts with `City Museum, Lisbon`; many thumbnails under `images.museumwnf.org/thumb/trails/iam/pt/1/i/...` | The sampled itinerary has 1 imported collection image. The related Lisbon location has 0 images in the sampled Inventory query. Legacy rows show more itinerary, location, and monument images. |
+| Tour detail | `tourdetails.php?id=47&flag=CON&cid=pt` | Paused-tour banner; `IN THE LAND OF THE ENCHANTED MOORISH MAIDEN. Islamic Art in Portugal.`; 7 days / 6 nights; anytime; price `Please contact`; link to Exhibition Trail | No sampled Inventory collection/item was found for tour 47. Tours are not modeled as first-class Inventory records in the sampled production import. |
+| Partners | `tr_partners.php?country=all` | Travel agents include Manar Travel, Viajes Mundo Amigo, AlternativeSicily, Zaatarah & Co., and Batouta Voyages | No sampled `mwnf3_travels:*agency*` Inventory partners were found. |
+
+## Legacy Source Mapping
+
+| Website content | Legacy source used by the site |
+|---|---|
+| Trails | `mwnf3_travels.trails`. |
+| Itineraries | `mwnf3_travels.tr_itineraries`. |
+| Locations | `mwnf3_travels.tr_locations`. |
+| Travel monuments | `mwnf3_travels.tr_monuments`. |
+| Pictures | `tr_trails_pictures`, `tr_itineraries_pictures`, `tr_locations_pictures`, and `tr_monuments_pictures`. |
+| Tours and agencies | `travels`, `travel_texts`, `travels_countries`, `travels_trails`, `travel_days`, `tr_agencies`, and `tr_agency_texts`. |
+
+## Legacy Scale Observed
+
+| Legacy family | Count observed |
+|---|---:|
+| Trails | 12 |
+| Itineraries | 109 |
+| Locations | 410 |
+| Travel monuments | 1,049 |
+| Tours | 24 |
+| Agencies | 5 |
+| Trail pictures | 123 |
+| Itinerary pictures | 438 |
+| Location pictures | 569 |
+| Monument pictures | 7,807 |
+
+## Inventory Scale Observed
+
+| Inventory family | Count observed |
+|---|---:|
+| Travels context | 1 |
+| Travels root collection | 1 |
+| Trail collections | 12 |
+| Itinerary collections | 82 |
+| Location collections | 274 |
+| Travel monument items | 676 |
+| Travel collection images | 235 |
+| Travel item images | 1,468 |
+| Travel child picture items under monument parents | 0 |
+
+## Country Coverage Sample
+
+| Country | Legacy itineraries | Inventory itineraries | Legacy monuments | Inventory monuments |
+|---|---:|---:|---:|---:|
+| Algeria `dz` | 5 | 0 | 68 | 0 |
+| Syria `sy` | 8 | 0 | 85 | 0 |
+| Portugal `pt` | 24 | 10 | 258 | 77 |
+| Jordan `jo` | 5 | 5 | 40 | 26 |
+| Palestine `pa` | 9 | 9 | 67 | 60 |
+| Tunisia `tn` | 11 | 11 | 109 | 99 |
+
+## Import Quality
+
+The core imported hierarchy is credible for the sampled Portugal data. Trail, itinerary, location, and monument keys are consistent and traceable:
+
+- `mwnf3_travels:trail:IAM:pt:1`
+- `mwnf3_travels:itinerary:IAM:pt:1:I`
+- `mwnf3_travels:itinerary:IAM:pt:1:V`
+- `mwnf3_travels:location:IAM:pt:1:I:1`
+- `mwnf3_travels:location:IAM:pt:1:V:5`
+- `mwnf3_travels:monument:IAM:pt:1:I:1:a`
+- `mwnf3_travels:monument:IAM:pt:1:I:1:b`
+- `mwnf3_travels:monument:IAM:pt:1:V:5:d`
+
+The sampled Portugal itinerary title and description match the public website. Sampled Portugal locations and monuments also preserve recognizable titles, including `LISBON`, `MERTOLA`, `City Museum`, `National Archaeology Museum`, and `Parish Church of Nossa Senhora da Anunciacao`.
+
+The import is weaker for coverage and media. Unlike the `mwnf3` object/monument importer, the sampled Travels monument picture data does not appear as child `picture` items. The observed image count is much lower than the legacy picture-table count.
+
+## Gaps To Address
+
+1. **Country coverage is incomplete**
+
+   Algeria and Syria are visible/source-backed on the Travels website but have zero sampled imported itinerary and monument rows. Portugal is also partial in the sampled count comparison.
+
+2. **Monument and location coverage is partial**
+
+   Several countries have fewer imported monuments than the legacy tables expose. This affects the ability to rebuild full Trails pages from Inventory.
+
+3. **Media coverage is much thinner than the website**
+
+   The website exposes large itinerary/location/monument galleries. Legacy picture tables contain 8,937 rows across sampled Travels media families, while Inventory has 1,703 travel image rows across collection and item images and no sampled child picture items under travel monument parents.
+
+4. **Tours are not imported as first-class Inventory data**
+
+   The sampled tour 47 page has title, duration, period, price text, day rows, and a trail link. No corresponding Inventory collection or item was found.
+
+5. **Travel agencies are not imported as first-class partners**
+
+   The live partner page lists five travel agencies. No sampled `mwnf3_travels:*agency*` Inventory partners were found.
+
+6. **Travel-service side content is not represented**
+
+   The legacy itinerary code loads cultural events, related walks, accommodation, traditional food, and useful contacts. The sampled Inventory import covers trail/itinerary/location/monument hierarchy, not these travel-service content families.
+
+## Business Assessment
+
+The Travels import is a useful base for Exhibition Trail hierarchy and some country content, especially the sampled Portugal IAM trail. It is not complete enough for a faithful Travels website replacement. The next importer review should prioritize missing countries, partial monument/location coverage, media coverage, and a clear business decision on whether tours, agencies, and travel-service sections belong in Inventory or a separate content system.


### PR DESCRIPTION
Improve the gap analysis for the websites import by addressing presentation and modeling issues, clarifying translation contexts, and ensuring proper handling of image rights and captions. Focus on refining the public gallery experience based on the findings.