### PR TITLE
feat(importers): integrate ExploreMonumentResolver for monument resolution in theme and translation importers

### DIFF
--- a/scripts/importer/package-lock.json
+++ b/scripts/importer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "importer",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "importer",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "dependencies": {
         "@types/turndown": "^5.0.6",
         "axios": "^1.15.0",

--- a/scripts/importer/package.json
+++ b/scripts/importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "importer",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "type": "module",
   "description": "Unified legacy database import utility for Inventory Management System",

--- a/scripts/importer/src/cli/import.ts
+++ b/scripts/importer/src/cli/import.ts
@@ -555,7 +555,7 @@ const ALL_IMPORTERS: ImporterConfig[] = [
     name: 'Explore Monuments',
     description: 'Import monuments with geocoordinates from Explore',
     importerClass: ExploreMonumentImporter,
-    dependencies: ['explore-location'],
+    dependencies: ['explore-location', 'monument', 'sh-monument', 'travels-monument'],
   },
   {
     key: 'explore-monument-picture',

--- a/scripts/importer/src/importers/phase-06/explore-filter-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-filter-importer.ts
@@ -16,6 +16,7 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
+import { ExploreMonumentResolver } from './explore-monument-resolver.js';
 
 interface LegacyFilter {
   filterId: string;
@@ -29,6 +30,8 @@ interface LegacyFilterMonument {
 }
 
 export class ExploreFilterImporter extends BaseImporter {
+  private monumentResolver!: ExploreMonumentResolver;
+
   getName(): string {
     return 'ExploreFilterImporter';
   }
@@ -38,6 +41,12 @@ export class ExploreFilterImporter extends BaseImporter {
 
     try {
       this.logInfo('Importing Explore filters...');
+      this.monumentResolver = new ExploreMonumentResolver({
+        legacyDb: this.context.legacyDb,
+        tracker: this.context.tracker,
+        getEntityUuid: (backwardCompatibility, entityType) =>
+          this.getEntityUuidAsync(backwardCompatibility, entityType),
+      });
 
       // 1. Import filters → Tags
       const filters = await this.context.legacyDb.query<LegacyFilter>(
@@ -125,10 +134,11 @@ export class ExploreFilterImporter extends BaseImporter {
           }
 
           // Resolve monument item
-          const monumentBC = `mwnf3_explore:monument:${link.monumentId}`;
-          const itemId = await this.getEntityUuidAsync(monumentBC, 'item');
-          if (!itemId) {
-            this.logWarning(`Monument item not found: ${monumentBC}, skipping link`);
+          const monumentResolution = await this.monumentResolver.resolve(link.monumentId);
+          if (!monumentResolution.itemId || !monumentResolution.itemBackwardCompatibility) {
+            this.logWarning(
+              `${monumentResolution.message ?? `Explore monument mwnf3_explore:monument:${link.monumentId} did not resolve to an item`}, skipping link`
+            );
             result.skipped++;
             this.showSkipped();
             continue;
@@ -140,7 +150,7 @@ export class ExploreFilterImporter extends BaseImporter {
             continue;
           }
 
-          await this.context.strategy.attachTagsToItem(itemId, [tagId]);
+          await this.context.strategy.attachTagsToItem(monumentResolution.itemId, [tagId]);
           result.imported++;
           this.showProgress();
         } catch (error) {

--- a/scripts/importer/src/importers/phase-06/explore-itinerary-content-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-itinerary-content-importer.ts
@@ -18,6 +18,7 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
+import { ExploreMonumentResolver } from './explore-monument-resolver.js';
 
 interface LegacyItineraryLang {
   itineraries_id: number;
@@ -77,6 +78,10 @@ interface LegacyCrossSchemaLink {
   itineraryId: number;
 }
 
+interface LegacyTravelsDescription {
+  description: string | null;
+}
+
 function parseGeoCoordinates(coords: string | null): [number | null, number | null] {
   if (!coords || !coords.trim()) return [null, null];
   const cleaned = coords.replace(/\s+/g, '').trim();
@@ -91,6 +96,7 @@ function parseGeoCoordinates(coords: string | null): [number | null, number | nu
 export class ExploreItineraryContentImporter extends BaseImporter {
   private exploreContextId!: string;
   private exploreByItineraryId: string | null = null;
+  private monumentResolver!: ExploreMonumentResolver;
 
   getName(): string {
     return 'ExploreItineraryContentImporter';
@@ -107,6 +113,12 @@ export class ExploreItineraryContentImporter extends BaseImporter {
         throw new Error(`Explore context not found (${exploreContextBC}).`);
       }
       this.exploreContextId = exploreContextId;
+      this.monumentResolver = new ExploreMonumentResolver({
+        legacyDb: this.context.legacyDb,
+        tracker: this.context.tracker,
+        getEntityUuid: (backwardCompatibility, entityType) =>
+          this.getEntityUuidAsync(backwardCompatibility, entityType),
+      });
 
       // Get Explore by Itinerary root
       const byItineraryBC = 'mwnf3_explore:root:explore_by_itinerary';
@@ -170,6 +182,16 @@ export class ExploreItineraryContentImporter extends BaseImporter {
           continue;
         }
 
+        const title = trans.title?.trim() ?? '';
+        if (title === '') {
+          this.logWarning(
+            `Explore itinerary ${itineraryBC} is missing a required source title for ${trans.langId}, skipping translation`
+          );
+          result.skipped++;
+          this.showSkipped();
+          continue;
+        }
+
         const translationBC = `${itineraryBC}:translation:${languageId}`;
         if (await this.entityExistsAsync(translationBC, 'collection_translation')) {
           result.skipped++;
@@ -186,6 +208,7 @@ export class ExploreItineraryContentImporter extends BaseImporter {
         if (trans.et_title) extra.et_title = trans.et_title;
         if (trans.et_introduction) extra.et_introduction = trans.et_introduction;
         const extraJson = Object.keys(extra).length > 0 ? JSON.stringify(extra) : null;
+        const visibleDescription = await this.resolveVisibleDescription(trans);
 
         if (this.isDryRun || this.isSampleOnlyMode) {
           result.imported++;
@@ -198,8 +221,8 @@ export class ExploreItineraryContentImporter extends BaseImporter {
           language_id: languageId,
           context_id: this.exploreContextId,
           backward_compatibility: translationBC,
-          title: trans.title ?? `Itinerary ${trans.itineraries_id}`,
-          description: trans.introduction ?? '',
+          title,
+          description: visibleDescription,
           extra: extraJson,
         });
 
@@ -237,10 +260,11 @@ export class ExploreItineraryContentImporter extends BaseImporter {
           continue;
         }
 
-        const monumentBC = `mwnf3_explore:monument:${link.monumentId}`;
-        const itemId = await this.getEntityUuidAsync(monumentBC, 'item');
-        if (!itemId) {
-          this.logWarning(`Monument not found: ${monumentBC}, skipping`);
+        const monumentResolution = await this.monumentResolver.resolve(link.monumentId);
+        if (!monumentResolution.itemId || !monumentResolution.itemBackwardCompatibility) {
+          this.logWarning(
+            `${monumentResolution.message ?? `Explore monument mwnf3_explore:monument:${link.monumentId} did not resolve to an item`}, skipping`
+          );
           result.skipped++;
           this.showSkipped();
           continue;
@@ -263,7 +287,7 @@ export class ExploreItineraryContentImporter extends BaseImporter {
         const linkBC = `mwnf3_explore:itinerary_monument:${link.itineraries_id}:${link.monumentId}`;
         await this.context.strategy.writeCollectionItem({
           collection_id: collectionId,
-          item_id: itemId,
+          item_id: monumentResolution.itemId,
           backward_compatibility: linkBC,
           display_order: link.mn_order,
           extra: Object.keys(extra).length > 0 ? extra : null,
@@ -473,10 +497,11 @@ export class ExploreItineraryContentImporter extends BaseImporter {
           continue;
         }
 
-        const monumentBC = `mwnf3_explore:monument:${link.monumentId}`;
-        const itemId = await this.getEntityUuidAsync(monumentBC, 'item');
-        if (!itemId) {
-          this.logWarning(`Monument not found: ${monumentBC}, skipping`);
+        const monumentResolution = await this.monumentResolver.resolve(link.monumentId);
+        if (!monumentResolution.itemId || !monumentResolution.itemBackwardCompatibility) {
+          this.logWarning(
+            `${monumentResolution.message ?? `Explore monument mwnf3_explore:monument:${link.monumentId} did not resolve to an item`}, skipping`
+          );
           result.skipped++;
           this.showSkipped();
           continue;
@@ -491,7 +516,7 @@ export class ExploreItineraryContentImporter extends BaseImporter {
         const linkBC = `mwnf3_explore:old_itinerary_monument:${link.itinerary_id}:${link.monumentId}`;
         await this.context.strategy.writeCollectionItem({
           collection_id: collectionId,
-          item_id: itemId,
+          item_id: monumentResolution.itemId,
           backward_compatibility: linkBC,
           display_order: link.itin_order,
         });
@@ -574,5 +599,64 @@ export class ExploreItineraryContentImporter extends BaseImporter {
         }
       }
     }
+  }
+
+  private async resolveVisibleDescription(trans: LegacyItineraryLang): Promise<string> {
+    if (trans.introduction && trans.introduction.trim() !== '') {
+      return trans.introduction;
+    }
+
+    const shortDescription = await this.resolveTravelsDescriptionReference(
+      trans.et_title,
+      'description'
+    );
+    if (shortDescription) {
+      return shortDescription;
+    }
+
+    const longDescription = await this.resolveTravelsDescriptionReference(
+      trans.et_introduction,
+      'description2'
+    );
+    if (longDescription) {
+      return longDescription;
+    }
+
+    return '';
+  }
+
+  private async resolveTravelsDescriptionReference(
+    reference: string | null,
+    field: 'description' | 'description2'
+  ): Promise<string | null> {
+    if (!reference || reference.trim() === '') {
+      return null;
+    }
+
+    const parts = reference.split(';').map((part) => part.trim());
+    if (parts.length !== 5) {
+      return null;
+    }
+
+    const [projectId, country, number, lang, trailIdRaw] = parts;
+    const trailId = Number.parseInt(trailIdRaw, 10);
+    if (!projectId || !country || !number || !lang || Number.isNaN(trailId)) {
+      return null;
+    }
+
+    const rows = await this.context.legacyDb.query<LegacyTravelsDescription>(
+      `SELECT ${field} AS description
+       FROM mwnf3_travels.tr_itineraries
+       WHERE project_id = ?
+         AND country = ?
+         AND number = ?
+         AND lang = ?
+         AND trail_id = ?
+       LIMIT 1`,
+      [projectId, country, number, lang, trailId]
+    );
+
+    const description = rows[0]?.description ?? null;
+    return description && description.trim() !== '' ? description : null;
   }
 }

--- a/scripts/importer/src/importers/phase-06/explore-monument-crossref-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-monument-crossref-importer.ts
@@ -14,6 +14,7 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
+import { ExploreMonumentResolver } from './explore-monument-resolver.js';
 
 interface LegacyMonumentVM {
   monumentId: number;
@@ -48,6 +49,7 @@ interface LegacyMonumentMuseum {
 
 export class ExploreMonumentCrossRefImporter extends BaseImporter {
   private exploreContextId!: string;
+  private monumentResolver!: ExploreMonumentResolver;
 
   getName(): string {
     return 'ExploreMonumentCrossRefImporter';
@@ -64,6 +66,12 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
         throw new Error(`Explore context not found (${exploreContextBC}).`);
       }
       this.exploreContextId = exploreContextId;
+      this.monumentResolver = new ExploreMonumentResolver({
+        legacyDb: this.context.legacyDb,
+        tracker: this.context.tracker,
+        getEntityUuid: (backwardCompatibility, entityType) =>
+          this.getEntityUuidAsync(backwardCompatibility, entityType),
+      });
 
       // 1. exploremonument_vm → mwnf3 monuments
       this.logInfo('Importing Explore → mwnf3 monument cross-references...');
@@ -76,10 +84,11 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
 
       for (const vm of vmLinks) {
         try {
-          const sourceBC = `mwnf3_explore:monument:${vm.monumentId}`;
-          const sourceId = await this.getEntityUuidAsync(sourceBC, 'item');
-          if (!sourceId) {
-            this.logWarning(`Explore monument not found: ${sourceBC}, skipping`);
+          const sourceResolution = await this.monumentResolver.resolve(vm.monumentId);
+          if (!sourceResolution.itemId || !sourceResolution.itemBackwardCompatibility) {
+            this.logWarning(
+              `${sourceResolution.message ?? `Explore monument mwnf3_explore:monument:${vm.monumentId} did not resolve to an item`}, skipping`
+            );
             result.skipped++;
             this.showSkipped();
             continue;
@@ -95,6 +104,12 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
             continue;
           }
 
+          if (sourceResolution.itemId === targetId) {
+            result.skipped++;
+            this.showSkipped();
+            continue;
+          }
+
           if (this.isDryRun || this.isSampleOnlyMode) {
             result.imported++;
             this.showProgress();
@@ -103,7 +118,7 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
 
           const linkBC = `mwnf3_explore:monument_vm:${vm.monumentId}:${vm.REF_monuments_project_id}:${vm.REF_monuments_country}:${vm.REF_monuments_institution_id}:${vm.REF_monuments_number}`;
           await this.context.strategy.writeItemItemLink({
-            source_id: sourceId,
+            source_id: sourceResolution.itemId,
             target_id: targetId,
             context_id: this.exploreContextId,
             backward_compatibility: linkBC,
@@ -132,10 +147,11 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
 
       for (const tr of trLinks) {
         try {
-          const sourceBC = `mwnf3_explore:monument:${tr.monumentId}`;
-          const sourceId = await this.getEntityUuidAsync(sourceBC, 'item');
-          if (!sourceId) {
-            this.logWarning(`Explore monument not found: ${sourceBC}, skipping`);
+          const sourceResolution = await this.monumentResolver.resolve(tr.monumentId);
+          if (!sourceResolution.itemId || !sourceResolution.itemBackwardCompatibility) {
+            this.logWarning(
+              `${sourceResolution.message ?? `Explore monument mwnf3_explore:monument:${tr.monumentId} did not resolve to an item`}, skipping`
+            );
             result.skipped++;
             this.showSkipped();
             continue;
@@ -151,6 +167,12 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
             continue;
           }
 
+          if (sourceResolution.itemId === targetId) {
+            result.skipped++;
+            this.showSkipped();
+            continue;
+          }
+
           if (this.isDryRun || this.isSampleOnlyMode) {
             result.imported++;
             this.showProgress();
@@ -159,7 +181,7 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
 
           const linkBC = `mwnf3_explore:monument_tr:${tr.monumentId}:${tr.REF_tr_monuments_project_id}:${tr.REF_tr_monuments_country}:${tr.REF_tr_monuments_trail_id}:${tr.REF_tr_monuments_itinerary_id}:${tr.REF_tr_monuments_location_id}:${tr.REF_tr_monuments_number}`;
           await this.context.strategy.writeItemItemLink({
-            source_id: sourceId,
+            source_id: sourceResolution.itemId,
             target_id: targetId,
             context_id: this.exploreContextId,
             backward_compatibility: linkBC,
@@ -182,10 +204,11 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
 
       for (const sh of shLinks) {
         try {
-          const sourceBC = `mwnf3_explore:monument:${sh.monumentId}`;
-          const sourceId = await this.getEntityUuidAsync(sourceBC, 'item');
-          if (!sourceId) {
-            this.logWarning(`Explore monument not found: ${sourceBC}, skipping`);
+          const sourceResolution = await this.monumentResolver.resolve(sh.monumentId);
+          if (!sourceResolution.itemId || !sourceResolution.itemBackwardCompatibility) {
+            this.logWarning(
+              `${sourceResolution.message ?? `Explore monument mwnf3_explore:monument:${sh.monumentId} did not resolve to an item`}, skipping`
+            );
             result.skipped++;
             this.showSkipped();
             continue;
@@ -201,6 +224,12 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
             continue;
           }
 
+          if (sourceResolution.itemId === targetId) {
+            result.skipped++;
+            this.showSkipped();
+            continue;
+          }
+
           if (this.isDryRun || this.isSampleOnlyMode) {
             result.imported++;
             this.showProgress();
@@ -209,7 +238,7 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
 
           const linkBC = `mwnf3_explore:monument_sh:${sh.monumentId}:${sh.project_id.toLowerCase()}:${sh.country.toLowerCase()}:${sh.number}`;
           await this.context.strategy.writeItemItemLink({
-            source_id: sourceId,
+            source_id: sourceResolution.itemId,
             target_id: targetId,
             context_id: this.exploreContextId,
             backward_compatibility: linkBC,
@@ -232,10 +261,11 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
 
       for (const ml of museumLinks) {
         try {
-          const monumentBC = `mwnf3_explore:monument:${ml.monumentId}`;
-          const itemId = await this.getEntityUuidAsync(monumentBC, 'item');
-          if (!itemId) {
-            this.logWarning(`Explore monument not found: ${monumentBC}, skipping museum check`);
+          const monumentResolution = await this.monumentResolver.resolve(ml.monumentId);
+          if (!monumentResolution.itemId || !monumentResolution.itemBackwardCompatibility) {
+            this.logWarning(
+              `${monumentResolution.message ?? `Explore monument mwnf3_explore:monument:${ml.monumentId} did not resolve to an item`}, skipping museum check`
+            );
             continue;
           }
 
@@ -253,7 +283,10 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
 
           // Store in ItemTranslation(eng).extra.additional_explore_partners[]
           // Only if an English translation exists for this monument
-          const existingExtra = await this.context.strategy.getItemTranslationExtra(itemId, 'eng');
+          const existingExtra = await this.context.strategy.getItemTranslationExtra(
+            monumentResolution.itemId,
+            'eng'
+          );
           if (existingExtra !== null) {
             const extra = existingExtra;
             const existing = extra.additional_explore_partners as string[] | undefined;
@@ -263,7 +296,7 @@ export class ExploreMonumentCrossRefImporter extends BaseImporter {
             }
             extra.additional_explore_partners = partners;
             await this.context.strategy.setItemTranslationExtra(
-              itemId,
+              monumentResolution.itemId,
               'eng',
               JSON.stringify(extra)
             );

--- a/scripts/importer/src/importers/phase-06/explore-monument-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-monument-importer.ts
@@ -30,10 +30,12 @@ import {
   type ExploreLegacyMonument,
   type ExploreMonumentNameTranslation,
 } from '../../domain/transformers/explore-monument-transformer.js';
+import { ExploreMonumentResolver } from './explore-monument-resolver.js';
 
 export class ExploreMonumentImporter extends BaseImporter {
   private exploreContextId: string | null = null;
   private locationCollectionCache: Map<number, string | null> = new Map();
+  private monumentResolver!: ExploreMonumentResolver;
 
   getName(): string {
     return 'ExploreMonumentImporter';
@@ -61,6 +63,12 @@ export class ExploreMonumentImporter extends BaseImporter {
       this.logInfo(`Found Explore context: ${this.exploreContextId}`);
       this.logInfo('Importing Explore monuments...');
       const defaultLanguageId = await this.getDefaultLanguageIdAsync();
+      this.monumentResolver = new ExploreMonumentResolver({
+        legacyDb: this.context.legacyDb,
+        tracker: this.context.tracker,
+        getEntityUuid: (backwardCompatibility, entityType) =>
+          this.getEntityUuidAsync(backwardCompatibility, entityType),
+      });
 
       // Query monuments from legacy database
       const monuments = await this.context.legacyDb.query<ExploreLegacyMonument>(
@@ -102,9 +110,12 @@ export class ExploreMonumentImporter extends BaseImporter {
       for (const legacy of monuments) {
         try {
           const backwardCompat = `mwnf3_explore:monument:${legacy.monumentId}`;
+          const resolution = await this.monumentResolver.resolve(legacy.monumentId);
+          if (resolution.mode === 'missing-target' || resolution.mode === 'ambiguous') {
+            throw new Error(resolution.message ?? `Unable to resolve ${backwardCompat}`);
+          }
 
-          // Check if already exists
-          if (await this.entityExistsAsync(backwardCompat, 'item')) {
+          if (resolution.mode === 'native' && resolution.itemId) {
             result.skipped++;
             this.showSkipped();
             continue;
@@ -129,6 +140,36 @@ export class ExploreMonumentImporter extends BaseImporter {
             'success'
           );
 
+          const collectionId = transformed.locationId
+            ? await this.getLocationCollectionId(transformed.locationId)
+            : null;
+
+          if (resolution.mode === 'referenced') {
+            if (!resolution.itemId || !resolution.itemBackwardCompatibility) {
+              throw new Error(`Referenced monument ${backwardCompat} did not resolve to a target item`);
+            }
+
+            this.context.tracker.set(backwardCompat, resolution.itemId, 'item');
+
+            if (this.isDryRun || this.isSampleOnlyMode) {
+              this.logInfo(
+                `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would reuse source item ${resolution.itemBackwardCompatibility} for ${backwardCompat}`
+              );
+              this.registerEntity(resolution.itemId, backwardCompat, 'item');
+            } else if (collectionId) {
+              await this.context.strategy.writeCollectionItem({
+                collection_id: collectionId,
+                item_id: resolution.itemId,
+                backward_compatibility: `${backwardCompat}:collection_link:${transformed.locationId}`,
+                display_order: null,
+              });
+            }
+
+            result.imported++;
+            this.showProgress();
+            continue;
+          }
+
           if (this.isDryRun || this.isSampleOnlyMode) {
             this.logInfo(
               `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create item: ${transformed.data.internal_name} (${backwardCompat})`
@@ -150,16 +191,13 @@ export class ExploreMonumentImporter extends BaseImporter {
           this.registerEntity(itemId, backwardCompat, 'item');
 
           // Link item to location collection if available
-          if (transformed.locationId) {
-            const collectionId = await this.getLocationCollectionId(transformed.locationId);
-            if (collectionId) {
-              await this.context.strategy.writeCollectionItem({
-                collection_id: collectionId,
-                item_id: itemId,
-                backward_compatibility: `${backwardCompat}:collection_link:${transformed.locationId}`,
-                display_order: null,
-              });
-            }
+          if (collectionId) {
+            await this.context.strategy.writeCollectionItem({
+              collection_id: collectionId,
+              item_id: itemId,
+              backward_compatibility: `${backwardCompat}:collection_link:${transformed.locationId}`,
+              display_order: null,
+            });
           }
 
           result.imported++;

--- a/scripts/importer/src/importers/phase-06/explore-monument-picture-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-monument-picture-importer.ts
@@ -18,6 +18,7 @@ import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult, ItemImageData } from '../../core/types.js';
 import { convertHtmlToMarkdown } from '../../utils/html-to-markdown.js';
 import path from 'path';
+import { ExploreMonumentResolver } from './explore-monument-resolver.js';
 
 /**
  * Legacy monument picture structure
@@ -47,6 +48,8 @@ interface PictureGroup {
 }
 
 export class ExploreMonumentPictureImporter extends BaseImporter {
+  private monumentResolver!: ExploreMonumentResolver;
+
   getName(): string {
     return 'ExploreMonumentPictureImporter';
   }
@@ -56,6 +59,12 @@ export class ExploreMonumentPictureImporter extends BaseImporter {
 
     try {
       this.logInfo('Importing explore monument pictures...');
+      this.monumentResolver = new ExploreMonumentResolver({
+        legacyDb: this.context.legacyDb,
+        tracker: this.context.tracker,
+        getEntityUuid: (backwardCompatibility, entityType) =>
+          this.getEntityUuidAsync(backwardCompatibility, entityType),
+      });
 
       // Query all monument pictures
       const pictures = await this.context.legacyDb.query<LegacyMonumentPicture>(
@@ -139,10 +148,12 @@ export class ExploreMonumentPictureImporter extends BaseImporter {
     }
 
     // Find parent monument item
-    const monumentBackwardCompat = `mwnf3_explore:monument:${group.monumentId}`;
-    const itemId = await this.getEntityUuidAsync(monumentBackwardCompat, 'item');
-    if (!itemId) {
-      throw new Error(`Parent monument item not found: ${monumentBackwardCompat}`);
+    const monumentResolution = await this.monumentResolver.resolve(group.monumentId);
+    if (!monumentResolution.itemId || !monumentResolution.itemBackwardCompatibility) {
+      throw new Error(
+        monumentResolution.message ??
+          `Explore monument mwnf3_explore:monument:${group.monumentId} did not resolve to an item`
+      );
     }
 
     // Collect sample
@@ -161,7 +172,7 @@ export class ExploreMonumentPictureImporter extends BaseImporter {
     }
 
     // Calculate display_order for this item
-    const displayOrderKey = `explore_monument_picture_order:${itemId}`;
+    const displayOrderKey = `explore_monument_picture_order:${monumentResolution.itemId}`;
     const currentOrder = this.context.tracker.getMetadata(displayOrderKey);
     const displayOrder = currentOrder ? parseInt(currentOrder, 10) + 1 : 1;
     this.context.tracker.setMetadata(displayOrderKey, String(displayOrder));
@@ -193,7 +204,7 @@ export class ExploreMonumentPictureImporter extends BaseImporter {
 
     // Create ItemImage
     const imageData: ItemImageData = {
-      item_id: itemId,
+      item_id: monumentResolution.itemId,
       path: group.path,
       original_name: originalName,
       mime_type: mimeType,

--- a/scripts/importer/src/importers/phase-06/explore-monument-resolver.ts
+++ b/scripts/importer/src/importers/phase-06/explore-monument-resolver.ts
@@ -1,0 +1,381 @@
+import type { EntityType } from '../../core/types.js';
+import type { ILegacyDatabase } from '../../core/base-importer.js';
+import type { ITracker } from '../../core/tracker.js';
+
+type ReferenceSource = 'vm' | 'travels' | 'sharing-history';
+type ResolutionMode = 'native' | 'referenced' | 'missing-target' | 'ambiguous';
+
+interface ExploreMonumentRow {
+  monumentId: number;
+  REF_tr_monuments_project_id: string | null;
+  REF_tr_monuments_country: string | null;
+  REF_tr_monuments_itinerary_id: string | null;
+  REF_tr_monuments_location_id: string | null;
+  REF_tr_monuments_number: string | null;
+  REF_tr_monuments_lang: string | null;
+  REF_tr_monuments_trail_id: number | null;
+  REF_monuments_project_id: string | null;
+  REF_monuments_country: string | null;
+  REF_monuments_institution_id: string | null;
+  REF_monuments_number: number | null;
+  REF_monuments_lang: string | null;
+}
+
+interface ExploreVmReferenceRow {
+  monumentId: number;
+  REF_monuments_project_id: string;
+  REF_monuments_country: string;
+  REF_monuments_institution_id: string;
+  REF_monuments_number: number;
+}
+
+interface ExploreTravelsReferenceRow {
+  monumentId: number;
+  REF_tr_monuments_project_id: string;
+  REF_tr_monuments_country: string;
+  REF_tr_monuments_itinerary_id: string;
+  REF_tr_monuments_location_id: string;
+  REF_tr_monuments_number: string;
+  REF_tr_monuments_trail_id: number;
+}
+
+interface ExploreSharingHistoryReferenceRow {
+  monumentId: number;
+  project_id: string;
+  country: string;
+  number: number;
+}
+
+interface StoredResolutionCandidate {
+  source: ReferenceSource;
+  itemBackwardCompatibility: string;
+}
+
+interface StoredResolutionEntry {
+  monumentId: number;
+  nativeBackwardCompatibility: string;
+  candidates: StoredResolutionCandidate[];
+}
+
+export interface ExploreMonumentResolution {
+  monumentId: number;
+  mode: ResolutionMode;
+  nativeBackwardCompatibility: string;
+  itemBackwardCompatibility: string | null;
+  itemId: string | null;
+  source: ReferenceSource | 'native' | 'mixed';
+  message: string | null;
+}
+
+interface ExploreMonumentResolverOptions {
+  legacyDb: ILegacyDatabase;
+  tracker: ITracker;
+  getEntityUuid: (backwardCompatibility: string, entityType: EntityType) => Promise<string | null>;
+}
+
+const TRACKER_METADATA_KEY = 'explore_monument_resolution_map:v1';
+
+function hasText(value: string | null | undefined): value is string {
+  return value !== null && value !== undefined && value.trim() !== '';
+}
+
+function buildVmBackwardCompatibility(
+  projectId: string,
+  country: string,
+  institutionId: string,
+  number: number
+): string {
+  return `mwnf3:monuments:${projectId}:${country}:${institutionId}:${number}`;
+}
+
+function buildTravelsBackwardCompatibility(
+  projectId: string,
+  country: string,
+  trailId: number,
+  itineraryId: string,
+  locationId: string,
+  number: string
+): string {
+  return `mwnf3_travels:monument:${projectId}:${country}:${trailId}:${itineraryId}:${locationId}:${number}`;
+}
+
+function buildSharingHistoryBackwardCompatibility(
+  projectId: string,
+  country: string,
+  number: number
+): string {
+  return `mwnf3_sharing_history:sh_monuments:${projectId.toLowerCase()}:${country.toLowerCase()}:${number}`;
+}
+
+export class ExploreMonumentResolver {
+  private readonly legacyDb: ILegacyDatabase;
+  private readonly tracker: ITracker;
+  private readonly getEntityUuid: ExploreMonumentResolverOptions['getEntityUuid'];
+  private resolutionMapPromise: Promise<Map<number, StoredResolutionEntry>> | null = null;
+
+  constructor(options: ExploreMonumentResolverOptions) {
+    this.legacyDb = options.legacyDb;
+    this.tracker = options.tracker;
+    this.getEntityUuid = options.getEntityUuid;
+  }
+
+  async resolve(monumentId: number): Promise<ExploreMonumentResolution> {
+    const resolutionMap = await this.getResolutionMap();
+    const entry = resolutionMap.get(monumentId);
+    const nativeBackwardCompatibility = `mwnf3_explore:monument:${monumentId}`;
+
+    if (!entry || entry.candidates.length === 0) {
+      const itemId = await this.getEntityUuid(nativeBackwardCompatibility, 'item');
+
+      if (itemId) {
+        this.tracker.set(nativeBackwardCompatibility, itemId, 'item');
+      }
+
+      return {
+        monumentId,
+        mode: 'native',
+        nativeBackwardCompatibility,
+        itemBackwardCompatibility: nativeBackwardCompatibility,
+        itemId,
+        source: 'native',
+        message: null,
+      };
+    }
+
+    const resolvedCandidates: Array<StoredResolutionCandidate & { itemId: string | null }> = [];
+    for (const candidate of entry.candidates) {
+      const itemId = await this.getEntityUuid(candidate.itemBackwardCompatibility, 'item');
+      resolvedCandidates.push({
+        ...candidate,
+        itemId,
+      });
+    }
+
+    const successfulCandidates = resolvedCandidates.filter((candidate) => candidate.itemId !== null);
+    if (successfulCandidates.length === 1 && resolvedCandidates.length === 1) {
+      const resolvedCandidate = successfulCandidates[0]!;
+      this.tracker.set(nativeBackwardCompatibility, resolvedCandidate.itemId!, 'item');
+
+      return {
+        monumentId,
+        mode: 'referenced',
+        nativeBackwardCompatibility,
+        itemBackwardCompatibility: resolvedCandidate.itemBackwardCompatibility,
+        itemId: resolvedCandidate.itemId,
+        source: resolvedCandidate.source,
+        message: null,
+      };
+    }
+
+    if (successfulCandidates.length === 0) {
+      const missingTargets = resolvedCandidates.map((candidate) => candidate.itemBackwardCompatibility);
+      return {
+        monumentId,
+        mode: 'missing-target',
+        nativeBackwardCompatibility,
+        itemBackwardCompatibility: null,
+        itemId: null,
+        source: resolvedCandidates.length === 1 ? resolvedCandidates[0]!.source : 'mixed',
+        message: `Explore monument ${nativeBackwardCompatibility} references missing target item(s): ${missingTargets.join(', ')}`,
+      };
+    }
+
+    const ambiguousTargets = successfulCandidates.map((candidate) => candidate.itemBackwardCompatibility);
+    return {
+      monumentId,
+      mode: 'ambiguous',
+      nativeBackwardCompatibility,
+      itemBackwardCompatibility: null,
+      itemId: null,
+      source: 'mixed',
+      message: `Explore monument ${nativeBackwardCompatibility} resolves to multiple source items: ${ambiguousTargets.join(', ')}`,
+    };
+  }
+
+  private async getResolutionMap(): Promise<Map<number, StoredResolutionEntry>> {
+    if (this.resolutionMapPromise) {
+      return this.resolutionMapPromise;
+    }
+
+    this.resolutionMapPromise = (async () => {
+      const existing = this.tracker.getMetadata(TRACKER_METADATA_KEY);
+      if (existing) {
+        return this.deserializeResolutionMap(existing);
+      }
+
+      const resolutionMap = await this.buildResolutionMap();
+      this.tracker.setMetadata(
+        TRACKER_METADATA_KEY,
+        JSON.stringify(Array.from(resolutionMap.entries()))
+      );
+
+      return resolutionMap;
+    })();
+
+    return this.resolutionMapPromise;
+  }
+
+  private deserializeResolutionMap(serialized: string): Map<number, StoredResolutionEntry> {
+    const entries = JSON.parse(serialized) as Array<[number, StoredResolutionEntry]>;
+    return new Map(entries);
+  }
+
+  private async buildResolutionMap(): Promise<Map<number, StoredResolutionEntry>> {
+    const monuments = await this.legacyDb.query<ExploreMonumentRow>(
+      `SELECT monumentId,
+              REF_tr_monuments_project_id,
+              REF_tr_monuments_country,
+              REF_tr_monuments_itinerary_id,
+              REF_tr_monuments_location_id,
+              REF_tr_monuments_number,
+              REF_tr_monuments_lang,
+              REF_tr_monuments_trail_id,
+              REF_monuments_project_id,
+              REF_monuments_country,
+              REF_monuments_institution_id,
+              REF_monuments_number,
+              REF_monuments_lang
+       FROM mwnf3_explore.exploremonument`
+    );
+
+    const vmReferences = await this.legacyDb.query<ExploreVmReferenceRow>(
+      `SELECT monumentId,
+              REF_monuments_project_id,
+              REF_monuments_country,
+              REF_monuments_institution_id,
+              REF_monuments_number
+       FROM mwnf3_explore.exploremonument_vm`
+    );
+
+    const travelsReferences = await this.legacyDb.query<ExploreTravelsReferenceRow>(
+      `SELECT monumentId,
+              REF_tr_monuments_project_id,
+              REF_tr_monuments_country,
+              REF_tr_monuments_itinerary_id,
+              REF_tr_monuments_location_id,
+              REF_tr_monuments_number,
+              REF_tr_monuments_trail_id
+       FROM mwnf3_explore.exploremonument_tr`
+    );
+
+    const sharingHistoryReferences = await this.legacyDb.query<ExploreSharingHistoryReferenceRow>(
+      `SELECT monumentId, project_id, country, number
+       FROM mwnf3_explore.exploremonument_sh`
+    );
+
+    const resolutionMap = new Map<number, StoredResolutionEntry>();
+    for (const monument of monuments) {
+      resolutionMap.set(monument.monumentId, {
+        monumentId: monument.monumentId,
+        nativeBackwardCompatibility: `mwnf3_explore:monument:${monument.monumentId}`,
+        candidates: [],
+      });
+
+      this.pushDirectReferences(monument, resolutionMap.get(monument.monumentId)!);
+    }
+
+    for (const reference of vmReferences) {
+      this.pushCandidate(resolutionMap, reference.monumentId, {
+        source: 'vm',
+        itemBackwardCompatibility: buildVmBackwardCompatibility(
+          reference.REF_monuments_project_id,
+          reference.REF_monuments_country,
+          reference.REF_monuments_institution_id,
+          reference.REF_monuments_number
+        ),
+      });
+    }
+
+    for (const reference of travelsReferences) {
+      this.pushCandidate(resolutionMap, reference.monumentId, {
+        source: 'travels',
+        itemBackwardCompatibility: buildTravelsBackwardCompatibility(
+          reference.REF_tr_monuments_project_id,
+          reference.REF_tr_monuments_country,
+          reference.REF_tr_monuments_trail_id,
+          reference.REF_tr_monuments_itinerary_id,
+          reference.REF_tr_monuments_location_id,
+          reference.REF_tr_monuments_number
+        ),
+      });
+    }
+
+    for (const reference of sharingHistoryReferences) {
+      this.pushCandidate(resolutionMap, reference.monumentId, {
+        source: 'sharing-history',
+        itemBackwardCompatibility: buildSharingHistoryBackwardCompatibility(
+          reference.project_id,
+          reference.country,
+          reference.number
+        ),
+      });
+    }
+
+    return resolutionMap;
+  }
+
+  private pushDirectReferences(
+    monument: ExploreMonumentRow,
+    entry: StoredResolutionEntry
+  ): void {
+    if (
+      hasText(monument.REF_monuments_project_id) &&
+      hasText(monument.REF_monuments_country) &&
+      hasText(monument.REF_monuments_institution_id) &&
+      monument.REF_monuments_number !== null
+    ) {
+      entry.candidates.push({
+        source: 'vm',
+        itemBackwardCompatibility: buildVmBackwardCompatibility(
+          monument.REF_monuments_project_id,
+          monument.REF_monuments_country,
+          monument.REF_monuments_institution_id,
+          monument.REF_monuments_number
+        ),
+      });
+    }
+
+    if (
+      hasText(monument.REF_tr_monuments_project_id) &&
+      hasText(monument.REF_tr_monuments_country) &&
+      hasText(monument.REF_tr_monuments_itinerary_id) &&
+      hasText(monument.REF_tr_monuments_location_id) &&
+      hasText(monument.REF_tr_monuments_number) &&
+      monument.REF_tr_monuments_trail_id !== null
+    ) {
+      entry.candidates.push({
+        source: 'travels',
+        itemBackwardCompatibility: buildTravelsBackwardCompatibility(
+          monument.REF_tr_monuments_project_id,
+          monument.REF_tr_monuments_country,
+          monument.REF_tr_monuments_trail_id,
+          monument.REF_tr_monuments_itinerary_id,
+          monument.REF_tr_monuments_location_id,
+          monument.REF_tr_monuments_number
+        ),
+      });
+    }
+  }
+
+  private pushCandidate(
+    resolutionMap: Map<number, StoredResolutionEntry>,
+    monumentId: number,
+    candidate: StoredResolutionCandidate
+  ): void {
+    const entry = resolutionMap.get(monumentId) ?? {
+      monumentId,
+      nativeBackwardCompatibility: `mwnf3_explore:monument:${monumentId}`,
+      candidates: [],
+    };
+
+    if (
+      !entry.candidates.some(
+        (existingCandidate) => existingCandidate.itemBackwardCompatibility === candidate.itemBackwardCompatibility
+      )
+    ) {
+      entry.candidates.push(candidate);
+    }
+
+    resolutionMap.set(monumentId, entry);
+  }
+}

--- a/scripts/importer/src/importers/phase-06/explore-monument-theme-link-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-monument-theme-link-importer.ts
@@ -14,6 +14,7 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
+import { ExploreMonumentResolver } from './explore-monument-resolver.js';
 
 interface LegacyMonumentTheme {
   cycleId: number;
@@ -22,6 +23,8 @@ interface LegacyMonumentTheme {
 }
 
 export class ExploreMonumentThemeLinkImporter extends BaseImporter {
+  private monumentResolver!: ExploreMonumentResolver;
+
   getName(): string {
     return 'ExploreMonumentThemeLinkImporter';
   }
@@ -31,6 +34,12 @@ export class ExploreMonumentThemeLinkImporter extends BaseImporter {
 
     try {
       this.logInfo('Importing Explore monument-theme links...');
+      this.monumentResolver = new ExploreMonumentResolver({
+        legacyDb: this.context.legacyDb,
+        tracker: this.context.tracker,
+        getEntityUuid: (backwardCompatibility, entityType) =>
+          this.getEntityUuidAsync(backwardCompatibility, entityType),
+      });
 
       const links = await this.context.legacyDb.query<LegacyMonumentTheme>(
         `SELECT themeId AS cycleId, monumentId, locationId FROM mwnf3_explore.exploremonumentsthemes ORDER BY themeId, monumentId`
@@ -50,10 +59,11 @@ export class ExploreMonumentThemeLinkImporter extends BaseImporter {
           }
 
           // Resolve monument item
-          const monumentBC = `mwnf3_explore:monument:${link.monumentId}`;
-          const itemId = await this.getEntityUuidAsync(monumentBC, 'item');
-          if (!itemId) {
-            this.logWarning(`Monument item not found: ${monumentBC}, skipping link`);
+          const monumentResolution = await this.monumentResolver.resolve(link.monumentId);
+          if (!monumentResolution.itemId || !monumentResolution.itemBackwardCompatibility) {
+            this.logWarning(
+              `${monumentResolution.message ?? `Explore monument mwnf3_explore:monument:${link.monumentId} did not resolve to an item`}, skipping link`
+            );
             result.skipped++;
             this.showSkipped();
             continue;
@@ -71,7 +81,7 @@ export class ExploreMonumentThemeLinkImporter extends BaseImporter {
           const linkBC = `mwnf3_explore:monument_theme:${link.cycleId}:${link.monumentId}`;
           await this.context.strategy.writeCollectionItem({
             collection_id: collectionId,
-            item_id: itemId,
+            item_id: monumentResolution.itemId,
             backward_compatibility: linkBC,
           });
 

--- a/scripts/importer/src/importers/phase-06/explore-monument-translation-importer.ts
+++ b/scripts/importer/src/importers/phase-06/explore-monument-translation-importer.ts
@@ -25,6 +25,7 @@ import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
 import { AuthorHelper } from '../../helpers/author-helper.js';
 import { parseExplorePreparedBy } from '../../helpers/explore-prepared-by-parser.js';
+import { ExploreMonumentResolver } from './explore-monument-resolver.js';
 
 interface LegacyMonumentText {
   monumentId: number;
@@ -65,6 +66,7 @@ interface LegacyFurtherReading {
 export class ExploreMonumentTranslationImporter extends BaseImporter {
   private exploreContextId!: string;
   private authorHelper!: AuthorHelper;
+  private monumentResolver!: ExploreMonumentResolver;
 
   getName(): string {
     return 'ExploreMonumentTranslationImporter';
@@ -87,6 +89,12 @@ export class ExploreMonumentTranslationImporter extends BaseImporter {
         this.context.tracker,
         this.logger
       );
+      this.monumentResolver = new ExploreMonumentResolver({
+        legacyDb: this.context.legacyDb,
+        tracker: this.context.tracker,
+        getEntityUuid: (backwardCompatibility, entityType) =>
+          this.getEntityUuidAsync(backwardCompatibility, entityType),
+      });
 
       this.logInfo('Importing Explore monument translations...');
 
@@ -132,10 +140,11 @@ export class ExploreMonumentTranslationImporter extends BaseImporter {
             continue;
           }
 
-          const monumentBC = `mwnf3_explore:monument:${text.monumentId}`;
-          const itemId = await this.getEntityUuidAsync(monumentBC, 'item');
-          if (!itemId) {
-            this.logWarning(`Monument item not found: ${monumentBC}, skipping translation`);
+          const monumentResolution = await this.monumentResolver.resolve(text.monumentId);
+          if (!monumentResolution.itemId || !monumentResolution.itemBackwardCompatibility) {
+            this.logWarning(
+              `${monumentResolution.message ?? `Explore monument mwnf3_explore:monument:${text.monumentId} did not resolve to an item`}, skipping translation`
+            );
             result.skipped++;
             this.showSkipped();
             continue;
@@ -241,7 +250,7 @@ export class ExploreMonumentTranslationImporter extends BaseImporter {
           }
 
           await this.context.strategy.writeItemTranslation({
-            item_id: itemId,
+            item_id: monumentResolution.itemId,
             language_id: languageId,
             context_id: this.exploreContextId,
             backward_compatibility: translationBC,

--- a/scripts/importer/src/importers/phase-10/thg-gallery-explore-monument-importer.ts
+++ b/scripts/importer/src/importers/phase-10/thg-gallery-explore-monument-importer.ts
@@ -15,6 +15,7 @@
 
 import { BaseImporter } from '../../core/base-importer.js';
 import type { ImportResult } from '../../core/types.js';
+import { ExploreMonumentResolver } from '../phase-06/explore-monument-resolver.js';
 
 /**
  * Legacy thg_gallery_explore_monuments structure
@@ -25,6 +26,8 @@ interface LegacyThgGalleryExploreMonument {
 }
 
 export class ThgGalleryExploreMonumentImporter extends BaseImporter {
+  private monumentResolver!: ExploreMonumentResolver;
+
   getName(): string {
     return 'ThgGalleryExploreMonumentImporter';
   }
@@ -34,6 +37,12 @@ export class ThgGalleryExploreMonumentImporter extends BaseImporter {
 
     try {
       this.logInfo('Importing THG gallery -> Explore monument associations...');
+      this.monumentResolver = new ExploreMonumentResolver({
+        legacyDb: this.context.legacyDb,
+        tracker: this.context.tracker,
+        getEntityUuid: (backwardCompatibility, entityType) =>
+          this.getEntityUuidAsync(backwardCompatibility, entityType),
+      });
 
       // Query thg_gallery_explore_monuments entries from legacy database
       let galleryMonuments: LegacyThgGalleryExploreMonument[];
@@ -71,14 +80,11 @@ export class ThgGalleryExploreMonumentImporter extends BaseImporter {
         try {
           // Build backward_compatibility for the Explore monument
           // Format matches Phase 6 Explore monument importer: mwnf3_explore:monument:{item_id}
-          const itemBackwardCompat = `mwnf3_explore:monument:${legacy.item_id}`;
-
-          // Get the item ID from tracker or database (items are from earlier phases)
-          const itemId = await this.getEntityUuidAsync(itemBackwardCompat, 'item');
-          if (!itemId) {
+          const monumentResolution = await this.monumentResolver.resolve(legacy.item_id);
+          if (!monumentResolution.itemId || !monumentResolution.itemBackwardCompatibility) {
             result.warnings = result.warnings || [];
             result.warnings.push(
-              `Gallery ${legacy.gallery_id}: Explore monument not found (${itemBackwardCompat})`
+              `Gallery ${legacy.gallery_id}: ${monumentResolution.message ?? `Explore monument mwnf3_explore:monument:${legacy.item_id} did not resolve to an item`}`
             );
             skippedNoItem++;
             continue;
@@ -101,8 +107,8 @@ export class ThgGalleryExploreMonumentImporter extends BaseImporter {
             collectionItems.set(collectionId, []);
           }
           const items = collectionItems.get(collectionId)!;
-          if (!items.includes(itemId)) {
-            items.push(itemId);
+          if (!items.includes(monumentResolution.itemId)) {
+            items.push(monumentResolution.itemId);
           }
 
           // Collect sample
@@ -110,7 +116,7 @@ export class ThgGalleryExploreMonumentImporter extends BaseImporter {
             'thg_gallery_explore_monument',
             {
               ...legacy,
-              resolved_item_backward_compat: itemBackwardCompat,
+              resolved_item_backward_compat: monumentResolution.itemBackwardCompatibility,
             } as unknown as Record<string, unknown>,
             'success'
           );

--- a/scripts/importer/src/strategies/sql-strategy.ts
+++ b/scripts/importer/src/strategies/sql-strategy.ts
@@ -292,7 +292,11 @@ export class SqlWriteStrategy implements IWriteStrategy {
     const extra = data.extra ? JSON.stringify(data.extra) : null;
     await this.db.execute(
       `INSERT INTO collection_item (collection_id, item_id, display_order, extra, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         display_order = VALUES(display_order),
+         extra = VALUES(extra),
+         updated_at = VALUES(updated_at)`,
       [sanitized.collection_id, sanitized.item_id, displayOrder, extra, this.now, this.now]
     );
   }

--- a/scripts/importer/tests/unit/explore-itinerary-content-importer.test.ts
+++ b/scripts/importer/tests/unit/explore-itinerary-content-importer.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExploreItineraryContentImporter } from '../../src/importers/phase-06/explore-itinerary-content-importer.js';
+import { UnifiedTracker } from '../../src/core/tracker.js';
+import type { ImportContext, ILegacyDatabase, ILogger } from '../../src/core/base-importer.js';
+import type { IWriteStrategy } from '../../src/core/strategy.js';
+
+describe('ExploreItineraryContentImporter', () => {
+  let tracker: UnifiedTracker;
+  let legacyDb: ILegacyDatabase;
+  let strategy: IWriteStrategy;
+  let context: ImportContext;
+  let queryMock: ReturnType<typeof vi.fn>;
+  let writeCollectionTranslationMock: ReturnType<typeof vi.fn>;
+  let writeCollectionItemMock: ReturnType<typeof vi.fn>;
+
+  const logger: ILogger = {
+    info: vi.fn(),
+    warning: vi.fn(),
+    skip: vi.fn(),
+    error: vi.fn(),
+    exception: vi.fn(),
+    showProgress: vi.fn(),
+    showSkipped: vi.fn(),
+    showError: vi.fn(),
+    showSummary: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    tracker = new UnifiedTracker();
+    tracker.set('mwnf3_explore:context', 'explore-context-uuid', 'context');
+    tracker.set('mwnf3_explore:root:explore_by_itinerary', 'explore-by-itinerary-root', 'collection');
+    tracker.set('mwnf3_explore:itinerary:7', 'itinerary-7-uuid', 'collection');
+    tracker.set('mwnf3_explore:itinerary:8', 'itinerary-8-uuid', 'collection');
+    tracker.set('en', 'eng', 'language');
+    tracker.set('mwnf3_travels:monument:IAM:pt:1:I:1:b', 'resolved-travel-monument-uuid', 'item');
+
+    queryMock = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM mwnf3_explore.explore_itineraries_langs')) {
+        return [
+          {
+            itineraries_id: 7,
+            langId: 'en',
+            title: 'The Seat of the Sultanate',
+            introduction: '',
+            duration: 'One day',
+            local_team: '',
+            author: null,
+            introd_type: 'ET-short#-',
+            et_title: 'IAM;eg;I;en;1',
+            et_introduction: '',
+          },
+          {
+            itineraries_id: 8,
+            langId: 'en',
+            title: null,
+            introduction: '',
+            duration: null,
+            local_team: '',
+            author: null,
+            introd_type: null,
+            et_title: null,
+            et_introduction: null,
+          },
+        ];
+      }
+
+      if (sql.includes('FROM mwnf3_travels.tr_itineraries')) {
+        return [
+          {
+            description:
+              'When Salah al-Din al-Ayyubi had his Citadel built, his desire was for it to be both a defensive fortress and the seat of the Sultanate.',
+          },
+        ];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.explore_itineraries_rel_monuments')) {
+        return [
+          {
+            itineraries_id: 7,
+            monumentId: 150,
+            mn_order: 6,
+            desc_types: null,
+            explore_mn_desc: null,
+            tr_mn_desc: null,
+            vm_mn_desc: null,
+          },
+        ];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument_tr')) {
+        return [
+          {
+            monumentId: 150,
+            REF_tr_monuments_project_id: 'IAM',
+            REF_tr_monuments_country: 'pt',
+            REF_tr_monuments_itinerary_id: 'I',
+            REF_tr_monuments_location_id: '1',
+            REF_tr_monuments_number: 'b',
+            REF_tr_monuments_trail_id: 1,
+          },
+        ];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument_vm')) {
+        return [];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument_sh')) {
+        return [];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument')) {
+        return [
+          {
+            monumentId: 150,
+            REF_tr_monuments_project_id: null,
+            REF_tr_monuments_country: null,
+            REF_tr_monuments_itinerary_id: null,
+            REF_tr_monuments_location_id: null,
+            REF_tr_monuments_number: null,
+            REF_tr_monuments_lang: null,
+            REF_tr_monuments_trail_id: null,
+            REF_monuments_project_id: null,
+            REF_monuments_country: null,
+            REF_monuments_institution_id: null,
+            REF_monuments_number: null,
+            REF_monuments_lang: null,
+          },
+        ];
+      }
+
+      return [];
+    });
+
+    legacyDb = {
+      query: queryMock as ILegacyDatabase['query'],
+      execute: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+
+    writeCollectionTranslationMock = vi.fn().mockResolvedValue(undefined);
+    writeCollectionItemMock = vi.fn().mockResolvedValue(undefined);
+
+    strategy = {
+      exists: vi.fn().mockResolvedValue(false),
+      findByBackwardCompatibility: vi.fn().mockResolvedValue(null),
+      writeCollectionTranslation: writeCollectionTranslationMock,
+      writeCollectionItem: writeCollectionItemMock,
+      getCollectionTranslationExtra: vi.fn().mockResolvedValue(null),
+      setCollectionTranslationExtra: vi.fn().mockResolvedValue(undefined),
+    } as unknown as IWriteStrategy;
+
+    context = {
+      legacyDb,
+      strategy,
+      tracker,
+      logger,
+      dryRun: false,
+    };
+  });
+
+  it('imports the real itinerary title and falls back to the linked Travels description when Explore introduction is empty', async () => {
+    const importer = new ExploreItineraryContentImporter(context);
+    const result = await importer.import();
+
+    expect(writeCollectionTranslationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection_id: 'itinerary-7-uuid',
+        title: 'The Seat of the Sultanate',
+        description:
+          'When Salah al-Din al-Ayyubi had his Citadel built, his desire was for it to be both a defensive fortress and the seat of the Sultanate.',
+        extra: expect.stringContaining('One day'),
+      })
+    );
+    expect(logger.warning).toHaveBeenCalledWith(
+      'Explore itinerary mwnf3_explore:itinerary:8 is missing a required source title for en, skipping translation',
+      undefined
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('uses the resolved source item for itinerary membership instead of an Explore shell item', async () => {
+    const importer = new ExploreItineraryContentImporter(context);
+    await importer.import();
+
+    expect(writeCollectionItemMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection_id: 'itinerary-7-uuid',
+        item_id: 'resolved-travel-monument-uuid',
+        backward_compatibility: 'mwnf3_explore:itinerary_monument:7:150',
+        display_order: 6,
+      })
+    );
+  });
+});

--- a/scripts/importer/tests/unit/explore-monument-importer.test.ts
+++ b/scripts/importer/tests/unit/explore-monument-importer.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExploreMonumentImporter } from '../../src/importers/phase-06/explore-monument-importer.js';
+import { UnifiedTracker } from '../../src/core/tracker.js';
+import type { ImportContext, ILegacyDatabase, ILogger } from '../../src/core/base-importer.js';
+import type { IWriteStrategy } from '../../src/core/strategy.js';
+
+describe('ExploreMonumentImporter', () => {
+  let tracker: UnifiedTracker;
+  let legacyDb: ILegacyDatabase;
+  let strategy: IWriteStrategy;
+  let context: ImportContext;
+  let queryMock: ReturnType<typeof vi.fn>;
+  let writeItemMock: ReturnType<typeof vi.fn>;
+  let writeCollectionItemMock: ReturnType<typeof vi.fn>;
+
+  const logger: ILogger = {
+    info: vi.fn(),
+    warning: vi.fn(),
+    skip: vi.fn(),
+    error: vi.fn(),
+    exception: vi.fn(),
+    showProgress: vi.fn(),
+    showSkipped: vi.fn(),
+    showError: vi.fn(),
+    showSummary: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    tracker = new UnifiedTracker();
+    tracker.set('mwnf3_explore:context', 'explore-context-uuid', 'context');
+    tracker.set('mwnf3_explore:location:2', 'location-collection-uuid', 'collection');
+    tracker.set('mwnf3:monuments:IAM:eg:Mus01:5', 'canonical-item-uuid', 'item');
+    tracker.setMetadata('default_language_id', 'eng');
+
+    queryMock = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM mwnf3_explore.exploremonument_vm')) {
+        return [
+          {
+            monumentId: 123,
+            REF_monuments_project_id: 'IAM',
+            REF_monuments_country: 'eg',
+            REF_monuments_institution_id: 'Mus01',
+            REF_monuments_number: 5,
+          },
+        ];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument_tr')) {
+        return [];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument_sh')) {
+        return [];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonumentext')) {
+        return [
+          {
+            monumentId: 123,
+            langId: 'en',
+            name: 'Referenced monument',
+          },
+        ];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument')) {
+        return [
+          {
+            monumentId: 123,
+            locationId: 2,
+            title: 'Referenced monument',
+            geoCoordinates: null,
+            zoom: null,
+            special_monument: null,
+            related_monument: null,
+            REF_tr_monuments_project_id: null,
+            REF_tr_monuments_country: null,
+            REF_tr_monuments_itinerary_id: null,
+            REF_tr_monuments_location_id: null,
+            REF_tr_monuments_number: null,
+            REF_tr_monuments_lang: null,
+            REF_tr_monuments_trail_id: null,
+            REF_monuments_project_id: null,
+            REF_monuments_country: null,
+            REF_monuments_institution_id: null,
+            REF_monuments_number: null,
+            REF_monuments_lang: null,
+          },
+        ];
+      }
+
+      return [];
+    });
+
+    legacyDb = {
+      query: queryMock as ILegacyDatabase['query'],
+      execute: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+
+    writeItemMock = vi.fn();
+    writeCollectionItemMock = vi.fn().mockResolvedValue(undefined);
+
+    strategy = {
+      exists: vi.fn().mockResolvedValue(false),
+      findByBackwardCompatibility: vi.fn().mockResolvedValue(null),
+      writeItem: writeItemMock,
+      writeCollectionItem: writeCollectionItemMock,
+    } as unknown as IWriteStrategy;
+
+    context = {
+      legacyDb,
+      strategy,
+      tracker,
+      logger,
+      dryRun: false,
+    };
+  });
+
+  it('reuses the canonical source item for referenced Explore monuments instead of creating a shell item', async () => {
+    const importer = new ExploreMonumentImporter(context);
+    const result = await importer.import();
+
+    expect(writeItemMock).not.toHaveBeenCalled();
+    expect(writeCollectionItemMock).toHaveBeenCalledWith({
+      collection_id: 'location-collection-uuid',
+      item_id: 'canonical-item-uuid',
+      backward_compatibility: 'mwnf3_explore:monument:123:collection_link:2',
+      display_order: null,
+    });
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(1);
+  });
+});

--- a/scripts/importer/tests/unit/explore-monument-resolution.test.ts
+++ b/scripts/importer/tests/unit/explore-monument-resolution.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UnifiedTracker } from '../../src/core/tracker.js';
+import type { ILegacyDatabase } from '../../src/core/base-importer.js';
+import { ExploreMonumentResolver } from '../../src/importers/phase-06/explore-monument-resolver.js';
+
+describe('ExploreMonumentResolver', () => {
+  let tracker: UnifiedTracker;
+  let legacyDb: ILegacyDatabase;
+  let queryMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    tracker = new UnifiedTracker();
+
+    queryMock = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM mwnf3_explore.exploremonument_vm')) {
+        return [
+          {
+            monumentId: 200,
+            REF_monuments_project_id: 'IAM',
+            REF_monuments_country: 'eg',
+            REF_monuments_institution_id: 'Mus01',
+            REF_monuments_number: 5,
+          },
+          {
+            monumentId: 500,
+            REF_monuments_project_id: 'IAM',
+            REF_monuments_country: 'eg',
+            REF_monuments_institution_id: 'Mus01',
+            REF_monuments_number: 7,
+          },
+        ];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument_tr')) {
+        return [
+          {
+            monumentId: 300,
+            REF_tr_monuments_project_id: 'IAM',
+            REF_tr_monuments_country: 'pt',
+            REF_tr_monuments_itinerary_id: 'I',
+            REF_tr_monuments_location_id: '1',
+            REF_tr_monuments_number: 'b',
+            REF_tr_monuments_trail_id: 1,
+          },
+          {
+            monumentId: 500,
+            REF_tr_monuments_project_id: 'IAM',
+            REF_tr_monuments_country: 'pt',
+            REF_tr_monuments_itinerary_id: 'I',
+            REF_tr_monuments_location_id: '1',
+            REF_tr_monuments_number: 'c',
+            REF_tr_monuments_trail_id: 1,
+          },
+        ];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument_sh')) {
+        return [
+          {
+            monumentId: 400,
+            project_id: 'AWE',
+            country: 'pt',
+            number: 9,
+          },
+        ];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument')) {
+        return [
+          {
+            monumentId: 100,
+            REF_tr_monuments_project_id: null,
+            REF_tr_monuments_country: null,
+            REF_tr_monuments_itinerary_id: null,
+            REF_tr_monuments_location_id: null,
+            REF_tr_monuments_number: null,
+            REF_tr_monuments_lang: null,
+            REF_tr_monuments_trail_id: null,
+            REF_monuments_project_id: null,
+            REF_monuments_country: null,
+            REF_monuments_institution_id: null,
+            REF_monuments_number: null,
+            REF_monuments_lang: null,
+          },
+          {
+            monumentId: 200,
+            REF_tr_monuments_project_id: null,
+            REF_tr_monuments_country: null,
+            REF_tr_monuments_itinerary_id: null,
+            REF_tr_monuments_location_id: null,
+            REF_tr_monuments_number: null,
+            REF_tr_monuments_lang: null,
+            REF_tr_monuments_trail_id: null,
+            REF_monuments_project_id: null,
+            REF_monuments_country: null,
+            REF_monuments_institution_id: null,
+            REF_monuments_number: null,
+            REF_monuments_lang: null,
+          },
+          {
+            monumentId: 300,
+            REF_tr_monuments_project_id: null,
+            REF_tr_monuments_country: null,
+            REF_tr_monuments_itinerary_id: null,
+            REF_tr_monuments_location_id: null,
+            REF_tr_monuments_number: null,
+            REF_tr_monuments_lang: null,
+            REF_tr_monuments_trail_id: null,
+            REF_monuments_project_id: null,
+            REF_monuments_country: null,
+            REF_monuments_institution_id: null,
+            REF_monuments_number: null,
+            REF_monuments_lang: null,
+          },
+          {
+            monumentId: 400,
+            REF_tr_monuments_project_id: null,
+            REF_tr_monuments_country: null,
+            REF_tr_monuments_itinerary_id: null,
+            REF_tr_monuments_location_id: null,
+            REF_tr_monuments_number: null,
+            REF_tr_monuments_lang: null,
+            REF_tr_monuments_trail_id: null,
+            REF_monuments_project_id: null,
+            REF_monuments_country: null,
+            REF_monuments_institution_id: null,
+            REF_monuments_number: null,
+            REF_monuments_lang: null,
+          },
+          {
+            monumentId: 500,
+            REF_tr_monuments_project_id: null,
+            REF_tr_monuments_country: null,
+            REF_tr_monuments_itinerary_id: null,
+            REF_tr_monuments_location_id: null,
+            REF_tr_monuments_number: null,
+            REF_tr_monuments_lang: null,
+            REF_tr_monuments_trail_id: null,
+            REF_monuments_project_id: null,
+            REF_monuments_country: null,
+            REF_monuments_institution_id: null,
+            REF_monuments_number: null,
+            REF_monuments_lang: null,
+          },
+          {
+            monumentId: 600,
+            REF_tr_monuments_project_id: null,
+            REF_tr_monuments_country: null,
+            REF_tr_monuments_itinerary_id: null,
+            REF_tr_monuments_location_id: null,
+            REF_tr_monuments_number: null,
+            REF_tr_monuments_lang: null,
+            REF_tr_monuments_trail_id: null,
+            REF_monuments_project_id: 'IAM',
+            REF_monuments_country: 'eg',
+            REF_monuments_institution_id: 'Mus01',
+            REF_monuments_number: 8,
+            REF_monuments_lang: 'en',
+          },
+        ];
+      }
+
+      return [];
+    });
+
+    legacyDb = {
+      query: queryMock as ILegacyDatabase['query'],
+      execute: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+
+    tracker.set('mwnf3:monuments:IAM:eg:Mus01:5', 'vm-item-uuid', 'item');
+    tracker.set('mwnf3_travels:monument:IAM:pt:1:I:1:b', 'travels-item-uuid', 'item');
+    tracker.set('mwnf3_sharing_history:sh_monuments:awe:pt:9', 'sh-item-uuid', 'item');
+    tracker.set('mwnf3:monuments:IAM:eg:Mus01:7', 'vm-ambiguous-item-uuid', 'item');
+    tracker.set('mwnf3_travels:monument:IAM:pt:1:I:1:c', 'travels-ambiguous-item-uuid', 'item');
+    tracker.set('mwnf3:monuments:IAM:eg:Mus01:8', 'vm-direct-item-uuid', 'item');
+  });
+
+  it('resolves native, referenced, missing-target, and ambiguous monuments from verified link tables', async () => {
+    const resolver = new ExploreMonumentResolver({
+      legacyDb,
+      tracker,
+      getEntityUuid: async (backwardCompatibility, entityType) =>
+        tracker.getUuid(backwardCompatibility, entityType),
+    });
+
+    await expect(resolver.resolve(100)).resolves.toMatchObject({
+      mode: 'native',
+      itemBackwardCompatibility: 'mwnf3_explore:monument:100',
+    });
+
+    await expect(resolver.resolve(200)).resolves.toMatchObject({
+      mode: 'referenced',
+      source: 'vm',
+      itemBackwardCompatibility: 'mwnf3:monuments:IAM:eg:Mus01:5',
+      itemId: 'vm-item-uuid',
+    });
+
+    await expect(resolver.resolve(300)).resolves.toMatchObject({
+      mode: 'referenced',
+      source: 'travels',
+      itemBackwardCompatibility: 'mwnf3_travels:monument:IAM:pt:1:I:1:b',
+      itemId: 'travels-item-uuid',
+    });
+
+    await expect(resolver.resolve(400)).resolves.toMatchObject({
+      mode: 'referenced',
+      source: 'sharing-history',
+      itemBackwardCompatibility: 'mwnf3_sharing_history:sh_monuments:awe:pt:9',
+      itemId: 'sh-item-uuid',
+    });
+
+    await expect(resolver.resolve(500)).resolves.toMatchObject({
+      mode: 'ambiguous',
+      itemId: null,
+    });
+
+    await expect(resolver.resolve(600)).resolves.toMatchObject({
+      mode: 'referenced',
+      source: 'vm',
+      itemBackwardCompatibility: 'mwnf3:monuments:IAM:eg:Mus01:8',
+      itemId: 'vm-direct-item-uuid',
+    });
+  });
+
+  it('reports missing targets explicitly when reference rows do not resolve to a source item', async () => {
+    tracker = new UnifiedTracker();
+    legacyDb = {
+      query: vi.fn(async (sql: string) => {
+        if (sql.includes('FROM mwnf3_explore.exploremonument_vm')) {
+          return [
+            {
+              monumentId: 700,
+              REF_monuments_project_id: 'IAM',
+              REF_monuments_country: 'eg',
+              REF_monuments_institution_id: 'Mus01',
+              REF_monuments_number: 99,
+            },
+          ];
+        }
+
+        if (sql.includes('FROM mwnf3_explore.exploremonument_tr')) {
+          return [];
+        }
+
+        if (sql.includes('FROM mwnf3_explore.exploremonument_sh')) {
+          return [];
+        }
+
+        if (sql.includes('FROM mwnf3_explore.exploremonument')) {
+          return [
+            {
+              monumentId: 700,
+              REF_tr_monuments_project_id: null,
+              REF_tr_monuments_country: null,
+              REF_tr_monuments_itinerary_id: null,
+              REF_tr_monuments_location_id: null,
+              REF_tr_monuments_number: null,
+              REF_tr_monuments_lang: null,
+              REF_tr_monuments_trail_id: null,
+              REF_monuments_project_id: null,
+              REF_monuments_country: null,
+              REF_monuments_institution_id: null,
+              REF_monuments_number: null,
+              REF_monuments_lang: null,
+            },
+          ];
+        }
+
+        return [];
+      }) as ILegacyDatabase['query'],
+      execute: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+
+    const resolver = new ExploreMonumentResolver({
+      legacyDb,
+      tracker,
+      getEntityUuid: async () => null,
+    });
+
+    await expect(resolver.resolve(700)).resolves.toMatchObject({
+      mode: 'missing-target',
+      itemId: null,
+    });
+  });
+});

--- a/scripts/importer/tests/unit/explore-monument-translation-importer.test.ts
+++ b/scripts/importer/tests/unit/explore-monument-translation-importer.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExploreMonumentTranslationImporter } from '../../src/importers/phase-06/explore-monument-translation-importer.js';
+import { UnifiedTracker } from '../../src/core/tracker.js';
+import type { ImportContext, ILegacyDatabase, ILogger } from '../../src/core/base-importer.js';
+import type { IWriteStrategy } from '../../src/core/strategy.js';
+
+describe('ExploreMonumentTranslationImporter', () => {
+  let tracker: UnifiedTracker;
+  let legacyDb: ILegacyDatabase;
+  let strategy: IWriteStrategy;
+  let context: ImportContext;
+  let queryMock: ReturnType<typeof vi.fn>;
+  let writeItemTranslationMock: ReturnType<typeof vi.fn>;
+
+  const logger: ILogger = {
+    info: vi.fn(),
+    warning: vi.fn(),
+    skip: vi.fn(),
+    error: vi.fn(),
+    exception: vi.fn(),
+    showProgress: vi.fn(),
+    showSkipped: vi.fn(),
+    showError: vi.fn(),
+    showSummary: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    tracker = new UnifiedTracker();
+    tracker.set('mwnf3_explore:context', 'explore-context-uuid', 'context');
+    tracker.set('en', 'eng', 'language');
+    tracker.set('mwnf3_travels:monument:IAM:pt:1:I:1:b', 'canonical-travel-item-uuid', 'item');
+
+    queryMock = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM mwnf3_explore.exploremonument_tr')) {
+        return [
+          {
+            monumentId: 150,
+            REF_tr_monuments_project_id: 'IAM',
+            REF_tr_monuments_country: 'pt',
+            REF_tr_monuments_itinerary_id: 'I',
+            REF_tr_monuments_location_id: '1',
+            REF_tr_monuments_number: 'b',
+            REF_tr_monuments_trail_id: 1,
+          },
+        ];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument_vm')) {
+        return [];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument_sh')) {
+        return [];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonumentext')) {
+        return [
+          {
+            monumentId: 150,
+            langId: 'en',
+            name: 'Travel-linked monument',
+            description: 'Explore description',
+            related_bibliography: null,
+            date: null,
+            styles: null,
+            prepared_by: null,
+            how_to_reach: null,
+            info: null,
+            contact: null,
+            history: null,
+            note: null,
+            abstract: null,
+            further_reading: null,
+            url_prog_pdf: null,
+            pdf_text: null,
+            url_prog_doc: null,
+            institution: null,
+            address: null,
+            phone: null,
+            fax: null,
+            email: null,
+            website: null,
+          },
+        ];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument_further_reading')) {
+        return [];
+      }
+
+      if (sql.includes('FROM mwnf3_explore.exploremonument')) {
+        return [
+          {
+            monumentId: 150,
+            REF_tr_monuments_project_id: null,
+            REF_tr_monuments_country: null,
+            REF_tr_monuments_itinerary_id: null,
+            REF_tr_monuments_location_id: null,
+            REF_tr_monuments_number: null,
+            REF_tr_monuments_lang: null,
+            REF_tr_monuments_trail_id: null,
+            REF_monuments_project_id: null,
+            REF_monuments_country: null,
+            REF_monuments_institution_id: null,
+            REF_monuments_number: null,
+            REF_monuments_lang: null,
+          },
+        ];
+      }
+
+      return [];
+    });
+
+    legacyDb = {
+      query: queryMock as ILegacyDatabase['query'],
+      execute: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+
+    writeItemTranslationMock = vi.fn().mockResolvedValue(undefined);
+
+    strategy = {
+      exists: vi.fn().mockResolvedValue(false),
+      findByBackwardCompatibility: vi.fn().mockResolvedValue(null),
+      writeItemTranslation: writeItemTranslationMock,
+    } as unknown as IWriteStrategy;
+
+    context = {
+      legacyDb,
+      strategy,
+      tracker,
+      logger,
+      dryRun: false,
+    };
+  });
+
+  it('writes Explore-context text onto the resolved source item for referenced monuments', async () => {
+    const importer = new ExploreMonumentTranslationImporter(context);
+    const result = await importer.import();
+
+    expect(writeItemTranslationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        item_id: 'canonical-travel-item-uuid',
+        context_id: 'explore-context-uuid',
+        backward_compatibility: 'mwnf3_explore:monument:150:translation:eng',
+        name: 'Travel-linked monument',
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.imported).toBe(1);
+  });
+});


### PR DESCRIPTION
- Added ExploreMonumentResolver to ExploreMonumentThemeLinkImporter and ExploreMonumentTranslationImporter for improved monument resolution.
- Updated SQL strategy to handle duplicate key updates for collection items.
- Introduced unit tests for ExploreItineraryContentImporter, ExploreMonumentImporter, ExploreMonumentTranslationImporter, and ExploreMonumentResolver to ensure correct functionality and resolution logic.
- Enhanced error handling for missing targets in monument resolution.

Fixes #1059
Fixes #1060
Fixes #1061