### PR TITLE
ci: add intl PHP extension to mandatory CI setup (#1108)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,7 +28,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
-          extensions: fileinfo, zip, sqlite3, pdo_sqlite, gd, exif
+          extensions: fileinfo, intl, zip, sqlite3, pdo_sqlite, gd, exif
 
       - name: "Check > Composer > Validate composer.json"
         run: |
@@ -169,7 +169,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
-          extensions: fileinfo, zip, sqlite3, pdo_sqlite, gd, exif
+          extensions: fileinfo, intl, zip, sqlite3, pdo_sqlite, gd, exif
           tools: pint
 
       - name: "Check > Composer > Check requirements"
@@ -227,7 +227,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
-          extensions: fileinfo, zip, sqlite3, pdo_sqlite, gd, exif
+          extensions: fileinfo, intl, zip, sqlite3, pdo_sqlite, gd, exif
           coverage: xdebug
           tools: phpunit, pest
 


### PR DESCRIPTION
## Summary

Closes #1108

## Changes

Add `intl` to the `extensions` list in all three `shivammathur/setup-php@v2` steps of `.github/workflows/continuous-integration.yml`:

- `audit-composer` job
- `backend-lint` job
- `backend-tests` job

This aligns mandatory CI with the dev container and documented Filament 3 runtime requirements (`intl`, `zip`, `gd`, `exif`).

## No other changes

No new dependencies, migrations, or unrelated files were modified.