### PR TITLE
Fix; container instruction gaps + containerized smoke tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,9 +6,20 @@
 #   2. Direct test/lint runner — same image used by CI-equivalent docker commands.
 #
 # Build:  docker build -f .devcontainer/Dockerfile -t inventory-app-dev .
-# Run tests outside VS Code:
-#   docker run --rm -v "${PWD}:/workspaces/inventory-app" inventory-app-dev \
+# Run tests outside VS Code (requires the named vendor volume to exist — create it once with
+# `docker run --rm -v "${PWD}:/workspaces/inventory-app" -v inv-app-php-vendor:/workspaces/inventory-app/vendor
+#  -w /workspaces/inventory-app inventory-app-dev composer install --no-interaction`):
+#
+#   docker run --rm \
+#     -v "${PWD}:/workspaces/inventory-app" \
+#     -v inv-app-php-vendor:/workspaces/inventory-app/vendor \
+#     -e DB_CONNECTION=sqlite -e DB_DATABASE=:memory: \
+#     -e XDEBUG_MODE=off \
+#     inventory-app-dev \
 #     php artisan test --testsuite=Api --no-coverage --no-ansi
+#
+# NOTE: The workspace is mounted read-write so artisan can write bootstrap/cache.
+# The vendor/ volume keeps compiled autoload files on the fast Linux FS.
 
 FROM php:8.4-cli-bookworm
 

--- a/.github/agents/filament-admin-expert.agent.md
+++ b/.github/agents/filament-admin-expert.agent.md
@@ -36,10 +36,19 @@ Your job is to implement and review Filament-first features for /admin while kee
 5. Add or update focused tests in tests/Filament to prevent /admin to /web regressions.
 6. Run only the relevant validation steps for changed files and report what was run.
 
+## Dev Environment — Required for Lint and Tests
+
+> **CRITICAL — Windows dev machine: always run PHP commands inside the VS Code Dev Container.**
+> The host PHP is 8.2 and lacks `intl`, `zip`, `gd`, `exif` required by Filament 3. Open the workspace via "Reopen in Container" (Dev Containers extension). Named `vendor/` volumes are managed automatically by `.devcontainer/devcontainer.json`.
+>
+> - ❌ **NEVER** run `php artisan test` or `vendor/bin/pint` from a Windows host terminal.
+> - ✅ Use `XDEBUG_MODE=off` for normal no-coverage test runs to avoid Xdebug-induced slowdowns.
+> - Rebuild the image when `Dockerfile` or `composer.lock` change: `docker build -f .devcontainer/Dockerfile -t inventory-app-dev .` (host, then reopen in container).
+
 ## Tooling Preferences
 
 - Prefer workspace search and file edits over terminal-heavy workflows
-- Use terminal only when needed for validation commands and test runs
+- Use terminal only when needed for validation commands and test runs (always from the Dev Container terminal)
 - Keep changes minimal, explicit, and aligned with existing patterns
 
 ## Output Expectations

--- a/.github/agents/laravel-expert-agent.agent.md
+++ b/.github/agents/laravel-expert-agent.agent.md
@@ -93,6 +93,15 @@ You are a world-class Laravel expert with deep knowledge of modern Laravel devel
 - Apply database transactions for atomic operations
 - Use soft deletes when data retention is needed: `use SoftDeletes;`
 
+### Dev Environment — Required for Lint and Tests
+
+> **CRITICAL — Windows dev machine: always run PHP commands inside the VS Code Dev Container.**
+> The host PHP is 8.2 and lacks `intl`, `zip`, `gd`, `exif` required by this codebase. Open the workspace via "Reopen in Container" (Dev Containers extension). VS Code builds `inventory-app-dev` from `.devcontainer/Dockerfile` — named volumes for `vendor/` are managed automatically.
+>
+> - ❌ **NEVER** run `php artisan test` or `vendor/bin/pint` from a Windows host terminal.
+> - ✅ Run all PHP commands from the Dev Container terminal (or the VS Code tasks, which assume an in-container shell).
+> - Rebuild the image when `Dockerfile` or `composer.lock` change: `docker build -f .devcontainer/Dockerfile -t inventory-app-dev .` (run from the host, then reopen in container).
+
 ### Testing
 
 - Write feature tests for HTTP endpoints in `tests/Feature/`
@@ -101,7 +110,7 @@ You are a world-class Laravel expert with deep knowledge of modern Laravel devel
 - Apply database migrations and refreshing: `use RefreshDatabase;`
 - Test validation rules, authorization policies, and edge cases
 - Before concluding backend work, validate against the CI backend matrix suites: `Unit`, `Api`, `Web`, `Configuration`, `Console`, `Event`, `Integration`
-- Prefer `php artisan test --testsuite=<Suite> --coverage --parallel --no-ansi --stop-on-failure` over a generic `php artisan test`
+- Prefer `php artisan test --testsuite=<Suite> --no-coverage --parallel --no-ansi --stop-on-failure` over a generic `php artisan test` for local no-coverage runs (Xdebug is enabled in the container for debugging; use `XDEBUG_MODE=off` or `--no-coverage` to avoid slowdowns).
 - **CRITICAL**: NEVER pipe `php artisan test` or any `composer ci-*` command through `Select-Object`, `head`, `tail`, or any output filter. Run these commands unpiped so the full output is visible. Piping hides failure details and forces the entire run to be repeated.
   - ✅ `php artisan test --testsuite=Web --no-ansi --stop-on-failure`
   - ❌ `php artisan test --testsuite=Web --no-ansi --stop-on-failure 2>&1 | Select-Object -Last 10`

--- a/.github/agents/php-test-runner.agent.md
+++ b/.github/agents/php-test-runner.agent.md
@@ -19,7 +19,40 @@ After opening in container, `composer install` and `npm install` are run automat
 ```bash
 composer install --no-interaction
 npm install
+npm install --prefix spa
+npm install --prefix scripts/importer
 ```
+
+### Manual Docker runner (outside VS Code Dev Container)
+
+The image uses the same named volumes as the VS Code Dev Container. Dependency volumes must be populated before running tests. On a first use or after `composer.lock` changes, run the bootstrap step first:
+
+```powershell
+# Bootstrap PHP dependencies into the named vendor volume (run once, or after composer.lock changes)
+docker run --rm `
+  -v "E:\inventory\inventory-app:/workspaces/inventory-app" `
+  -v inv-app-php-vendor:/workspaces/inventory-app/vendor `
+  -w /workspaces/inventory-app `
+  inventory-app-dev `
+  composer install --no-interaction
+```
+
+Then run tests with both the workspace and vendor volumes mounted, Xdebug off, and a safe-directory override to suppress Git ownership warnings:
+
+```powershell
+docker run --rm `
+  -v "E:\inventory\inventory-app:/workspaces/inventory-app" `
+  -v inv-app-php-vendor:/workspaces/inventory-app/vendor `
+  -e DB_CONNECTION=sqlite -e DB_DATABASE=":memory:" `
+  -e XDEBUG_MODE=off `
+  -w /workspaces/inventory-app `
+  inventory-app-dev `
+  php artisan test --testsuite=Filament --no-coverage --parallel --no-ansi --stop-on-failure
+```
+
+> **Git safe.directory**: When the workspace is mounted from Windows, Git inside the container may warn about dubious ownership. This warning is harmless for tests but can surface in Composer post-install scripts. To silence it, pass `-e GIT_CONFIG_GLOBAL=/dev/null` or run `git config --global --add safe.directory /workspaces/inventory-app` inside the container.
+>
+> The Composer bootstrap command above suppresses it automatically because `composer install --no-interaction` does not invoke Git.
 
 ---
 
@@ -39,8 +72,26 @@ vendor/bin/pint --no-ansi
 
 Each suite maps 1:1 to a GitHub Actions matrix job. Always run with `--no-ansi` and never pipe output through filters.
 
+### Normal local runs (no coverage — default)
+
+Use `XDEBUG_MODE=off` for all no-coverage runs. The container enables Xdebug for debugging; leaving it active in test mode adds significant overhead and can cause timing-sensitive tests to fail.
+
 ```bash
-# Individual suites (CI parity)
+# Individual suites — no-coverage, Xdebug off (recommended for local dev)
+XDEBUG_MODE=off php artisan test --testsuite=Unit          --no-coverage --parallel --no-ansi --stop-on-failure
+XDEBUG_MODE=off php artisan test --testsuite=Api           --no-coverage --parallel --no-ansi --stop-on-failure
+XDEBUG_MODE=off php artisan test --testsuite=Web           --no-coverage --parallel --no-ansi --stop-on-failure
+XDEBUG_MODE=off php artisan test --testsuite=Filament      --no-coverage --parallel --no-ansi --stop-on-failure
+XDEBUG_MODE=off php artisan test --testsuite=Configuration --no-coverage --parallel --no-ansi --stop-on-failure
+XDEBUG_MODE=off php artisan test --testsuite=Console       --no-coverage --parallel --no-ansi --stop-on-failure
+XDEBUG_MODE=off php artisan test --testsuite=Event         --no-coverage --parallel --no-ansi --stop-on-failure
+XDEBUG_MODE=off php artisan test --testsuite=Integration   --no-coverage --parallel --no-ansi --stop-on-failure
+```
+
+### Coverage runs (CI parity — Xdebug coverage mode)
+
+```bash
+# Individual suites with coverage (matches GitHub Actions)
 php artisan test --testsuite=Unit          --coverage --parallel --no-ansi --stop-on-failure
 php artisan test --testsuite=Api           --coverage --parallel --no-ansi --stop-on-failure
 php artisan test --testsuite=Web           --coverage --parallel --no-ansi --stop-on-failure
@@ -51,19 +102,19 @@ php artisan test --testsuite=Event         --coverage --parallel --no-ansi --sto
 php artisan test --testsuite=Integration   --coverage --parallel --no-ansi --stop-on-failure
 ```
 
-### Full CI matrix in sequence
+### Full CI matrix in sequence (no-coverage, fast)
 
 ```bash
 for suite in Unit Api Web Filament Configuration Console Event Integration; do
     echo "=== $suite ==="
-    php artisan test --testsuite=$suite --coverage --parallel --no-ansi --stop-on-failure || break
+    XDEBUG_MODE=off php artisan test --testsuite=$suite --no-coverage --parallel --no-ansi --stop-on-failure || break
 done
 ```
 
 ### Single test (by name filter)
 
 ```bash
-php artisan test --filter=MyTestMethodName --no-coverage --no-ansi
+XDEBUG_MODE=off php artisan test --filter=MyTestMethodName --no-coverage --no-ansi
 ```
 
 ---
@@ -72,6 +123,8 @@ php artisan test --filter=MyTestMethodName --no-coverage --no-ansi
 
 - ❌ **NEVER** run `php artisan test` or `vendor/bin/pint` from the Windows host — use the Dev Container terminal.
 - ❌ **NEVER** pipe test or Pint output through any filter — full output is required to see failure details.
+- ✅ **Always use `XDEBUG_MODE=off` for no-coverage local test runs.** Xdebug debug mode is enabled by default in the container for step debugging; it significantly slows tests and can cause wall-clock timing assertions to fail.
+- ✅ The VS Code tasks (`php:test:*`) already set `XDEBUG_MODE=off` in their task environment — no manual override needed when using VS Code tasks.
 - ✅ The container sets `memory_limit = 512M` — required for Filament's class discovery scan.
 - ✅ The project root is mounted at `/workspaces/inventory-app` — local edits are immediately visible.
 - ✅ After `.devcontainer/Dockerfile` changes, rebuild with `docker build -f .devcontainer/Dockerfile -t inventory-app-dev .` from the host, then reopen in container.

--- a/.github/instructions/test-vuejs.instructions.md
+++ b/.github/instructions/test-vuejs.instructions.md
@@ -1,4 +1,3 @@
-```instructions
 ---
 applyTo: "resources/js/views/__tests__/**/*.test.ts"
 ---

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
 			"type": "shell",
 			"command": "vendor/bin/pint --no-ansi",
 			"group": "build",
-			"options": { "cwd": "${workspaceFolder}" },
+			"options": { "cwd": "${workspaceFolder}", "env": { "XDEBUG_MODE": "off" } },
 			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
 			"detail": "Run Laravel Pint (PHP 8.4 Dev Container)"
@@ -20,7 +20,7 @@
 			"type": "shell",
 			"command": "php artisan test --testsuite=Unit --no-coverage --parallel --no-ansi --stop-on-failure",
 			"group": "test",
-			"options": { "cwd": "${workspaceFolder}" },
+			"options": { "cwd": "${workspaceFolder}", "env": { "XDEBUG_MODE": "off" } },
 			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
 			"detail": "php artisan test --testsuite=Unit"
@@ -30,7 +30,7 @@
 			"type": "shell",
 			"command": "php artisan test --testsuite=Api --no-coverage --parallel --no-ansi --stop-on-failure",
 			"group": "test",
-			"options": { "cwd": "${workspaceFolder}" },
+			"options": { "cwd": "${workspaceFolder}", "env": { "XDEBUG_MODE": "off" } },
 			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
 			"detail": "php artisan test --testsuite=Api"
@@ -40,7 +40,7 @@
 			"type": "shell",
 			"command": "php artisan test --testsuite=Web --no-coverage --parallel --no-ansi --stop-on-failure",
 			"group": "test",
-			"options": { "cwd": "${workspaceFolder}" },
+			"options": { "cwd": "${workspaceFolder}", "env": { "XDEBUG_MODE": "off" } },
 			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
 			"detail": "php artisan test --testsuite=Web"
@@ -50,7 +50,7 @@
 			"type": "shell",
 			"command": "php artisan test --testsuite=Filament --no-coverage --parallel --no-ansi --stop-on-failure",
 			"group": "test",
-			"options": { "cwd": "${workspaceFolder}" },
+			"options": { "cwd": "${workspaceFolder}", "env": { "XDEBUG_MODE": "off" } },
 			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
 			"detail": "php artisan test --testsuite=Filament"
@@ -60,7 +60,7 @@
 			"type": "shell",
 			"command": "php artisan test --testsuite=Configuration --no-coverage --parallel --no-ansi --stop-on-failure",
 			"group": "test",
-			"options": { "cwd": "${workspaceFolder}" },
+			"options": { "cwd": "${workspaceFolder}", "env": { "XDEBUG_MODE": "off" } },
 			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
 			"detail": "php artisan test --testsuite=Configuration"
@@ -70,7 +70,7 @@
 			"type": "shell",
 			"command": "php artisan test --testsuite=Console --no-coverage --parallel --no-ansi --stop-on-failure",
 			"group": "test",
-			"options": { "cwd": "${workspaceFolder}" },
+			"options": { "cwd": "${workspaceFolder}", "env": { "XDEBUG_MODE": "off" } },
 			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
 			"detail": "php artisan test --testsuite=Console"
@@ -80,7 +80,7 @@
 			"type": "shell",
 			"command": "php artisan test --testsuite=Event --no-coverage --parallel --no-ansi --stop-on-failure",
 			"group": "test",
-			"options": { "cwd": "${workspaceFolder}" },
+			"options": { "cwd": "${workspaceFolder}", "env": { "XDEBUG_MODE": "off" } },
 			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
 			"detail": "php artisan test --testsuite=Event"
@@ -90,7 +90,7 @@
 			"type": "shell",
 			"command": "php artisan test --testsuite=Integration --no-coverage --parallel --no-ansi --stop-on-failure",
 			"group": "test",
-			"options": { "cwd": "${workspaceFolder}" },
+			"options": { "cwd": "${workspaceFolder}", "env": { "XDEBUG_MODE": "off" } },
 			"presentation": { "reveal": "always", "panel": "shared" },
 			"problemMatcher": [],
 			"detail": "php artisan test --testsuite=Integration"
@@ -174,12 +174,12 @@
 		{
 			"label": "docker:shell",
 			"type": "shell",
-			"command": "docker run --rm -it -v \"${workspaceFolder}:/workspaces/inventory-app\" -w /workspaces/inventory-app inventory-app-dev bash",
+			"command": "docker run --rm -it -v \"${workspaceFolder}:/workspaces/inventory-app\" -v inv-app-php-vendor:/workspaces/inventory-app/vendor -v inv-app-node-modules:/workspaces/inventory-app/node_modules -v inv-app-spa-node-modules:/workspaces/inventory-app/spa/node_modules -v inv-app-importer-node-modules:/workspaces/inventory-app/scripts/importer/node_modules -w /workspaces/inventory-app inventory-app-dev bash",
 			"group": "none",
 			"options": { "cwd": "${workspaceFolder}" },
 			"presentation": { "reveal": "always", "panel": "new", "focus": true },
 			"problemMatcher": [],
-			"detail": "Open an interactive bash shell in the inventory-app-dev container"
+			"detail": "Open an interactive bash shell in the inventory-app-dev container (mounts all dependency volumes)"
 		}
 
 	]

--- a/tests/Filament/Pages/DashboardSmokeTest.php
+++ b/tests/Filament/Pages/DashboardSmokeTest.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -28,17 +29,26 @@ class DashboardSmokeTest extends TestCase
             ->assertSee('Dashboard');
     }
 
-    public function test_dashboard_loads_under_1000ms_with_100k_items(): void
+    public function test_dashboard_query_count_is_bounded_with_100k_items(): void
     {
         $user = $this->createViewUser();
         $this->seedItems(100_000);
 
-        $start = microtime(true);
+        DB::enableQueryLog();
         $response = $this->actingAs($user)->get('/admin');
-        $elapsed = (microtime(true) - $start) * 1000;
+        $queryCount = count(DB::getQueryLog());
 
         $response->assertOk();
-        $this->assertLessThan(1000, $elapsed, "Dashboard took {$elapsed}ms, expected < 1000ms");
+
+        // Dashboard must issue a bounded number of queries regardless of item count.
+        // All count stats use aggregate SQL (SELECT COUNT(*) FROM …) which are O(1)
+        // even with 100 000+ items. A catastrophic N+1 regression would produce
+        // 100 000+ queries and fail this assertion immediately.
+        $this->assertLessThanOrEqual(
+            100,
+            $queryCount,
+            "Dashboard issued {$queryCount} queries with 100k items; expected ≤ 100. This may indicate an N+1 regression."
+        );
     }
 
     public function test_dashboard_shows_inventory_stats_for_authorized_user(): void


### PR DESCRIPTION
### Fixed 5 instruction gaps

**1 — test-vuejs.instructions.md frontmatter** (test-vuejs.instructions.md) Removed the erroneous ` ```instructions ` code fence that wrapped the YAML block, so Copilot now correctly recognises the `applyTo` pattern.

**2 — `laravel-expert-agent` Dev Container awareness** (laravel-expert-agent.agent.md) Added a new **Dev Environment** section that explicitly forbids running PHP commands from the Windows host and references the dependency-volume requirement. Updated the Testing section to recommend `--no-coverage` with `XDEBUG_MODE=off` for local runs.

**3 — `filament-admin-expert` Dev Container awareness** (filament-admin-expert.agent.md) Added the same Dev Environment block. Tooling Preferences now notes "Dev Container terminal" explicitly.

**4 — Dockerfile manual `docker run` example** (Dockerfile) Replaced the single-line example (no dep volumes, no Xdebug flag) with a correct multi-line example that mounts the `inv-app-php-vendor` volume, sets `XDEBUG_MODE=off`, and documents the one-time bootstrap step.

**5 — `docker:shell` task dependency volumes** (tasks.json) The task now mounts all four named volumes (`inv-app-php-vendor`, `inv-app-node-modules`, `inv-app-spa-node-modules`, `inv-app-importer-node-modules`), matching what devcontainer.json does.

---

### Stories implemented

**#1110 — Disable Xdebug for normal no-coverage local test runs** All 9 PHP tasks (`php:lint`, `php:test:Unit` … `php:test:Integration`) in tasks.json now carry `"env": { "XDEBUG_MODE": "off" }` in their options. php-test-runner.agent.md now documents two command sets: fast local (`--no-coverage` + `XDEBUG_MODE=off`) and CI-parity coverage runs.

**#1111 — Align manual Docker runner with Dev Container dependency mounts** Dockerfile comment and `docker:shell` task updated (above). php-test-runner.agent.md now includes a **Manual Docker runner** subsection with the bootstrap command, the correct run command with dep volumes, and a note about the Git `safe.directory` warning from Windows-mounted workspaces.

**#1109 — Make dashboard performance smoke test reliable in local containers** `test_dashboard_loads_under_1000ms_with_100k_items` replaced with `test_dashboard_query_count_is_bounded_with_100k_items` in DashboardSmokeTest.php. The new test seeds 100 000 items, captures the full DB query log, and asserts ≤ 100 queries were issued — catching any N+1 regression while remaining deterministic under parallel container load.

Fixes #1109 Fixes #1110 Fixes #1111

Co-authored-by: Copilot <copilot@github.com>