### PR TITLE
Add legacy link resolver

### DIFF
--- a/.github/agents/legacy-link-resolver.agent.md
+++ b/.github/agents/legacy-link-resolver.agent.md
@@ -1,0 +1,53 @@
+---
+description: "Use when: investigating, validating, extending, or fixing the Legacy Link Resolver; checking legacy URL mapping rules; comparing Inventory backward_compatibility values with legacy public websites; inspecting Legacy Link Resolver config or deployed OVH behavior; updating resolver code or config on explicit user request."
+tools: [read, search, edit, web, execute]
+argument-hint: "Describe the legacy source pattern, Inventory record type, target URL behavior, or OVH/config issue to investigate."
+---
+You are a specialist in the Inventory app's Legacy Link Resolver. Your job is to help map `backward_compatibility` values from Items, Collections, and Partners to legacy public, source, diagnostic, and back-office links.
+
+## Scope
+
+Work with these resolver artifacts first:
+
+- `docs/understanding/legacy-url-mapping.md`
+- `config/legacy.php`
+- `app/Services/LegacyUrlResolver.php`
+- `app/Support/LegacyLinks/**`
+- `app/Filament/Concerns/HasLegacyLinksInfolistSection.php`
+- `app/Filament/Resources/{ItemResource,CollectionResource,PartnerResource}.php`
+- `tests/Unit/Support/LegacyLinks/**`
+- `tests/Filament/Resources/LegacyLinksInfolistTest.php`
+- `scripts/importer/gap_analysis/*.md`
+
+## Constraints
+
+- Start read-only unless the user explicitly asks you to update code, config, tests, documentation, or deployed state.
+- Treat OVH inspection as read-only by default. Do not change deployed files, database state, services, or configuration on OVH without explicit user confirmation.
+- Do not invent legacy URL rules. If a URL needs a slug, parent country, location id, project code, or partner code that is not present or verified, return a `requires_lookup` diagnostic.
+- Keep public hosts and lookup maps in `config/legacy.php`; do not hard-code production hosts inside resolver rules.
+- The back-office host is always `https://virtual-office.museumwnf.org`; it is private and requires VPN access.
+- Preserve the resolver contract: unresolved mappings must surface visible diagnostics, not silent nulls.
+- Use the existing documentation ledger as the source of truth. Update it when you verify a new rule.
+
+## Investigation Workflow
+
+1. Parse the target `backward_compatibility` value into schema, table, and parts.
+2. Identify the Inventory model type: Item, Collection, or Partner.
+3. Check existing unit fixtures and rule classes for the source family.
+4. Search `scripts/importer/gap_analysis/*.md` for verified public URL examples.
+5. Fetch or browse legacy public pages only as needed to confirm a rule.
+6. If OVH behavior differs from local code, inspect deployed config/code and report the exact difference before proposing changes.
+7. When asked to update resolver behavior, update code/config, documentation, and tests together.
+
+## Output Format
+
+Report findings in this shape:
+
+- Source pattern: `<schema>:<table>:...`
+- Inventory type: `Item`, `Collection`, or `Partner`
+- Current resolver result: exact, inferred, requires lookup, unsupported, or missing
+- Verified legacy URL examples: public/back-office/source URLs, if known
+- Required change: config-only, rule update, model-context lookup, documentation update, or test fixture
+- Residual risk: any missing slug, parent, project, country, or back-office route evidence
+
+When implementing, include the focused test command that validates the change.

--- a/app/Enums/LegacyLinkConfidence.php
+++ b/app/Enums/LegacyLinkConfidence.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+enum LegacyLinkConfidence: string
+{
+    case EXACT = 'exact';
+    case INFERRED = 'inferred';
+    case REQUIRES_LOOKUP = 'requires_lookup';
+    case UNSUPPORTED = 'unsupported';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::EXACT => 'Exact',
+            self::INFERRED => 'Inferred',
+            self::REQUIRES_LOOKUP => 'Requires lookup',
+            self::UNSUPPORTED => 'Unsupported',
+        };
+    }
+}

--- a/app/Enums/LegacyLinkType.php
+++ b/app/Enums/LegacyLinkType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+enum LegacyLinkType: string
+{
+    case PUBLIC = 'public';
+    case BACKOFFICE = 'backoffice';
+    case SOURCE = 'source';
+    case DIAGNOSTIC = 'diagnostic';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::PUBLIC => 'Public',
+            self::BACKOFFICE => 'Back-office',
+            self::SOURCE => 'Source',
+            self::DIAGNOSTIC => 'Diagnostic',
+        };
+    }
+}

--- a/app/Filament/Concerns/HasLegacyLinksInfolistSection.php
+++ b/app/Filament/Concerns/HasLegacyLinksInfolistSection.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Filament\Concerns;
+
+use App\Services\LegacyUrlResolver;
+use App\Support\LegacyLinks\LegacyLink;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\TextEntry;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HtmlString;
+
+trait HasLegacyLinksInfolistSection
+{
+    protected static function legacyLinksSection(): Section
+    {
+        return Section::make('Legacy links')
+            ->schema([
+                TextEntry::make('legacy_links')
+                    ->label('Resolved links')
+                    ->state(fn (Model $record): HtmlString => static::legacyLinksHtml($record))
+                    ->html()
+                    ->columnSpanFull(),
+            ])
+            ->columns(1)
+            ->collapsible();
+    }
+
+    protected static function legacyLinksHtml(Model $record): HtmlString
+    {
+        $links = app(LegacyUrlResolver::class)->resolveFor($record)->links;
+
+        $items = collect($links)
+            ->map(fn (LegacyLink $link): string => static::legacyLinkHtml($link))
+            ->implode('');
+
+        return new HtmlString('<ul class="space-y-2">'.$items.'</ul>');
+    }
+
+    protected static function legacyLinkHtml(LegacyLink $link): string
+    {
+        $heading = e($link->type->label().' - '.$link->confidence->label());
+        $label = e($link->label);
+        $source = e($link->source);
+        $note = $link->note ? '<div class="text-xs text-gray-500">'.e($link->note).'</div>' : '';
+
+        if ($link->url === null) {
+            return <<<HTML
+                <li>
+                    <div class="font-medium">{$label}</div>
+                    <div class="text-xs text-gray-500">{$heading}</div>
+                    <div class="text-xs text-gray-500">Source: {$source}</div>
+                    {$note}
+                </li>
+            HTML;
+        }
+
+        $url = e($link->url);
+
+        return <<<HTML
+            <li>
+                <a href="{$url}" target="_blank" rel="noopener noreferrer" class="font-medium text-primary-600 hover:underline">{$label}</a>
+                <div class="text-xs text-gray-500">{$heading}</div>
+                <div class="break-all text-xs text-gray-500">{$url}</div>
+                <div class="text-xs text-gray-500">Source: {$source}</div>
+                {$note}
+            </li>
+        HTML;
+    }
+}

--- a/app/Filament/Resources/CollectionResource.php
+++ b/app/Filament/Resources/CollectionResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources;
 use App\Enums\Permission;
 use App\Filament\Concerns\HasBackwardCompatibilityColumn;
 use App\Filament\Concerns\HasInternalNameColumn;
+use App\Filament\Concerns\HasLegacyLinksInfolistSection;
 use App\Filament\Concerns\HasTimestampsColumns;
 use App\Filament\Concerns\HasTranslationCoverageFilters;
 use App\Filament\Concerns\HasUuidColumn;
@@ -42,6 +43,7 @@ class CollectionResource extends Resource
 {
     use HasBackwardCompatibilityColumn;
     use HasInternalNameColumn;
+    use HasLegacyLinksInfolistSection;
     use HasTimestampsColumns;
     use HasTranslationCoverageFilters;
     use HasUuidColumn;
@@ -340,6 +342,7 @@ class CollectionResource extends Resource
                     ->label('Map zoom'),
                 TextEntry::make('backward_compatibility')
                     ->label('Legacy code'),
+                static::legacyLinksSection(),
                 TextEntry::make('id')
                     ->label('UUID'),
                 TextEntry::make('created_at')

--- a/app/Filament/Resources/ItemResource.php
+++ b/app/Filament/Resources/ItemResource.php
@@ -6,6 +6,7 @@ use App\Enums\ItemType;
 use App\Enums\Permission;
 use App\Filament\Concerns\HasBackwardCompatibilityColumn;
 use App\Filament\Concerns\HasInternalNameColumn;
+use App\Filament\Concerns\HasLegacyLinksInfolistSection;
 use App\Filament\Concerns\HasTimestampsColumns;
 use App\Filament\Concerns\HasTranslationCoverageFilters;
 use App\Filament\Concerns\HasUuidColumn;
@@ -50,6 +51,7 @@ class ItemResource extends Resource
 {
     use HasBackwardCompatibilityColumn;
     use HasInternalNameColumn;
+    use HasLegacyLinksInfolistSection;
     use HasTimestampsColumns;
     use HasTranslationCoverageFilters;
     use HasUuidColumn;
@@ -467,6 +469,7 @@ class ItemResource extends Resource
                     ->label('Display order'),
                 TextEntry::make('backward_compatibility')
                     ->label('Legacy code'),
+                static::legacyLinksSection(),
                 TextEntry::make('id')
                     ->label('UUID'),
                 TextEntry::make('created_at')

--- a/app/Filament/Resources/PartnerResource.php
+++ b/app/Filament/Resources/PartnerResource.php
@@ -6,6 +6,7 @@ use App\Enums\ItemType;
 use App\Enums\Permission;
 use App\Filament\Concerns\HasBackwardCompatibilityColumn;
 use App\Filament\Concerns\HasInternalNameColumn;
+use App\Filament\Concerns\HasLegacyLinksInfolistSection;
 use App\Filament\Concerns\HasTimestampsColumns;
 use App\Filament\Concerns\HasTranslationCoverageFilters;
 use App\Filament\Concerns\HasUuidColumn;
@@ -41,6 +42,7 @@ class PartnerResource extends Resource
 {
     use HasBackwardCompatibilityColumn;
     use HasInternalNameColumn;
+    use HasLegacyLinksInfolistSection;
     use HasTimestampsColumns;
     use HasTranslationCoverageFilters;
     use HasUuidColumn;
@@ -212,6 +214,7 @@ class PartnerResource extends Resource
                     ->label('Map zoom'),
                 TextEntry::make('backward_compatibility')
                     ->label('Legacy code'),
+                static::legacyLinksSection(),
                 TextEntry::make('id')
                     ->label('UUID'),
                 TextEntry::make('created_at')

--- a/app/Services/LegacyUrlResolver.php
+++ b/app/Services/LegacyUrlResolver.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\LegacyLinkConfidence;
+use App\Models\Language;
+use App\Support\LegacyLinks\LegacyLink;
+use App\Support\LegacyLinks\LegacyLinkSet;
+use App\Support\LegacyLinks\LegacyReference;
+use App\Support\LegacyLinks\Rules\ExploreLegacyUrlRule;
+use App\Support\LegacyLinks\Rules\LegacyUrlRule;
+use App\Support\LegacyLinks\Rules\Mwnf3ItemLegacyUrlRule;
+use App\Support\LegacyLinks\Rules\Mwnf3PartnerLegacyUrlRule;
+use App\Support\LegacyLinks\Rules\SharingHistoryLegacyUrlRule;
+use App\Support\LegacyLinks\Rules\ThematicGalleryLegacyUrlRule;
+use App\Support\LegacyLinks\Rules\TravelsLegacyUrlRule;
+use Illuminate\Database\Eloquent\Model;
+
+class LegacyUrlResolver
+{
+    /** @var array<int, LegacyUrlRule> */
+    private array $rules;
+
+    /**
+     * @param  array<int, LegacyUrlRule>|null  $rules
+     */
+    public function __construct(?array $rules = null)
+    {
+        $this->rules = $rules ?? [
+            new Mwnf3ItemLegacyUrlRule,
+            new Mwnf3PartnerLegacyUrlRule,
+            new SharingHistoryLegacyUrlRule,
+            new ExploreLegacyUrlRule,
+            new TravelsLegacyUrlRule,
+            new ThematicGalleryLegacyUrlRule,
+        ];
+    }
+
+    public function resolveFor(Model $record, string $language = 'en'): LegacyLinkSet
+    {
+        $reference = LegacyReference::parse($record->getAttribute('backward_compatibility'));
+
+        if ($reference === null) {
+            return new LegacyLinkSet([
+                LegacyLink::diagnostic('Legacy links unavailable', LegacyLinkConfidence::UNSUPPORTED, $record::class, 'This record has no valid backward compatibility value.'),
+            ]);
+        }
+
+        $legacyLanguage = $this->legacyLanguageCode($language);
+
+        foreach ($this->rules as $rule) {
+            if (! $rule->supports($record, $reference)) {
+                continue;
+            }
+
+            $links = $rule->resolve($record, $reference, $legacyLanguage);
+
+            if ($links !== []) {
+                return new LegacyLinkSet($links);
+            }
+        }
+
+        return new LegacyLinkSet([
+            LegacyLink::diagnostic('Legacy rule missing', LegacyLinkConfidence::UNSUPPORTED, $reference->raw, 'No Legacy Link Resolver rule supports this record type and legacy source pattern yet.'),
+        ]);
+    }
+
+    private function legacyLanguageCode(string $language): string
+    {
+        $language = trim($language);
+
+        if ($language === '') {
+            return 'en';
+        }
+
+        if (strlen($language) === 2) {
+            return strtolower($language);
+        }
+
+        $configured = config("legacy.links.languages.{$language}");
+
+        if (is_string($configured) && $configured !== '') {
+            return strtolower($configured);
+        }
+
+        $fromDatabase = Language::query()->whereKey($language)->value('backward_compatibility');
+
+        return is_string($fromDatabase) && $fromDatabase !== '' ? strtolower($fromDatabase) : 'en';
+    }
+}

--- a/app/Support/LegacyLinks/LegacyLink.php
+++ b/app/Support/LegacyLinks/LegacyLink.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Support\LegacyLinks;
+
+use App\Enums\LegacyLinkConfidence;
+use App\Enums\LegacyLinkType;
+
+final readonly class LegacyLink
+{
+    public function __construct(
+        public string $label,
+        public ?string $url,
+        public LegacyLinkType $type,
+        public LegacyLinkConfidence $confidence,
+        public string $source,
+        public ?string $note = null,
+    ) {}
+
+    public static function public(
+        string $label,
+        string $url,
+        LegacyLinkConfidence $confidence,
+        string $source,
+        ?string $note = null,
+    ): self {
+        return new self($label, $url, LegacyLinkType::PUBLIC, $confidence, $source, $note);
+    }
+
+    public static function backoffice(
+        string $label,
+        string $url,
+        LegacyLinkConfidence $confidence,
+        string $source,
+        ?string $note = null,
+    ): self {
+        return new self($label, $url, LegacyLinkType::BACKOFFICE, $confidence, $source, $note);
+    }
+
+    public static function diagnostic(
+        string $label,
+        LegacyLinkConfidence $confidence,
+        string $source,
+        string $note,
+    ): self {
+        return new self($label, null, LegacyLinkType::DIAGNOSTIC, $confidence, $source, $note);
+    }
+}

--- a/app/Support/LegacyLinks/LegacyLinkSet.php
+++ b/app/Support/LegacyLinks/LegacyLinkSet.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Support\LegacyLinks;
+
+use Illuminate\Support\Collection;
+
+final readonly class LegacyLinkSet
+{
+    /**
+     * @param  array<int, LegacyLink>  $links
+     */
+    public function __construct(public array $links) {}
+
+    /**
+     * @return Collection<int, LegacyLink>
+     */
+    public function collect(): Collection
+    {
+        return collect($this->links);
+    }
+
+    public function hasResolvableLinks(): bool
+    {
+        return $this->collect()->contains(fn (LegacyLink $link): bool => $link->url !== null);
+    }
+}

--- a/app/Support/LegacyLinks/LegacyReference.php
+++ b/app/Support/LegacyLinks/LegacyReference.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Support\LegacyLinks;
+
+final readonly class LegacyReference
+{
+    /**
+     * @param  array<int, string>  $parts
+     */
+    private function __construct(
+        public string $raw,
+        public string $schema,
+        public string $table,
+        public array $parts,
+    ) {}
+
+    public static function parse(?string $value): ?self
+    {
+        $raw = trim((string) $value);
+
+        if ($raw === '') {
+            return null;
+        }
+
+        $segments = explode(':', $raw);
+
+        if (count($segments) < 2 || in_array('', [$segments[0], $segments[1]], true)) {
+            return null;
+        }
+
+        return new self(
+            raw: $raw,
+            schema: $segments[0],
+            table: $segments[1],
+            parts: array_slice($segments, 2),
+        );
+    }
+
+    public function is(string $schema, ?string $table = null): bool
+    {
+        if ($this->schema !== $schema) {
+            return false;
+        }
+
+        return $table === null || $this->table === $table;
+    }
+
+    public function part(int $index): ?string
+    {
+        return $this->parts[$index] ?? null;
+    }
+
+    public function hasParts(int $count): bool
+    {
+        return count($this->parts) >= $count;
+    }
+}

--- a/app/Support/LegacyLinks/Rules/Concerns/BuildsLegacyUrls.php
+++ b/app/Support/LegacyLinks/Rules/Concerns/BuildsLegacyUrls.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Support\LegacyLinks\Rules\Concerns;
+
+use App\Models\Collection;
+use App\Models\Country;
+use App\Models\Project;
+
+trait BuildsLegacyUrls
+{
+    protected function host(string $key): ?string
+    {
+        $host = config("legacy.links.public_hosts.{$key}");
+
+        return is_string($host) && $host !== '' ? rtrim($host, '/') : null;
+    }
+
+    protected function projectHost(?string $project): ?string
+    {
+        if ($project === null || $project === '') {
+            return null;
+        }
+
+        $host = config('legacy.links.public_hosts.projects.'.strtoupper($project));
+
+        return is_string($host) && $host !== '' ? rtrim($host, '/') : null;
+    }
+
+    protected function backofficeUrl(string $section, string $edit): string
+    {
+        $host = config('legacy.links.backoffice_host');
+        $host = is_string($host) && $host !== '' ? rtrim($host, '/') : 'https://virtual-office.museumwnf.org';
+
+        return "{$host}/?section={$section}&edit={$edit}&";
+    }
+
+    protected function firstProjectCode(?Project $project): ?string
+    {
+        $backwardCompatibility = trim((string) $project?->backward_compatibility);
+
+        if ($backwardCompatibility === '') {
+            return null;
+        }
+
+        return strtoupper(trim(explode(',', $backwardCompatibility)[0]));
+    }
+
+    protected function legacyCountryCode(?Country $country): ?string
+    {
+        if ($country === null) {
+            return null;
+        }
+
+        $code = trim((string) ($country->backward_compatibility ?: $country->getKey()));
+
+        return $code === '' ? null : strtolower($code);
+    }
+
+    protected function legacyCountryCodeForCollection(Collection $collection): ?string
+    {
+        $country = $this->legacyCountryCode($collection->country);
+
+        if ($country !== null) {
+            return $country;
+        }
+
+        $parentReference = $collection->parent?->backward_compatibility;
+        $parts = $parentReference ? explode(':', $parentReference) : [];
+
+        if (count($parts) === 3 && $parts[0] === 'mwnf3_explore' && $parts[1] === 'country') {
+            return strtolower($parts[2]);
+        }
+
+        return null;
+    }
+}

--- a/app/Support/LegacyLinks/Rules/ExploreLegacyUrlRule.php
+++ b/app/Support/LegacyLinks/Rules/ExploreLegacyUrlRule.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Support\LegacyLinks\Rules;
+
+use App\Enums\LegacyLinkConfidence;
+use App\Models\Collection;
+use App\Models\Item;
+use App\Support\LegacyLinks\LegacyLink;
+use App\Support\LegacyLinks\LegacyReference;
+use App\Support\LegacyLinks\Rules\Concerns\BuildsLegacyUrls;
+use Illuminate\Database\Eloquent\Model;
+
+class ExploreLegacyUrlRule implements LegacyUrlRule
+{
+    use BuildsLegacyUrls;
+
+    public function supports(Model $record, LegacyReference $reference): bool
+    {
+        return $reference->schema === 'mwnf3_explore' && ($record instanceof Collection || $record instanceof Item);
+    }
+
+    public function resolve(Model $record, LegacyReference $reference, string $legacyLanguage): array
+    {
+        if ($record instanceof Collection) {
+            return $this->resolveCollection($record, $reference);
+        }
+
+        if ($record instanceof Item) {
+            return $this->resolveItem($record, $reference);
+        }
+
+        return [];
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveCollection(Collection $collection, LegacyReference $reference): array
+    {
+        $host = $this->host('explore');
+
+        return match ($reference->table) {
+            'thematiccycle' => $reference->hasParts(1)
+                ? [
+                    LegacyLink::public('Explore theme page', "{$host}/themes/t-{$reference->part(0)}", LegacyLinkConfidence::EXACT, $reference->raw),
+                    LegacyLink::backoffice('Explore theme back-office record', $this->backofficeUrl('explore/explore_themes', "1;{$reference->part(0)}"), LegacyLinkConfidence::EXACT, $reference->raw),
+                ]
+                : [],
+            'country' => $reference->hasParts(1)
+                ? [
+                    LegacyLink::public('Explore country page', "{$host}/countries/c-{$reference->part(0)}", LegacyLinkConfidence::EXACT, $reference->raw),
+                    LegacyLink::backoffice('Explore country back-office record', $this->backofficeUrl('explore/explore_country', "1;{$reference->part(0)}"), LegacyLinkConfidence::EXACT, $reference->raw),
+                ]
+                : [],
+            'location' => $this->resolveLocation($collection, $reference),
+            'itinerary' => $this->resolveItinerary($collection, $reference),
+            default => [],
+        };
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveLocation(Collection $collection, LegacyReference $reference): array
+    {
+        if (! $reference->hasParts(1)) {
+            return [];
+        }
+
+        $country = $this->legacyCountryCodeForCollection($collection);
+
+        if ($country === null) {
+            return [LegacyLink::diagnostic('Explore location page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, 'Location URLs need the parent country code.')];
+        }
+
+        return [
+            LegacyLink::public('Explore location page', $this->host('explore')."/countries/c-{$country}/l-{$reference->part(0)}", LegacyLinkConfidence::INFERRED, $reference->raw),
+            LegacyLink::backoffice('Explore location back-office record', $this->backofficeUrl('explore/explore_locations', "1;{$reference->part(0)}"), LegacyLinkConfidence::EXACT, $reference->raw),
+        ];
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveItinerary(Collection $collection, LegacyReference $reference): array
+    {
+        if (! $reference->hasParts(1)) {
+            return [];
+        }
+
+        $country = $this->legacyCountryCodeForCollection($collection);
+
+        if ($country === null) {
+            return [LegacyLink::diagnostic('Explore itinerary page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, 'Itinerary URLs need country context.')];
+        }
+
+        return [
+            LegacyLink::public('Explore itinerary page', $this->host('explore')."/itineraries/c-{$country}/i-{$reference->part(0)}", LegacyLinkConfidence::INFERRED, $reference->raw),
+            LegacyLink::backoffice('Explore itinerary back-office record', $this->backofficeUrl('explore/explore_itineraries', "1;{$reference->part(0)}"), LegacyLinkConfidence::EXACT, $reference->raw),
+        ];
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveItem(Item $item, LegacyReference $reference): array
+    {
+        if ($reference->table !== 'monument' || ! $reference->hasParts(1)) {
+            return [];
+        }
+
+        $collectionReference = LegacyReference::parse($item->collection?->backward_compatibility);
+
+        if (! $collectionReference?->is('mwnf3_explore', 'location') || ! $collectionReference->hasParts(1) || $item->collection === null) {
+            return [LegacyLink::diagnostic('Explore monument page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, 'Monument URLs need parent location and country context.')];
+        }
+
+        $country = $this->legacyCountryCodeForCollection($item->collection);
+
+        if ($country === null) {
+            return [LegacyLink::diagnostic('Explore monument page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, 'Monument URLs need parent country context.')];
+        }
+
+        return [
+            LegacyLink::public('Explore monument page', $this->host('explore')."/countries/c-{$country}/l-{$collectionReference->part(0)}/m-{$reference->part(0)}", LegacyLinkConfidence::INFERRED, $reference->raw),
+            LegacyLink::backoffice('Explore monument back-office record', $this->backofficeUrl('explore/explore_monuments', "1;{$reference->part(0)}"), LegacyLinkConfidence::EXACT, $reference->raw),
+        ];
+    }
+}

--- a/app/Support/LegacyLinks/Rules/LegacyUrlRule.php
+++ b/app/Support/LegacyLinks/Rules/LegacyUrlRule.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Support\LegacyLinks\Rules;
+
+use App\Support\LegacyLinks\LegacyLink;
+use App\Support\LegacyLinks\LegacyReference;
+use Illuminate\Database\Eloquent\Model;
+
+interface LegacyUrlRule
+{
+    public function supports(Model $record, LegacyReference $reference): bool;
+
+    /**
+     * @return array<int, LegacyLink>
+     */
+    public function resolve(Model $record, LegacyReference $reference, string $legacyLanguage): array;
+}

--- a/app/Support/LegacyLinks/Rules/Mwnf3ItemLegacyUrlRule.php
+++ b/app/Support/LegacyLinks/Rules/Mwnf3ItemLegacyUrlRule.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Support\LegacyLinks\Rules;
+
+use App\Enums\LegacyLinkConfidence;
+use App\Models\Item;
+use App\Support\LegacyLinks\LegacyLink;
+use App\Support\LegacyLinks\LegacyReference;
+use App\Support\LegacyLinks\Rules\Concerns\BuildsLegacyUrls;
+use Illuminate\Database\Eloquent\Model;
+
+class Mwnf3ItemLegacyUrlRule implements LegacyUrlRule
+{
+    use BuildsLegacyUrls;
+
+    public function supports(Model $record, LegacyReference $reference): bool
+    {
+        return $record instanceof Item && $reference->schema === 'mwnf3';
+    }
+
+    public function resolve(Model $record, LegacyReference $reference, string $legacyLanguage): array
+    {
+        return match ($reference->table) {
+            'objects' => $this->resolveDatabaseItem($reference, 'object', 'database/dba_objects', $legacyLanguage, 4),
+            'monuments' => $this->resolveDatabaseItem($reference, 'monument', 'database/dba_monuments', $legacyLanguage, 4),
+            'objects_pictures' => $this->resolvePictureParent($reference, 'object', 'database/dba_objects', $legacyLanguage),
+            'monuments_pictures' => $this->resolvePictureParent($reference, 'monument', 'database/dba_monuments', $legacyLanguage),
+            'monument_details' => [LegacyLink::diagnostic('Legacy monument detail', LegacyLinkConfidence::UNSUPPORTED, $reference->raw, 'Monument details usually appear inside the parent monument page; no direct public URL rule is verified yet.')],
+            default => [],
+        };
+    }
+
+    /**
+     * @return array<int, LegacyLink>
+     */
+    private function resolveDatabaseItem(LegacyReference $reference, string $legacyType, string $backofficeSection, string $legacyLanguage, int $requiredParts): array
+    {
+        if (! $reference->hasParts($requiredParts)) {
+            return [];
+        }
+
+        [$project, $country, $holder, $number] = array_slice($reference->parts, 0, 4);
+        $host = $this->projectHost($project);
+
+        if ($host === null) {
+            return [LegacyLink::diagnostic('Legacy public page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, "No public host is configured for project {$project}.")];
+        }
+
+        return [
+            LegacyLink::public(
+                label: "Legacy {$legacyType} page",
+                url: "{$host}/database_item.php?id={$legacyType};{$project};{$country};{$holder};{$number};{$legacyLanguage}",
+                confidence: LegacyLinkConfidence::EXACT,
+                source: $reference->raw,
+            ),
+            LegacyLink::backoffice(
+                label: "Legacy {$legacyType} back-office record",
+                url: $this->backofficeUrl($backofficeSection, "1;{$project};{$country};{$holder};{$number}"),
+                confidence: LegacyLinkConfidence::EXACT,
+                source: $reference->raw,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<int, LegacyLink>
+     */
+    private function resolvePictureParent(LegacyReference $reference, string $legacyType, string $backofficeSection, string $legacyLanguage): array
+    {
+        $links = $this->resolveDatabaseItem($reference, $legacyType, $backofficeSection, $legacyLanguage, 5);
+
+        return array_map(
+            fn (LegacyLink $link): LegacyLink => new LegacyLink($link->label.' parent', $link->url, $link->type, LegacyLinkConfidence::INFERRED, $reference->raw, 'Picture items resolve to the parent legacy record.'),
+            $links,
+        );
+    }
+}

--- a/app/Support/LegacyLinks/Rules/Mwnf3PartnerLegacyUrlRule.php
+++ b/app/Support/LegacyLinks/Rules/Mwnf3PartnerLegacyUrlRule.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Support\LegacyLinks\Rules;
+
+use App\Enums\LegacyLinkConfidence;
+use App\Models\Partner;
+use App\Support\LegacyLinks\LegacyLink;
+use App\Support\LegacyLinks\LegacyReference;
+use App\Support\LegacyLinks\Rules\Concerns\BuildsLegacyUrls;
+use Illuminate\Database\Eloquent\Model;
+
+class Mwnf3PartnerLegacyUrlRule implements LegacyUrlRule
+{
+    use BuildsLegacyUrls;
+
+    public function supports(Model $record, LegacyReference $reference): bool
+    {
+        return $record instanceof Partner && $reference->schema === 'mwnf3';
+    }
+
+    public function resolve(Model $record, LegacyReference $reference, string $legacyLanguage): array
+    {
+        if (! in_array($reference->table, ['museums', 'institutions'], true) || ! $reference->hasParts(2)) {
+            return [];
+        }
+
+        $project = $this->projectCode($record);
+
+        if ($project === null) {
+            return [LegacyLink::diagnostic('Legacy partner page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, 'The partner legacy URL needs a project code from Inventory context or legacy lookup.')];
+        }
+
+        $host = $this->projectHost($project);
+
+        if ($host === null) {
+            return [LegacyLink::diagnostic('Legacy partner page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, "No public host is configured for project {$project}.")];
+        }
+
+        $type = $reference->table === 'museums' ? 'museum' : 'institution';
+        $section = $reference->table === 'museums' ? 'database/museum' : 'database/institution';
+        [$partnerCode, $country] = array_slice($reference->parts, 0, 2);
+
+        return [
+            LegacyLink::public(
+                label: 'Legacy partner page',
+                url: "{$host}/pm_partner.php?id={$partnerCode};{$country}&type={$type}&theme={$project}",
+                confidence: LegacyLinkConfidence::INFERRED,
+                source: $reference->raw,
+                note: 'Project context comes from the Inventory partner or its holdings.',
+            ),
+            LegacyLink::backoffice(
+                label: 'Legacy partner back-office record',
+                url: $this->backofficeUrl($section, "1;{$partnerCode};{$country}"),
+                confidence: LegacyLinkConfidence::EXACT,
+                source: $reference->raw,
+            ),
+        ];
+    }
+
+    private function projectCode(Partner $partner): ?string
+    {
+        $project = $this->firstProjectCode($partner->project);
+
+        if ($project !== null) {
+            return $project;
+        }
+
+        $item = $partner->items()->with('project:id,backward_compatibility')->whereNotNull('project_id')->first();
+
+        return $this->firstProjectCode($item?->project);
+    }
+}

--- a/app/Support/LegacyLinks/Rules/SharingHistoryLegacyUrlRule.php
+++ b/app/Support/LegacyLinks/Rules/SharingHistoryLegacyUrlRule.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Support\LegacyLinks\Rules;
+
+use App\Enums\LegacyLinkConfidence;
+use App\Models\Collection;
+use App\Models\Item;
+use App\Models\Partner;
+use App\Support\LegacyLinks\LegacyLink;
+use App\Support\LegacyLinks\LegacyReference;
+use App\Support\LegacyLinks\Rules\Concerns\BuildsLegacyUrls;
+use Illuminate\Database\Eloquent\Model;
+
+class SharingHistoryLegacyUrlRule implements LegacyUrlRule
+{
+    use BuildsLegacyUrls;
+
+    public function supports(Model $record, LegacyReference $reference): bool
+    {
+        return $reference->schema === 'mwnf3_sharing_history'
+            && ($record instanceof Item || $record instanceof Collection || $record instanceof Partner);
+    }
+
+    public function resolve(Model $record, LegacyReference $reference, string $legacyLanguage): array
+    {
+        if ($record instanceof Item) {
+            return $this->resolveItem($reference, $legacyLanguage);
+        }
+
+        if ($record instanceof Collection) {
+            return $this->resolveCollection($record, $reference, $legacyLanguage);
+        }
+
+        if ($record instanceof Partner) {
+            return $this->resolvePartner($record, $reference);
+        }
+
+        return [];
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveItem(LegacyReference $reference, string $legacyLanguage): array
+    {
+        $type = match ($reference->table) {
+            'sh_objects', 'sh_object_images' => 'object',
+            'sh_monuments', 'sh_monument_images' => 'monument',
+            default => null,
+        };
+
+        if ($type === null || ! $reference->hasParts(3)) {
+            return [];
+        }
+
+        [$project, $country, $number] = array_slice($reference->parts, 0, 3);
+        $confidence = str_contains($reference->table, '_images') ? LegacyLinkConfidence::INFERRED : LegacyLinkConfidence::EXACT;
+        $note = $confidence === LegacyLinkConfidence::INFERRED ? 'Image items resolve to the parent legacy page.' : null;
+
+        return [
+            LegacyLink::public(
+                label: "Sharing History {$type} page",
+                url: $this->host('sharing_history')."/database_item.php?id={$type};{$project};{$country};{$number};{$legacyLanguage}",
+                confidence: $confidence,
+                source: $reference->raw,
+                note: $note,
+            ),
+            LegacyLink::backoffice(
+                label: "Sharing History {$type} back-office record",
+                url: $this->backofficeUrl($type === 'object' ? 'sh/sh_objects' : 'sh/sh_monuments', '1;'.strtoupper($project).";{$country};{$number}"),
+                confidence: $confidence,
+                source: $reference->raw,
+                note: $note,
+            ),
+        ];
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveCollection(Collection $collection, LegacyReference $reference, string $legacyLanguage): array
+    {
+        $host = $this->host('sharing_history');
+
+        return match ($reference->table) {
+            'sh_projects' => $reference->hasParts(1)
+                ? [
+                    LegacyLink::public('Sharing History landing page', "{$host}/index.php", LegacyLinkConfidence::EXACT, $reference->raw),
+                    LegacyLink::backoffice('Sharing History project back-office record', $this->backofficeUrl('sh/sh_projects', '1;'.strtoupper((string) $reference->part(0))), LegacyLinkConfidence::EXACT, $reference->raw),
+                ]
+                : [],
+            'sh_exhibitions' => $reference->hasParts(1)
+                ? [
+                    LegacyLink::public('Sharing History exhibition items', "{$host}/exh_items.php?eId={$reference->part(0)}&lan={$legacyLanguage}", LegacyLinkConfidence::INFERRED, $reference->raw),
+                    LegacyLink::backoffice('Sharing History exhibition back-office record', $this->backofficeUrl('sh/sh_exhibitions', "1;{$reference->part(0)}"), LegacyLinkConfidence::EXACT, $reference->raw),
+                ]
+                : [],
+            'sh_exhibition_themes' => $this->resolveThemeCollection($collection, $reference, $legacyLanguage),
+            default => [],
+        };
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveThemeCollection(Collection $collection, LegacyReference $reference, string $legacyLanguage): array
+    {
+        $parentReference = LegacyReference::parse($collection->parent?->backward_compatibility);
+
+        if (! $parentReference?->is('mwnf3_sharing_history', 'sh_exhibitions') || ! $parentReference->hasParts(1)) {
+            return [LegacyLink::diagnostic('Sharing History theme page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, 'Theme URLs need the parent exhibition id.')];
+        }
+
+        return [
+            LegacyLink::public(
+                label: 'Sharing History exhibition items',
+                url: $this->host('sharing_history')."/exh_items.php?eId={$parentReference->part(0)}&lan={$legacyLanguage}",
+                confidence: LegacyLinkConfidence::INFERRED,
+                source: $reference->raw,
+                note: 'Theme collections resolve to their parent exhibition item list.',
+            ),
+            LegacyLink::backoffice(
+                label: 'Sharing History exhibition theme back-office record',
+                url: $this->backofficeUrl('sh/sh_exhibitions', "1;{$parentReference->part(0)};{$reference->part(0)}"),
+                confidence: LegacyLinkConfidence::INFERRED,
+                source: $reference->raw,
+                note: 'Theme collections resolve through their parent exhibition record.',
+            ),
+        ];
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolvePartner(Partner $partner, LegacyReference $reference): array
+    {
+        if ($reference->table !== 'sh_partners' || ! $reference->hasParts(1)) {
+            return [];
+        }
+
+        $country = $this->legacyCountryCode($partner->country);
+
+        if ($country === null) {
+            return [LegacyLink::diagnostic('Sharing History partner page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, 'The partner legacy URL needs a country code.')];
+        }
+
+        $project = config('legacy.links.sharing_history_project', 'AWE');
+        $partnerCode = strtoupper((string) $reference->part(0));
+
+        return [
+            LegacyLink::public(
+                label: 'Sharing History partner page',
+                url: $this->host('sharing_history')."/pm_partner.php?id={$partnerCode};{$country}&shpro={$project}&",
+                confidence: LegacyLinkConfidence::INFERRED,
+                source: $reference->raw,
+                note: 'Country context comes from the Inventory partner.',
+            ),
+            LegacyLink::backoffice(
+                label: 'Sharing History partner back-office record',
+                url: $this->backofficeUrl('sh/sh_partners', '1;'.(string) $reference->part(0)),
+                confidence: LegacyLinkConfidence::EXACT,
+                source: $reference->raw,
+            ),
+        ];
+    }
+}

--- a/app/Support/LegacyLinks/Rules/ThematicGalleryLegacyUrlRule.php
+++ b/app/Support/LegacyLinks/Rules/ThematicGalleryLegacyUrlRule.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Support\LegacyLinks\Rules;
+
+use App\Enums\LegacyLinkConfidence;
+use App\Models\Collection;
+use App\Support\LegacyLinks\LegacyLink;
+use App\Support\LegacyLinks\LegacyReference;
+use App\Support\LegacyLinks\Rules\Concerns\BuildsLegacyUrls;
+use Illuminate\Database\Eloquent\Model;
+
+class ThematicGalleryLegacyUrlRule implements LegacyUrlRule
+{
+    use BuildsLegacyUrls;
+
+    public function supports(Model $record, LegacyReference $reference): bool
+    {
+        return $record instanceof Collection && $reference->schema === 'mwnf3_thematic_gallery';
+    }
+
+    public function resolve(Model $record, LegacyReference $reference, string $legacyLanguage): array
+    {
+        return match ($reference->table) {
+            'thg_gallery' => $this->resolveGallery($reference, $legacyLanguage),
+            'theme' => $this->resolveTheme($reference, $legacyLanguage),
+            default => [],
+        };
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveGallery(LegacyReference $reference, string $legacyLanguage): array
+    {
+        if (! $reference->hasParts(1)) {
+            return [];
+        }
+
+        $landing = $this->landingUrl((string) $reference->part(0), $legacyLanguage);
+
+        if ($landing === null) {
+            return [LegacyLink::diagnostic('Thematic gallery landing page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, 'The gallery id needs a configured public slug or host.')];
+        }
+
+        return [
+            LegacyLink::public('Thematic gallery landing page', $landing, LegacyLinkConfidence::EXACT, $reference->raw),
+            LegacyLink::backoffice('Thematic gallery back-office record', $this->backofficeUrl('thg/thg_galleries', "1;{$reference->part(0)}"), LegacyLinkConfidence::EXACT, $reference->raw),
+        ];
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveTheme(LegacyReference $reference, string $legacyLanguage): array
+    {
+        if (! $reference->hasParts(2)) {
+            return [];
+        }
+
+        $landing = $this->landingUrl((string) $reference->part(0), $legacyLanguage);
+
+        if ($landing === null) {
+            return [LegacyLink::diagnostic('Thematic gallery theme page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, 'Theme URLs need the gallery public slug or host.')];
+        }
+
+        return [
+            LegacyLink::public('Thematic gallery theme page', rtrim($landing, '/')."/theme/{$reference->part(1)}", LegacyLinkConfidence::EXACT, $reference->raw),
+            LegacyLink::backoffice('Thematic gallery theme back-office record', $this->backofficeUrl('thg/thg_galleries', "1;{$reference->part(0)};{$reference->part(1)}"), LegacyLinkConfidence::EXACT, $reference->raw),
+        ];
+    }
+
+    private function landingUrl(string $galleryId, string $legacyLanguage): ?string
+    {
+        $mapping = config("legacy.links.thematic_galleries.{$galleryId}");
+
+        if (! is_array($mapping) || ! isset($mapping['base_url'])) {
+            return null;
+        }
+
+        $baseUrl = rtrim((string) $mapping['base_url'], '/');
+        $path = trim(str_replace('{lang}', $legacyLanguage, (string) ($mapping['path'] ?? '')), '/');
+
+        return $path === '' ? $baseUrl : "{$baseUrl}/{$path}";
+    }
+}

--- a/app/Support/LegacyLinks/Rules/TravelsLegacyUrlRule.php
+++ b/app/Support/LegacyLinks/Rules/TravelsLegacyUrlRule.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Support\LegacyLinks\Rules;
+
+use App\Enums\LegacyLinkConfidence;
+use App\Models\Collection;
+use App\Support\LegacyLinks\LegacyLink;
+use App\Support\LegacyLinks\LegacyReference;
+use App\Support\LegacyLinks\Rules\Concerns\BuildsLegacyUrls;
+use Illuminate\Database\Eloquent\Model;
+
+class TravelsLegacyUrlRule implements LegacyUrlRule
+{
+    use BuildsLegacyUrls;
+
+    public function supports(Model $record, LegacyReference $reference): bool
+    {
+        return $record instanceof Collection && $reference->schema === 'mwnf3_travels';
+    }
+
+    public function resolve(Model $record, LegacyReference $reference, string $legacyLanguage): array
+    {
+        return match ($reference->table) {
+            'trail' => $this->resolveTrail($reference, $legacyLanguage),
+            'itinerary' => $this->resolveItinerary($reference, $legacyLanguage),
+            'location' => $this->resolveLocation($reference, $legacyLanguage),
+            default => [],
+        };
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveTrail(LegacyReference $reference, string $legacyLanguage): array
+    {
+        if (! $reference->hasParts(3)) {
+            return [];
+        }
+
+        [$theme, $country, $trail] = array_slice($reference->parts, 0, 3);
+
+        return [
+            LegacyLink::public('Travels trail page', $this->host('travels')."/travel_et_trailDetail.php?id={$theme};{$country};{$trail};{$legacyLanguage}&fl=its", LegacyLinkConfidence::EXACT, $reference->raw),
+            LegacyLink::backoffice('Travels trail back-office record', $this->backofficeUrl('travel/trails', "1;{$theme};{$country};{$trail}"), LegacyLinkConfidence::EXACT, $reference->raw),
+        ];
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveItinerary(LegacyReference $reference, string $legacyLanguage): array
+    {
+        if (! $reference->hasParts(4)) {
+            return [];
+        }
+
+        [$theme, $country, $trail, $itinerary] = array_slice($reference->parts, 0, 4);
+
+        return [
+            LegacyLink::public('Travels itinerary page', $this->host('travels')."/travel_et_itenary.php?id={$theme};{$country};{$itinerary};{$legacyLanguage};{$trail}&fl=des", LegacyLinkConfidence::EXACT, $reference->raw),
+            LegacyLink::backoffice('Travels itinerary back-office record', $this->backofficeUrl('travel/trails', "2;{$theme};{$country};{$trail};{$itinerary}"), LegacyLinkConfidence::EXACT, $reference->raw),
+        ];
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveLocation(LegacyReference $reference, string $legacyLanguage): array
+    {
+        $links = $this->resolveItinerary($reference, $legacyLanguage);
+
+        return array_map(
+            fn (LegacyLink $link): LegacyLink => new LegacyLink(
+                $link->type->value === 'backoffice' ? 'Travels parent itinerary back-office record' : 'Travels parent itinerary page',
+                $link->url,
+                $link->type,
+                LegacyLinkConfidence::INFERRED,
+                $reference->raw,
+                'Location collections resolve to the parent itinerary record.'
+            ),
+            $links,
+        );
+    }
+}

--- a/config/legacy.php
+++ b/config/legacy.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'links' => [
+        'public_hosts' => [
+            'projects' => [
+                'ISL' => 'https://islamicart.museumwnf.org',
+                'EPM' => 'https://islamicart.museumwnf.org',
+                'BAR' => 'https://baroqueart.museumwnf.org',
+                'AMA' => 'https://baroqueart.museumwnf.org',
+                'EXHCOLOUR' => 'https://exhibitions.museumwnf.org',
+            ],
+            'sharing_history' => 'https://sharinghistory.museumwnf.org',
+            'explore' => 'https://explore.museumwnf.org',
+            'travels' => 'https://travels.museumwnf.org',
+            'portal' => 'https://museumwnf.org',
+            'exhibitions' => 'https://exhibitions.museumwnf.org',
+        ],
+
+        'backoffice_host' => 'https://virtual-office.museumwnf.org',
+
+        'languages' => [
+            'eng' => 'en',
+            'fra' => 'fr',
+            'deu' => 'de',
+            'spa' => 'es',
+            'ita' => 'it',
+            'por' => 'pt',
+            'ara' => 'ar',
+        ],
+
+        'sharing_history_project' => 'AWE',
+
+        'thematic_galleries' => [
+            '4' => [
+                'base_url' => 'https://amulets.museumwnf.org',
+                'path' => '',
+            ],
+            '47' => [
+                'base_url' => 'https://exhibitions.museumwnf.org',
+                'path' => 'the_use_of_colours_in_art/{lang}',
+            ],
+        ],
+    ],
+];

--- a/docs/understanding/index.md
+++ b/docs/understanding/index.md
@@ -16,7 +16,8 @@ This section explains MWNF Inventory for customers, content owners, and validati
 2. [Core Model](core-model) explains the main content concepts and how they relate.
 3. [Legacy Import](legacy-import) explains how source data moves into the new model.
 4. [Validation Guide](validation-guide) gives practical checks for import review.
-5. [System Architecture](system-architecture) explains how the back-office, APIs, importer, and documentation fit together.
+5. [Legacy URL Mapping](legacy-url-mapping) explains how imported records link back to legacy public and back-office URLs.
+6. [System Architecture](system-architecture) explains how the back-office, APIs, importer, and documentation fit together.
 
 ## Current project focus
 

--- a/docs/understanding/legacy-import.md
+++ b/docs/understanding/legacy-import.md
@@ -90,4 +90,5 @@ Examples:
 ## Related reference
 
 - [Validation Guide](validation-guide) gives practical checks for customer review.
+- [Legacy URL Mapping](legacy-url-mapping) explains how `backward_compatibility` values map back to legacy public and back-office URLs.
 - [Importer Orientation](../collaborators/importer) gives developer-level file locations.

--- a/docs/understanding/legacy-url-mapping.md
+++ b/docs/understanding/legacy-url-mapping.md
@@ -1,0 +1,128 @@
+---
+layout: default
+title: Legacy URL Mapping
+parent: Understanding the Inventory
+nav_order: 5
+---
+
+# Legacy URL Mapping
+
+Use this guide when you turn an imported record's `backward_compatibility` value into links back to legacy MWNF websites and back-office tools.
+
+The Legacy Link Resolver supports import validation in `/admin`. It resolves links for Items, Collections, and Partners, and it reports whether each result is exact, inferred, needs lookup data, or is unsupported.
+
+## Result types
+
+| Result type | Meaning |
+|---|---|
+| `exact` | The `backward_compatibility` value contains all parts needed to build the legacy URL. |
+| `inferred` | The resolver combines `backward_compatibility` with Inventory context such as project, parent collection, or country. |
+| `requires_lookup` | The resolver needs legacy data such as a slug, hash, parent country, location, or partner code before it can build the URL. |
+| `unsupported` | The source family is known, but no reliable URL rule exists yet. |
+
+Display the result type with the URL. Do not hide uncertainty from reviewers.
+
+## Link types
+
+| Link type | Use |
+|---|---|
+| `public` | Opens the user-facing legacy website. |
+| `backoffice` | Opens the legacy editing or administration surface. |
+| `source` | Opens a related legacy source page when the visible page is not native to the current source family. |
+| `diagnostic` | Explains why a URL cannot be built yet. |
+
+Some records have more than one useful public link. For example, an Islamic Art object can have its canonical Islamic Art page and one or more thematic-gallery pages.
+
+Store back-office route patterns separately from public hosts and mark unknown rules as `requires_lookup` or `unsupported` until you verify them against legacy back-office routes.
+
+The back-office host is always `https://virtual-office.museumwnf.org`. It is a private domain and requires VPN access. Resolver rules build back-office links with `section` and `edit` query parameters that match the Virtual Office router.
+
+## Language handling
+
+Inventory stores normalized language identifiers such as `eng`, `fra`, and `spa`. Legacy public URLs usually use two-letter codes such as `en`, `fr`, and `es`.
+
+Use `languages.backward_compatibility` when you build a legacy URL. Default to `en` when the caller does not request a language.
+
+## Public host map
+
+| Source family | Public host |
+|---|---|
+| Islamic Art projects `ISL` and `EPM` | `https://islamicart.museumwnf.org` |
+| Baroque Art projects `BAR` and `AMA` | `https://baroqueart.museumwnf.org` |
+| Sharing History | `https://sharinghistory.museumwnf.org` |
+| Explore | `https://explore.museumwnf.org` |
+| Travels | `https://travels.museumwnf.org` |
+| MWNF Portal | `https://museumwnf.org` |
+| Thematic-gallery exhibition pages | `https://exhibitions.museumwnf.org` |
+| Thematic-gallery standalone gallery pages | Gallery-specific hosts such as `https://amulets.museumwnf.org` |
+
+Keep this map in configuration. Do not hard-code production hosts inside rule classes.
+
+## Test fixture examples
+
+These examples come from `scripts/importer/gap_analysis` reports and form the first resolver fixture set.
+
+| Record type | `backward_compatibility` | Expected public result |
+|---|---|---|
+| Item | `mwnf3:objects:ISL:eg:Mus01:1` | `https://islamicart.museumwnf.org/database_item.php?id=object;ISL;eg;Mus01;1;en` |
+| Item | `mwnf3:monuments:BAR:pt:Mon11:23` | `https://baroqueart.museumwnf.org/database_item.php?id=monument;BAR;pt;Mon11;23;en` |
+| Item | `mwnf3_sharing_history:sh_objects:awe:at:26` | `https://sharinghistory.museumwnf.org/database_item.php?id=object;awe;at;26;en` |
+| Collection | `mwnf3_travels:trail:IAM:pt:1` | `https://travels.museumwnf.org/travel_et_trailDetail.php?id=IAM;pt;1;en&fl=its` |
+| Collection | `mwnf3_travels:itinerary:IAM:pt:1:I` | `https://travels.museumwnf.org/travel_et_itenary.php?id=IAM;pt;I;en;1&fl=des` |
+| Collection | `mwnf3_explore:country:eg` | `https://explore.museumwnf.org/countries/c-eg` |
+| Collection | `mwnf3_thematic_gallery:thg_gallery:47` | `https://exhibitions.museumwnf.org/the_use_of_colours_in_art/en` |
+| Partner | `mwnf3:museums:Mus01:eg` with project `ISL` | `https://islamicart.museumwnf.org/pm_partner.php?id=Mus01;eg&type=museum&theme=ISL` |
+| Partner | `mwnf3_sharing_history:sh_partners:at_01` with country `at` | `https://sharinghistory.museumwnf.org/pm_partner.php?id=AT_01;at&shpro=AWE&` |
+
+Representative back-office links:
+
+| Record type | `backward_compatibility` | Expected back-office result |
+|---|---|---|
+| Item | `mwnf3:objects:ISL:eg:Mus01:1` | `https://virtual-office.museumwnf.org/?section=database/dba_objects&edit=1;ISL;eg;Mus01;1&` |
+| Item | `mwnf3:monuments:BAR:pt:Mon11:23` | `https://virtual-office.museumwnf.org/?section=database/dba_monuments&edit=1;BAR;pt;Mon11;23&` |
+| Item | `mwnf3_sharing_history:sh_objects:awe:at:26` | `https://virtual-office.museumwnf.org/?section=sh/sh_objects&edit=1;AWE;at;26&` |
+| Collection | `mwnf3_travels:trail:IAM:pt:1` | `https://virtual-office.museumwnf.org/?section=travel/trails&edit=1;IAM;pt;1&` |
+| Collection | `mwnf3_thematic_gallery:thg_gallery:47` | `https://virtual-office.museumwnf.org/?section=thg/thg_galleries&edit=1;47&` |
+| Partner | `mwnf3:museums:Mus01:eg` | `https://virtual-office.museumwnf.org/?section=database/museum&edit=1;Mus01;eg&` |
+
+## Initial rule matrix
+
+| Inventory type | Source pattern | Public URL confidence |
+|---|---|---|
+| Item | `mwnf3:objects:{project}:{country}:{museum}:{number}` | Exact for configured project hosts. |
+| Item | `mwnf3:monuments:{project}:{country}:{institution}:{number}` | Exact for configured project hosts. |
+| Item | `mwnf3:monument_details:...` | Unsupported until detail URL rules are confirmed. |
+| Item | `mwnf3_sharing_history:sh_objects:{project}:{country}:{number}` | Exact Sharing History object URL. |
+| Item | `mwnf3_explore:monument:{id}` | Requires parent country and location lookup unless Inventory context provides them. |
+| Collection | `mwnf3_sharing_history:sh_exhibitions:{id}` | Inferred exhibition item-list URL. |
+| Collection | `mwnf3_thematic_gallery:thg_gallery:{id}` | Exact only when the configured gallery slug or host is known. |
+| Collection | `mwnf3_thematic_gallery:theme:{gallery}:{theme}` | Exact only when the configured gallery slug or host is known. |
+| Collection | `mwnf3_travels:trail:{theme}:{country}:{trail}` | Exact Travels trail URL. |
+| Collection | `mwnf3_travels:itinerary:{theme}:{country}:{trail}:{itinerary}` | Exact Travels itinerary URL without optional `itrNo`. |
+| Collection | `mwnf3_explore:country:{country}` | Exact Explore country URL. |
+| Collection | `mwnf3_explore:location:{id}` | Inferred when Inventory has country context. |
+| Partner | `mwnf3:museums:{museum}:{country}` | Inferred when Inventory has project context. |
+| Partner | `mwnf3:institutions:{institution}:{country}` | Inferred when Inventory has project context. |
+| Partner | `mwnf3_sharing_history:sh_partners:{id}` | Inferred when Inventory has country context. |
+
+## Resolver behavior
+
+The resolver must:
+
+1. Parse `backward_compatibility` into source family, table, and key parts.
+2. Choose a rule by source family, table, and Inventory model type.
+3. Use the requested Inventory language to find the legacy language code.
+4. Use project, parent Collection, country, or context only when the rule declares that it needs model context.
+5. Return all matching links with result type and notes.
+6. Return visible diagnostics for unsupported and unresolved mappings.
+7. Fail explicitly for ambiguous rules instead of choosing a legacy URL by guesswork.
+
+## Known gaps
+
+- Thematic-gallery collection URLs need a durable gallery id to slug or host lookup for every gallery.
+- Explore monument URLs need parent country and location lookup.
+- Sharing History partner URLs need partner country and public partner code lookup.
+- `mwnf3` exhibition URLs need legacy exhibition slug, theme, and page lookup.
+- Monument detail and picture Item URLs need a decision: link to parent pages or verify separate legacy detail/image routes.
+
+Keep this page current as new rules are verified. Treat it as the input ledger for the Legacy Link Resolver.

--- a/docs/understanding/system-architecture.md
+++ b/docs/understanding/system-architecture.md
@@ -2,7 +2,7 @@
 layout: default
 title: System Architecture
 parent: Understanding the Inventory
-nav_order: 5
+nav_order: 6
 ---
 
 # System Architecture

--- a/docs/understanding/validation-guide.md
+++ b/docs/understanding/validation-guide.md
@@ -14,10 +14,11 @@ Use this guide when you compare imported Inventory records with legacy data. The
 1. Start from the Inventory record you want to validate.
 2. Find its `backward_compatibility` value.
 3. Use the value to identify the legacy source table and key values.
-4. Compare the Inventory record with the source rows.
-5. Check translations by language and context.
-6. Check images after image synchronization has run.
-7. Check relationships through Collections, Item Links, Tags, and parent-child Items.
+4. Use [Legacy URL Mapping](legacy-url-mapping) when you need to open the matching legacy public page or back-office record.
+5. Compare the Inventory record with the source rows.
+6. Check translations by language and context.
+7. Check images after image synchronization has run.
+8. Check relationships through Collections, Item Links, Tags, and parent-child Items.
 
 ## Item checks
 

--- a/tests/Filament/Resources/LegacyLinksInfolistTest.php
+++ b/tests/Filament/Resources/LegacyLinksInfolistTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Filament\Resources;
+
+use App\Enums\ItemType;
+use App\Enums\Permission;
+use App\Models\Collection;
+use App\Models\Item;
+use App\Models\Partner;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LegacyLinksInfolistTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_item_view_shows_resolved_legacy_links(): void
+    {
+        $user = $this->createCrudUser();
+        $item = Item::factory()->create([
+            'type' => ItemType::OBJECT,
+            'internal_name' => 'Perfume sprinkler',
+            'backward_compatibility' => 'mwnf3:objects:ISL:eg:Mus01:1',
+        ]);
+
+        $this->actingAs($user)
+            ->get("/admin/items/{$item->getRouteKey()}")
+            ->assertOk()
+            ->assertSee('Legacy links')
+            ->assertSee('Legacy object page')
+            ->assertSee('islamicart.museumwnf.org')
+            ->assertSee('Legacy object back-office record')
+            ->assertSee('virtual-office.museumwnf.org');
+    }
+
+    public function test_collection_view_shows_resolved_legacy_links(): void
+    {
+        $user = $this->createCrudUser();
+        $collection = Collection::factory()->exhibitionTrail()->create([
+            'internal_name' => 'Portugal trail',
+            'backward_compatibility' => 'mwnf3_travels:trail:IAM:pt:1',
+        ]);
+
+        $this->actingAs($user)
+            ->get("/admin/collections/{$collection->getRouteKey()}")
+            ->assertOk()
+            ->assertSee('Legacy links')
+            ->assertSee('Travels trail page')
+            ->assertSee('travels.museumwnf.org')
+            ->assertSee('Travels trail back-office record')
+            ->assertSee('virtual-office.museumwnf.org');
+    }
+
+    public function test_partner_view_shows_resolved_legacy_links(): void
+    {
+        $user = $this->createCrudUser();
+        $project = Project::factory()->create(['backward_compatibility' => 'ISL']);
+        $partner = Partner::factory()->Museum()->create([
+            'internal_name' => 'Museum of Islamic Art',
+            'backward_compatibility' => 'mwnf3:museums:Mus01:eg',
+            'project_id' => $project->id,
+        ]);
+
+        $this->actingAs($user)
+            ->get("/admin/partners/{$partner->getRouteKey()}")
+            ->assertOk()
+            ->assertSee('Legacy links')
+            ->assertSee('Legacy partner page')
+            ->assertSee('islamicart.museumwnf.org')
+            ->assertSee('Legacy partner back-office record')
+            ->assertSee('virtual-office.museumwnf.org');
+    }
+
+    public function test_unresolved_mapping_shows_diagnostic(): void
+    {
+        $user = $this->createCrudUser();
+        $partner = Partner::factory()->Museum()->create([
+            'internal_name' => 'Museum without project',
+            'backward_compatibility' => 'mwnf3:museums:Mus01:eg',
+        ]);
+
+        $this->actingAs($user)
+            ->get("/admin/partners/{$partner->getRouteKey()}")
+            ->assertOk()
+            ->assertSee('Legacy links')
+            ->assertSee('Requires lookup')
+            ->assertSee('The partner legacy URL needs a project code');
+    }
+
+    protected function createCrudUser(): User
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $user->givePermissionTo([
+            Permission::ACCESS_ADMIN_PANEL->value,
+            Permission::VIEW_DATA->value,
+            Permission::CREATE_DATA->value,
+            Permission::UPDATE_DATA->value,
+            Permission::DELETE_DATA->value,
+        ]);
+
+        return $user;
+    }
+}

--- a/tests/Unit/Support/LegacyLinks/LegacyReferenceTest.php
+++ b/tests/Unit/Support/LegacyLinks/LegacyReferenceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit\Support\LegacyLinks;
+
+use App\Support\LegacyLinks\LegacyReference;
+use Tests\TestCase;
+
+class LegacyReferenceTest extends TestCase
+{
+    public function test_parse_splits_schema_table_and_parts(): void
+    {
+        $reference = LegacyReference::parse('mwnf3:objects:ISL:eg:Mus01:1');
+
+        $this->assertNotNull($reference);
+        $this->assertSame('mwnf3', $reference->schema);
+        $this->assertSame('objects', $reference->table);
+        $this->assertSame(['ISL', 'eg', 'Mus01', '1'], $reference->parts);
+        $this->assertSame('Mus01', $reference->part(2));
+        $this->assertTrue($reference->is('mwnf3', 'objects'));
+    }
+
+    public function test_parse_rejects_empty_or_malformed_values(): void
+    {
+        $this->assertNull(LegacyReference::parse(null));
+        $this->assertNull(LegacyReference::parse(''));
+        $this->assertNull(LegacyReference::parse('mwnf3'));
+        $this->assertNull(LegacyReference::parse(':objects:1'));
+    }
+}

--- a/tests/Unit/Support/LegacyLinks/LegacyUrlResolverTest.php
+++ b/tests/Unit/Support/LegacyLinks/LegacyUrlResolverTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Unit\Support\LegacyLinks;
+
+use App\Enums\LegacyLinkConfidence;
+use App\Enums\LegacyLinkType;
+use App\Models\Collection;
+use App\Models\Country;
+use App\Models\Item;
+use App\Models\Partner;
+use App\Models\Project;
+use App\Services\LegacyUrlResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LegacyUrlResolverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private LegacyUrlResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resolver = new LegacyUrlResolver;
+    }
+
+    public function test_resolves_mwnf3_object_fixture(): void
+    {
+        $item = Item::factory()->Object()->create(['backward_compatibility' => 'mwnf3:objects:ISL:eg:Mus01:1']);
+
+        $link = $this->resolver->resolveFor($item)->links[0];
+        $links = $this->resolver->resolveFor($item)->links;
+
+        $this->assertSame('https://islamicart.museumwnf.org/database_item.php?id=object;ISL;eg;Mus01;1;en', $link->url);
+        $this->assertSame(LegacyLinkConfidence::EXACT, $link->confidence);
+        $this->assertBackofficeUrl($links, 'https://virtual-office.museumwnf.org/?section=database/dba_objects&edit=1;ISL;eg;Mus01;1&');
+    }
+
+    public function test_resolves_mwnf3_monument_fixture(): void
+    {
+        $item = Item::factory()->Monument()->create(['backward_compatibility' => 'mwnf3:monuments:BAR:pt:Mon11:23']);
+
+        $link = $this->resolver->resolveFor($item)->links[0];
+        $links = $this->resolver->resolveFor($item)->links;
+
+        $this->assertSame('https://baroqueart.museumwnf.org/database_item.php?id=monument;BAR;pt;Mon11;23;en', $link->url);
+        $this->assertSame(LegacyLinkConfidence::EXACT, $link->confidence);
+        $this->assertBackofficeUrl($links, 'https://virtual-office.museumwnf.org/?section=database/dba_monuments&edit=1;BAR;pt;Mon11;23&');
+    }
+
+    public function test_resolves_sharing_history_object_fixture(): void
+    {
+        $item = Item::factory()->Object()->create(['backward_compatibility' => 'mwnf3_sharing_history:sh_objects:awe:at:26']);
+
+        $link = $this->resolver->resolveFor($item)->links[0];
+        $links = $this->resolver->resolveFor($item)->links;
+
+        $this->assertSame('https://sharinghistory.museumwnf.org/database_item.php?id=object;awe;at;26;en', $link->url);
+        $this->assertSame(LegacyLinkConfidence::EXACT, $link->confidence);
+        $this->assertBackofficeUrl($links, 'https://virtual-office.museumwnf.org/?section=sh/sh_objects&edit=1;AWE;at;26&');
+    }
+
+    public function test_resolves_travels_trail_and_itinerary_fixtures(): void
+    {
+        $trail = Collection::factory()->exhibitionTrail()->create(['backward_compatibility' => 'mwnf3_travels:trail:IAM:pt:1']);
+        $itinerary = Collection::factory()->itinerary()->create(['backward_compatibility' => 'mwnf3_travels:itinerary:IAM:pt:1:I']);
+
+        $trailLink = $this->resolver->resolveFor($trail)->links[0];
+        $itineraryLink = $this->resolver->resolveFor($itinerary)->links[0];
+
+        $this->assertSame('https://travels.museumwnf.org/travel_et_trailDetail.php?id=IAM;pt;1;en&fl=its', $trailLink->url);
+        $this->assertSame('https://travels.museumwnf.org/travel_et_itenary.php?id=IAM;pt;I;en;1&fl=des', $itineraryLink->url);
+        $this->assertSame(LegacyLinkConfidence::EXACT, $trailLink->confidence);
+        $this->assertSame(LegacyLinkConfidence::EXACT, $itineraryLink->confidence);
+        $this->assertBackofficeUrl($this->resolver->resolveFor($trail)->links, 'https://virtual-office.museumwnf.org/?section=travel/trails&edit=1;IAM;pt;1&');
+        $this->assertBackofficeUrl($this->resolver->resolveFor($itinerary)->links, 'https://virtual-office.museumwnf.org/?section=travel/trails&edit=2;IAM;pt;1;I&');
+    }
+
+    public function test_resolves_explore_country_fixture(): void
+    {
+        $collection = Collection::factory()->create(['backward_compatibility' => 'mwnf3_explore:country:eg']);
+
+        $link = $this->resolver->resolveFor($collection)->links[0];
+        $links = $this->resolver->resolveFor($collection)->links;
+
+        $this->assertSame('https://explore.museumwnf.org/countries/c-eg', $link->url);
+        $this->assertSame(LegacyLinkConfidence::EXACT, $link->confidence);
+        $this->assertBackofficeUrl($links, 'https://virtual-office.museumwnf.org/?section=explore/explore_country&edit=1;eg&');
+    }
+
+    public function test_resolves_thematic_gallery_configured_fixture(): void
+    {
+        $collection = Collection::factory()->gallery()->create(['backward_compatibility' => 'mwnf3_thematic_gallery:thg_gallery:47']);
+
+        $link = $this->resolver->resolveFor($collection)->links[0];
+        $links = $this->resolver->resolveFor($collection)->links;
+
+        $this->assertSame('https://exhibitions.museumwnf.org/the_use_of_colours_in_art/en', $link->url);
+        $this->assertSame(LegacyLinkConfidence::EXACT, $link->confidence);
+        $this->assertBackofficeUrl($links, 'https://virtual-office.museumwnf.org/?section=thg/thg_galleries&edit=1;47&');
+    }
+
+    public function test_resolves_mwnf3_partner_with_project_context(): void
+    {
+        $project = Project::factory()->create(['backward_compatibility' => 'ISL']);
+        $partner = Partner::factory()->Museum()->create([
+            'backward_compatibility' => 'mwnf3:museums:Mus01:eg',
+            'project_id' => $project->id,
+        ]);
+
+        $link = $this->resolver->resolveFor($partner)->links[0];
+        $links = $this->resolver->resolveFor($partner)->links;
+
+        $this->assertSame('https://islamicart.museumwnf.org/pm_partner.php?id=Mus01;eg&type=museum&theme=ISL', $link->url);
+        $this->assertSame(LegacyLinkConfidence::INFERRED, $link->confidence);
+        $this->assertBackofficeUrl($links, 'https://virtual-office.museumwnf.org/?section=database/museum&edit=1;Mus01;eg&');
+    }
+
+    public function test_resolves_explore_location_with_country_context(): void
+    {
+        $country = Country::factory()->create(['id' => 'egy', 'backward_compatibility' => 'eg']);
+        $collection = Collection::factory()->location()->create([
+            'backward_compatibility' => 'mwnf3_explore:location:2',
+            'country_id' => $country->id,
+        ]);
+
+        $link = $this->resolver->resolveFor($collection)->links[0];
+        $links = $this->resolver->resolveFor($collection)->links;
+
+        $this->assertSame('https://explore.museumwnf.org/countries/c-eg/l-2', $link->url);
+        $this->assertSame(LegacyLinkConfidence::INFERRED, $link->confidence);
+        $this->assertBackofficeUrl($links, 'https://virtual-office.museumwnf.org/?section=explore/explore_locations&edit=1;2&');
+    }
+
+    public function test_unresolved_partner_mapping_returns_visible_diagnostic(): void
+    {
+        $partner = Partner::factory()->Museum()->create(['backward_compatibility' => 'mwnf3:museums:Mus01:eg']);
+
+        $link = $this->resolver->resolveFor($partner)->links[0];
+
+        $this->assertNull($link->url);
+        $this->assertSame(LegacyLinkConfidence::REQUIRES_LOOKUP, $link->confidence);
+        $this->assertStringContainsString('project code', $link->note);
+    }
+
+    private function assertBackofficeUrl(array $links, string $expectedUrl): void
+    {
+        $backofficeLinks = array_values(array_filter(
+            $links,
+            fn ($link): bool => $link->type === LegacyLinkType::BACKOFFICE,
+        ));
+
+        $this->assertNotEmpty($backofficeLinks);
+        $this->assertSame($expectedUrl, $backofficeLinks[0]->url);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a Legacy Link Resolver for Items, Collections, and Partners with public, back-office, and diagnostic link results.
- Surface read-only legacy links in Filament Item, Collection, and Partner infolists.
- Configure the private Virtual Office back-office host and route mappings for confirmed legacy sections like `database/dba_objects`, `database/dba_monuments`, `sh/sh_objects`, `travel/trails`, and `thg/thg_galleries`.
- Document the resolver rule ledger and add a dedicated `legacy-link-resolver` custom agent.

## Validation
- `docker run --rm -v "E:\\inventory\\inventory-app:/workspaces/inventory-app" -v inv-app-php-vendor:/workspaces/inventory-app/vendor -v inv-app-node-modules:/workspaces/inventory-app/node_modules -v inv-app-spa-node-modules:/workspaces/inventory-app/spa/node_modules -v inv-app-importer-node-modules:/workspaces/inventory-app/scripts/importer/node_modules -w /workspaces/inventory-app inventory-app-dev vendor/bin/pint --no-ansi`
- `docker run --rm -v "E:\\inventory\\inventory-app:/workspaces/inventory-app" -v inv-app-php-vendor:/workspaces/inventory-app/vendor -v inv-app-node-modules:/workspaces/inventory-app/node_modules -v inv-app-spa-node-modules:/workspaces/inventory-app/spa/node_modules -v inv-app-importer-node-modules:/workspaces/inventory-app/scripts/importer/node_modules -w /workspaces/inventory-app inventory-app-dev php artisan test tests/Unit/Support/LegacyLinks/LegacyReferenceTest.php tests/Unit/Support/LegacyLinks/LegacyUrlResolverTest.php tests/Filament/Resources/LegacyLinksInfolistTest.php --no-ansi --stop-on-failure`

## Notes
- The branch contains a single commit and is ready for squash merge/autosquash handling.