### PR TITLE
Implement forgot password flow in Filament auth

### DIFF
--- a/app/Filament/Auth/Login.php
+++ b/app/Filament/Auth/Login.php
@@ -4,9 +4,13 @@ namespace App\Filament\Auth;
 
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\Component;
+use Filament\Forms\Components\TextInput;
 use Filament\Http\Responses\Auth\Contracts\LoginResponse as FilamentLoginResponse;
 use Filament\Models\Contracts\FilamentUser;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\HtmlString;
 use Laravel\Fortify\Features;
 
 class Login extends \Filament\Pages\Auth\Login
@@ -71,5 +75,19 @@ class Login extends \Filament\Pages\Auth\Login
     protected function getForgotPasswordUrl(): ?string
     {
         return Filament::getCurrentPanel()->route('auth.password.request');
+    }
+
+    protected function getPasswordFormComponent(): Component
+    {
+        $url = $this->getForgotPasswordUrl();
+
+        return TextInput::make('password')
+            ->label(__('filament-panels::pages/auth/login.form.password.label'))
+            ->hint($url ? new HtmlString(Blade::render('<x-filament::link :href="$url" tabindex="3"> {{ __(\'filament-panels::pages/auth/login.actions.request_password_reset.label\') }}</x-filament::link>', ['url' => $url])) : null)
+            ->password()
+            ->revealable(filament()->arePasswordsRevealable())
+            ->autocomplete('current-password')
+            ->required()
+            ->extraInputAttributes(['tabindex' => 2]);
     }
 }


### PR DESCRIPTION
Add a reset password feature to the Filament login interface, allowing users to request a password reset link via email. This implementation includes a new entry point for the forgot password action and integrates it into the existing password form.

Fixes #1071