### PR TITLE
Implement admin password reset flow with MFA confirmation

### DIFF
--- a/app/Filament/Auth/PasswordResetMfaChallenge.php
+++ b/app/Filament/Auth/PasswordResetMfaChallenge.php
@@ -210,6 +210,7 @@ class PasswordResetMfaChallenge extends SimplePage
             ->success()
             ->send();
 
+        Filament::auth()->logout();
         $this->redirect(Filament::getLoginUrl());
     }
 

--- a/app/Filament/Auth/RequestPasswordReset.php
+++ b/app/Filament/Auth/RequestPasswordReset.php
@@ -2,6 +2,8 @@
 
 namespace App\Filament\Auth;
 
+use App\Models\User;
+use App\Notifications\AdminPasswordResetNotification;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use DanHarrin\LivewireRateLimiting\WithRateLimiting;
 use Filament\Actions\Action;
@@ -81,7 +83,12 @@ class RequestPasswordReset extends SimplePage
 
         $data = $this->form->getState();
 
-        Password::broker(config('fortify.passwords'))->sendResetLink(['email' => $data['email']]);
+        $user = User::query()->where('email', $data['email'])->first();
+
+        if ($user) {
+            $token = Password::broker(config('fortify.passwords'))->createToken($user);
+            $user->notify(new AdminPasswordResetNotification($token));
+        }
 
         Notification::make()
             ->title(__('If an account exists for that email, we have sent a password reset link.'))

--- a/app/Filament/Auth/ResetPassword.php
+++ b/app/Filament/Auth/ResetPassword.php
@@ -131,6 +131,7 @@ class ResetPassword extends SimplePage
                 ->success()
                 ->send();
 
+            Filament::auth()->logout();
             $this->redirect(Filament::getLoginUrl());
 
             return;

--- a/app/Notifications/AdminPasswordResetNotification.php
+++ b/app/Notifications/AdminPasswordResetNotification.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\ResetPassword;
+
+class AdminPasswordResetNotification extends ResetPassword
+{
+    /**
+     * Get the password reset URL for the given notifiable.
+     */
+    protected function resetUrl($notifiable): string
+    {
+        return route('filament.admin.auth.password.reset', [
+            'token' => $this->token,
+            'email' => $notifiable->getEmailForPasswordReset(),
+        ]);
+    }
+}

--- a/tests/Filament/Pages/PasswordResetTest.php
+++ b/tests/Filament/Pages/PasswordResetTest.php
@@ -7,10 +7,11 @@ use App\Filament\Auth\PasswordResetMfaChallenge;
 use App\Filament\Auth\RequestPasswordReset;
 use App\Filament\Auth\ResetPassword;
 use App\Models\User;
+use App\Notifications\AdminPasswordResetNotification;
 use Filament\Facades\Filament;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Password;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -46,7 +47,7 @@ class PasswordResetTest extends TestCase
 
     public function test_reset_link_is_dispatched_for_existing_email(): void
     {
-        Mail::fake();
+        Notification::fake();
 
         $user = User::factory()->create(['email' => 'user@example.com']);
 
@@ -54,6 +55,23 @@ class PasswordResetTest extends TestCase
             ->set('data.email', 'user@example.com')
             ->call('submit')
             ->assertHasNoErrors();
+
+        Notification::assertSentTo($user, AdminPasswordResetNotification::class);
+    }
+
+    public function test_admin_reset_link_targets_filament_route_not_web_route(): void
+    {
+        $user = User::factory()->create(['email' => 'user@example.com']);
+        $notification = new AdminPasswordResetNotification('admin-reset-token');
+
+        $mailMessage = $notification->toMail($user);
+        $expectedUrl = route('filament.admin.auth.password.reset', [
+            'token' => 'admin-reset-token',
+            'email' => 'user@example.com',
+        ]);
+
+        $this->assertSame($expectedUrl, $mailMessage->actionUrl);
+        $this->assertStringNotContainsString('/web/', $mailMessage->actionUrl);
     }
 
     public function test_reset_link_submission_shows_success_notification_even_for_unknown_email(): void
@@ -115,6 +133,7 @@ class PasswordResetTest extends TestCase
             ->assertRedirect(Filament::getLoginUrl());
 
         $this->assertTrue(Hash::check('NewPassword1!', $user->fresh()->password));
+        $this->assertGuest(config('fortify.guard'));
     }
 
     public function test_reset_password_token_is_invalidated_after_successful_reset_without_mfa(): void
@@ -202,6 +221,7 @@ class PasswordResetTest extends TestCase
             ->assertRedirect(Filament::getLoginUrl());
 
         $this->assertEquals($newPasswordHash, $user->fresh()->password);
+        $this->assertGuest(config('fortify.guard'));
     }
 
     public function test_valid_totp_code_invalidates_reset_token(): void


### PR DESCRIPTION
The admin password reset flow now sends a dedicated reset email link scoped to the admin interface, ensuring users remain within the Filament admin routes. The reset process guarantees a logged-out state after a successful reset and includes enhanced tests for regression coverage. This update aligns with the isolation rules between admin and web surfaces.

Fixes #1071