### PR TITLE
Fix THG legacy links and content tab layout

### DIFF
--- a/app/Filament/Concerns/HasFullWidthRelationManagerContentTab.php
+++ b/app/Filament/Concerns/HasFullWidthRelationManagerContentTab.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Filament\Concerns;
+
+use Filament\Infolists\Infolist;
+
+trait HasFullWidthRelationManagerContentTab
+{
+    protected function makeInfolist(): Infolist
+    {
+        return parent::makeInfolist()
+            ->columns(1);
+    }
+}

--- a/app/Filament/Resources/CollectionResource/Pages/ViewCollection.php
+++ b/app/Filament/Resources/CollectionResource/Pages/ViewCollection.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\CollectionResource\Pages;
 
+use App\Filament\Concerns\HasFullWidthRelationManagerContentTab;
 use App\Filament\Resources\CollectionResource;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
@@ -9,6 +10,8 @@ use Filament\Resources\Pages\ViewRecord;
 
 class ViewCollection extends ViewRecord
 {
+    use HasFullWidthRelationManagerContentTab;
+
     protected static string $resource = CollectionResource::class;
 
     protected function getHeaderActions(): array

--- a/app/Filament/Resources/CollectionTranslationResource/Pages/ViewCollectionTranslation.php
+++ b/app/Filament/Resources/CollectionTranslationResource/Pages/ViewCollectionTranslation.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\CollectionTranslationResource\Pages;
 
+use App\Filament\Concerns\HasFullWidthRelationManagerContentTab;
 use App\Filament\Resources\CollectionResource;
 use App\Filament\Resources\CollectionTranslationResource;
 use Filament\Actions\Action;
@@ -11,6 +12,8 @@ use Filament\Resources\Pages\ViewRecord;
 
 class ViewCollectionTranslation extends ViewRecord
 {
+    use HasFullWidthRelationManagerContentTab;
+
     protected static string $resource = CollectionTranslationResource::class;
 
     protected function getHeaderActions(): array

--- a/app/Filament/Resources/ItemResource/Pages/ViewItem.php
+++ b/app/Filament/Resources/ItemResource/Pages/ViewItem.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\ItemResource\Pages;
 
+use App\Filament\Concerns\HasFullWidthRelationManagerContentTab;
 use App\Filament\Resources\ItemResource;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
@@ -9,6 +10,8 @@ use Filament\Resources\Pages\ViewRecord;
 
 class ViewItem extends ViewRecord
 {
+    use HasFullWidthRelationManagerContentTab;
+
     protected static string $resource = ItemResource::class;
 
     protected function getHeaderActions(): array

--- a/app/Filament/Resources/ItemTranslationResource/Pages/ViewItemTranslation.php
+++ b/app/Filament/Resources/ItemTranslationResource/Pages/ViewItemTranslation.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\ItemTranslationResource\Pages;
 
+use App\Filament\Concerns\HasFullWidthRelationManagerContentTab;
 use App\Filament\Resources\ItemResource;
 use App\Filament\Resources\ItemTranslationResource;
 use Filament\Actions\Action;
@@ -11,6 +12,8 @@ use Filament\Resources\Pages\ViewRecord;
 
 class ViewItemTranslation extends ViewRecord
 {
+    use HasFullWidthRelationManagerContentTab;
+
     protected static string $resource = ItemTranslationResource::class;
 
     protected function getHeaderActions(): array

--- a/app/Filament/Resources/PartnerResource/Pages/ViewPartner.php
+++ b/app/Filament/Resources/PartnerResource/Pages/ViewPartner.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\PartnerResource\Pages;
 
+use App\Filament\Concerns\HasFullWidthRelationManagerContentTab;
 use App\Filament\Resources\PartnerResource;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
@@ -9,6 +10,8 @@ use Filament\Resources\Pages\ViewRecord;
 
 class ViewPartner extends ViewRecord
 {
+    use HasFullWidthRelationManagerContentTab;
+
     protected static string $resource = PartnerResource::class;
 
     protected function getHeaderActions(): array

--- a/app/Filament/Resources/PartnerTranslationResource/Pages/ViewPartnerTranslation.php
+++ b/app/Filament/Resources/PartnerTranslationResource/Pages/ViewPartnerTranslation.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\PartnerTranslationResource\Pages;
 
+use App\Filament\Concerns\HasFullWidthRelationManagerContentTab;
 use App\Filament\Resources\PartnerResource;
 use App\Filament\Resources\PartnerTranslationResource;
 use Filament\Actions\Action;
@@ -11,6 +12,8 @@ use Filament\Resources\Pages\ViewRecord;
 
 class ViewPartnerTranslation extends ViewRecord
 {
+    use HasFullWidthRelationManagerContentTab;
+
     protected static string $resource = PartnerTranslationResource::class;
 
     protected function getHeaderActions(): array

--- a/app/Support/LegacyLinks/Rules/Concerns/ResolvesThematicGalleryUrls.php
+++ b/app/Support/LegacyLinks/Rules/Concerns/ResolvesThematicGalleryUrls.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Support\LegacyLinks\Rules\Concerns;
+
+use App\Models\Collection;
+use App\Support\LegacyLinks\LegacyReference;
+
+trait ResolvesThematicGalleryUrls
+{
+    private const THG_GALLERIES_ROOT = 'thg_galleries_root';
+
+    private const THG_EXHIBITIONS_ROOT = 'thg_exhibitions_root';
+
+    private const MAX_THG_CONTEXT_DEPTH = 10;
+
+    protected function thematicGalleryLandingUrl(string $galleryId, string $legacyLanguage, ?Collection $collection = null): ?string
+    {
+        $baseUrl = $this->thematicGalleryBaseUrl($galleryId);
+
+        if ($baseUrl === null) {
+            return null;
+        }
+
+        $path = config("legacy.links.thematic_galleries.{$galleryId}.path");
+
+        if (! is_string($path) && $collection !== null && $this->isThematicExhibitionCollection($collection)) {
+            $folder = $this->thematicExhibitionFolder($collection);
+            $path = $folder === null ? null : "{$folder}/{lang}";
+        }
+
+        if (! is_string($path) || trim($path) === '') {
+            return $baseUrl;
+        }
+
+        $path = trim(str_replace('{lang}', $legacyLanguage, $path), '/');
+
+        return "{$baseUrl}/{$path}";
+    }
+
+    protected function thematicGalleryBaseUrl(string $galleryId): ?string
+    {
+        $baseUrl = config("legacy.links.thematic_galleries.{$galleryId}.base_url");
+
+        return is_string($baseUrl) && $baseUrl !== '' ? rtrim($baseUrl, '/') : null;
+    }
+
+    /**
+     * @return array{gallery_id: string, surface: 'gallery'|'exhibition', gallery_collection: Collection|null}|null
+     */
+    protected function thematicGalleryContextForCollection(Collection $collection): ?array
+    {
+        $galleryId = null;
+        $galleryCollection = null;
+        $current = $collection;
+
+        for ($depth = 0; $depth < self::MAX_THG_CONTEXT_DEPTH; $depth++) {
+            $reference = LegacyReference::parse($current->backward_compatibility);
+
+            if ($reference?->is('mwnf3_thematic_gallery', 'thg_gallery') && $reference->hasParts(1)) {
+                $galleryId ??= (string) $reference->part(0);
+                $galleryCollection ??= $current;
+            }
+
+            if ($reference?->is('mwnf3_thematic_gallery', 'theme') && $reference->hasParts(1)) {
+                $galleryId ??= (string) $reference->part(0);
+            }
+
+            $internalName = (string) $current->internal_name;
+
+            if ($internalName === self::THG_GALLERIES_ROOT || $reference?->is('mwnf3_thematic_gallery', 'galleries_root')) {
+                return $galleryId === null ? null : [
+                    'gallery_id' => $galleryId,
+                    'surface' => 'gallery',
+                    'gallery_collection' => $galleryCollection,
+                ];
+            }
+
+            if ($internalName === self::THG_EXHIBITIONS_ROOT || $reference?->is('mwnf3_thematic_gallery', 'exhibitions_root')) {
+                return $galleryId === null ? null : [
+                    'gallery_id' => $galleryId,
+                    'surface' => 'exhibition',
+                    'gallery_collection' => $galleryCollection,
+                ];
+            }
+
+            if ($current->parent === null) {
+                return null;
+            }
+
+            $current = $current->parent;
+        }
+
+        throw new \RuntimeException('Collection hierarchy depth exceeds maximum of '.self::MAX_THG_CONTEXT_DEPTH.' levels.');
+    }
+
+    protected function thematicGalleryDatabaseItemUrl(Collection $collection, LegacyReference $reference, string $legacyLanguage): ?string
+    {
+        if (! $reference->hasParts(4)) {
+            return null;
+        }
+
+        $context = $this->thematicGalleryContextForCollection($collection);
+
+        if ($context === null) {
+            return null;
+        }
+
+        $baseUrl = $this->thematicGalleryBaseUrl($context['gallery_id']);
+
+        if ($baseUrl === null) {
+            return null;
+        }
+
+        [$project, $country, $holder, $number] = array_slice($reference->parts, 0, 4);
+        $databaseItemPath = "database-item/{$reference->schema}/{$reference->table}/{$project}/{$country}/{$holder}/{$number}/{$legacyLanguage}";
+
+        if ($context['surface'] === 'gallery') {
+            return "{$baseUrl}/{$databaseItemPath}";
+        }
+
+        $folder = $this->thematicExhibitionFolder($context['gallery_collection'] ?? $collection);
+
+        return $folder === null ? null : "{$baseUrl}/{$folder}/en/{$databaseItemPath}";
+    }
+
+    protected function isThematicExhibitionCollection(Collection $collection): bool
+    {
+        $context = $this->thematicGalleryContextForCollection($collection);
+
+        return ($context['surface'] ?? null) === 'exhibition';
+    }
+
+    protected function thematicExhibitionFolder(Collection $collection): ?string
+    {
+        $internalName = trim((string) $collection->internal_name);
+
+        if (str_starts_with($internalName, 'exhibition_')) {
+            $folder = substr($internalName, strlen('exhibition_'));
+
+            return $folder === '' ? null : $folder;
+        }
+
+        return $internalName === '' ? null : $internalName;
+    }
+}

--- a/app/Support/LegacyLinks/Rules/Mwnf3ItemLegacyUrlRule.php
+++ b/app/Support/LegacyLinks/Rules/Mwnf3ItemLegacyUrlRule.php
@@ -7,11 +7,12 @@ use App\Models\Item;
 use App\Support\LegacyLinks\LegacyLink;
 use App\Support\LegacyLinks\LegacyReference;
 use App\Support\LegacyLinks\Rules\Concerns\BuildsLegacyUrls;
+use App\Support\LegacyLinks\Rules\Concerns\ResolvesThematicGalleryUrls;
 use Illuminate\Database\Eloquent\Model;
 
 class Mwnf3ItemLegacyUrlRule implements LegacyUrlRule
 {
-    use BuildsLegacyUrls;
+    use BuildsLegacyUrls, ResolvesThematicGalleryUrls;
 
     public function supports(Model $record, LegacyReference $reference): bool
     {
@@ -21,10 +22,10 @@ class Mwnf3ItemLegacyUrlRule implements LegacyUrlRule
     public function resolve(Model $record, LegacyReference $reference, string $legacyLanguage): array
     {
         return match ($reference->table) {
-            'objects' => $this->resolveDatabaseItem($reference, 'object', 'database/dba_objects', $legacyLanguage, 4),
-            'monuments' => $this->resolveDatabaseItem($reference, 'monument', 'database/dba_monuments', $legacyLanguage, 4),
-            'objects_pictures' => $this->resolvePictureParent($reference, 'object', 'database/dba_objects', $legacyLanguage),
-            'monuments_pictures' => $this->resolvePictureParent($reference, 'monument', 'database/dba_monuments', $legacyLanguage),
+            'objects' => $this->resolveDatabaseItem($record, $reference, 'object', 'database/dba_objects', $legacyLanguage, 4),
+            'monuments' => $this->resolveDatabaseItem($record, $reference, 'monument', 'database/dba_monuments', $legacyLanguage, 4),
+            'objects_pictures' => $this->resolvePictureParent($record, $reference, 'object', 'database/dba_objects', $legacyLanguage),
+            'monuments_pictures' => $this->resolvePictureParent($record, $reference, 'monument', 'database/dba_monuments', $legacyLanguage),
             'monument_details' => [LegacyLink::diagnostic('Legacy monument detail', LegacyLinkConfidence::UNSUPPORTED, $reference->raw, 'Monument details usually appear inside the parent monument page; no direct public URL rule is verified yet.')],
             default => [],
         };
@@ -33,7 +34,7 @@ class Mwnf3ItemLegacyUrlRule implements LegacyUrlRule
     /**
      * @return array<int, LegacyLink>
      */
-    private function resolveDatabaseItem(LegacyReference $reference, string $legacyType, string $backofficeSection, string $legacyLanguage, int $requiredParts): array
+    private function resolveDatabaseItem(Item $record, LegacyReference $reference, string $legacyType, string $backofficeSection, string $legacyLanguage, int $requiredParts): array
     {
         if (! $reference->hasParts($requiredParts)) {
             return [];
@@ -41,33 +42,71 @@ class Mwnf3ItemLegacyUrlRule implements LegacyUrlRule
 
         [$project, $country, $holder, $number] = array_slice($reference->parts, 0, 4);
         $host = $this->projectHost($project);
+        $links = [];
 
         if ($host === null) {
-            return [LegacyLink::diagnostic('Legacy public page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, "No public host is configured for project {$project}.")];
-        }
-
-        return [
-            LegacyLink::public(
+            $links[] = LegacyLink::diagnostic('Legacy public page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, "No public host is configured for project {$project}.");
+        } else {
+            $links[] = LegacyLink::public(
                 label: "Legacy {$legacyType} page",
                 url: "{$host}/database_item.php?id={$legacyType};{$project};{$country};{$holder};{$number};{$legacyLanguage}",
                 confidence: LegacyLinkConfidence::EXACT,
                 source: $reference->raw,
-            ),
+            );
+        }
+
+        $links = array_merge($links, $this->resolveThematicCollectionItemLinks($record, $reference, $legacyType, $legacyLanguage));
+
+        $links[] =
             LegacyLink::backoffice(
                 label: "Legacy {$legacyType} back-office record",
                 url: $this->backofficeUrl($backofficeSection, "1;{$project};{$country};{$holder};{$number}"),
                 confidence: LegacyLinkConfidence::EXACT,
                 source: $reference->raw,
-            ),
-        ];
+            );
+
+        return $links;
+    }
+
+    /** @return array<int, LegacyLink> */
+    private function resolveThematicCollectionItemLinks(Item $record, LegacyReference $reference, string $legacyType, string $legacyLanguage): array
+    {
+        if (! in_array($reference->table, ['objects', 'monuments'], true)) {
+            return [];
+        }
+
+        return $record->attachedToCollections()
+            ->with('parent.parent.parent.parent.parent.parent.parent.parent.parent.parent')
+            ->get()
+            ->map(function ($collection) use ($reference, $legacyType, $legacyLanguage): ?LegacyLink {
+                $context = $this->thematicGalleryContextForCollection($collection);
+
+                if ($context === null) {
+                    return null;
+                }
+
+                $url = $this->thematicGalleryDatabaseItemUrl($collection, $reference, $legacyLanguage);
+                $label = $context['surface'] === 'exhibition'
+                    ? "Thematic exhibition {$legacyType} page"
+                    : "Thematic gallery {$legacyType} page";
+
+                if ($url === null) {
+                    return LegacyLink::diagnostic($label, LegacyLinkConfidence::REQUIRES_LOOKUP, $collection->backward_compatibility ?? $reference->raw, "The gallery id {$context['gallery_id']} needs a configured public host or exhibition folder.");
+                }
+
+                return LegacyLink::public($label, $url, LegacyLinkConfidence::EXACT, $collection->backward_compatibility ?? $reference->raw);
+            })
+            ->filter()
+            ->values()
+            ->all();
     }
 
     /**
      * @return array<int, LegacyLink>
      */
-    private function resolvePictureParent(LegacyReference $reference, string $legacyType, string $backofficeSection, string $legacyLanguage): array
+    private function resolvePictureParent(Item $record, LegacyReference $reference, string $legacyType, string $backofficeSection, string $legacyLanguage): array
     {
-        $links = $this->resolveDatabaseItem($reference, $legacyType, $backofficeSection, $legacyLanguage, 5);
+        $links = $this->resolveDatabaseItem($record, $reference, $legacyType, $backofficeSection, $legacyLanguage, 5);
 
         return array_map(
             fn (LegacyLink $link): LegacyLink => new LegacyLink($link->label.' parent', $link->url, $link->type, LegacyLinkConfidence::INFERRED, $reference->raw, 'Picture items resolve to the parent legacy record.'),

--- a/app/Support/LegacyLinks/Rules/ThematicGalleryLegacyUrlRule.php
+++ b/app/Support/LegacyLinks/Rules/ThematicGalleryLegacyUrlRule.php
@@ -7,11 +7,12 @@ use App\Models\Collection;
 use App\Support\LegacyLinks\LegacyLink;
 use App\Support\LegacyLinks\LegacyReference;
 use App\Support\LegacyLinks\Rules\Concerns\BuildsLegacyUrls;
+use App\Support\LegacyLinks\Rules\Concerns\ResolvesThematicGalleryUrls;
 use Illuminate\Database\Eloquent\Model;
 
 class ThematicGalleryLegacyUrlRule implements LegacyUrlRule
 {
-    use BuildsLegacyUrls;
+    use BuildsLegacyUrls, ResolvesThematicGalleryUrls;
 
     public function supports(Model $record, LegacyReference $reference): bool
     {
@@ -21,20 +22,20 @@ class ThematicGalleryLegacyUrlRule implements LegacyUrlRule
     public function resolve(Model $record, LegacyReference $reference, string $legacyLanguage): array
     {
         return match ($reference->table) {
-            'thg_gallery' => $this->resolveGallery($reference, $legacyLanguage),
+            'thg_gallery' => $this->resolveGallery($record, $reference, $legacyLanguage),
             'theme' => $this->resolveTheme($reference, $legacyLanguage),
             default => [],
         };
     }
 
     /** @return array<int, LegacyLink> */
-    private function resolveGallery(LegacyReference $reference, string $legacyLanguage): array
+    private function resolveGallery(Collection $record, LegacyReference $reference, string $legacyLanguage): array
     {
         if (! $reference->hasParts(1)) {
             return [];
         }
 
-        $landing = $this->landingUrl((string) $reference->part(0), $legacyLanguage);
+        $landing = $this->thematicGalleryLandingUrl((string) $reference->part(0), $legacyLanguage, $record);
 
         if ($landing === null) {
             return [LegacyLink::diagnostic('Thematic gallery landing page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, 'The gallery id needs a configured public slug or host.')];
@@ -53,7 +54,7 @@ class ThematicGalleryLegacyUrlRule implements LegacyUrlRule
             return [];
         }
 
-        $landing = $this->landingUrl((string) $reference->part(0), $legacyLanguage);
+        $landing = $this->thematicGalleryLandingUrl((string) $reference->part(0), $legacyLanguage);
 
         if ($landing === null) {
             return [LegacyLink::diagnostic('Thematic gallery theme page', LegacyLinkConfidence::REQUIRES_LOOKUP, $reference->raw, 'Theme URLs need the gallery public slug or host.')];
@@ -63,19 +64,5 @@ class ThematicGalleryLegacyUrlRule implements LegacyUrlRule
             LegacyLink::public('Thematic gallery theme page', rtrim($landing, '/')."/theme/{$reference->part(1)}", LegacyLinkConfidence::EXACT, $reference->raw),
             LegacyLink::backoffice('Thematic gallery theme back-office record', $this->backofficeUrl('thg/thg_galleries', "1;{$reference->part(0)};{$reference->part(1)}"), LegacyLinkConfidence::EXACT, $reference->raw),
         ];
-    }
-
-    private function landingUrl(string $galleryId, string $legacyLanguage): ?string
-    {
-        $mapping = config("legacy.links.thematic_galleries.{$galleryId}");
-
-        if (! is_array($mapping) || ! isset($mapping['base_url'])) {
-            return null;
-        }
-
-        $baseUrl = rtrim((string) $mapping['base_url'], '/');
-        $path = trim(str_replace('{lang}', $legacyLanguage, (string) ($mapping['path'] ?? '')), '/');
-
-        return $path === '' ? $baseUrl : "{$baseUrl}/{$path}";
     }
 }

--- a/config/legacy.php
+++ b/config/legacy.php
@@ -36,9 +36,181 @@ return [
                 'base_url' => 'https://amulets.museumwnf.org',
                 'path' => '',
             ],
+            '5' => [
+                'base_url' => 'https://archaeology.museumwnf.org',
+                'path' => '',
+            ],
+            '6' => [
+                'base_url' => 'https://architectural-elements.museumwnf.org',
+                'path' => '',
+            ],
+            '7' => [
+                'base_url' => 'https://arms-armoury.museumwnf.org',
+                'path' => '',
+            ],
+            '8' => [
+                'base_url' => 'https://calligraphy.museumwnf.org',
+                'path' => '',
+            ],
+            '9' => [
+                'base_url' => 'https://carpets.museumwnf.org',
+                'path' => '',
+            ],
+            '11' => [
+                'base_url' => 'https://ceramics.museumwnf.org',
+                'path' => '',
+            ],
+            '12' => [
+                'base_url' => 'https://clothing.museumwnf.org',
+                'path' => '',
+            ],
+            '13' => [
+                'base_url' => 'https://coins-medals.museumwnf.org',
+                'path' => '',
+            ],
+            '14' => [
+                'base_url' => 'https://communication.museumwnf.org',
+                'path' => '',
+            ],
+            '16' => [
+                'base_url' => 'https://funerary-objects.museumwnf.org',
+                'path' => '',
+            ],
+            '17' => [
+                'base_url' => 'https://woodwork.museumwnf.org',
+                'path' => '',
+            ],
+            '18' => [
+                'base_url' => 'https://glass.museumwnf.org',
+                'path' => '',
+            ],
+            '19' => [
+                'base_url' => 'https://gold-silver.museumwnf.org',
+                'path' => '',
+            ],
+            '20' => [
+                'base_url' => 'https://ivory.museumwnf.org',
+                'path' => '',
+            ],
+            '21' => [
+                'base_url' => 'https://jewellery.museumwnf.org',
+                'path' => '',
+            ],
+            '22' => [
+                'base_url' => 'https://landscapes.museumwnf.org',
+                'path' => '',
+            ],
+            '23' => [
+                'base_url' => 'https://leatherworks.museumwnf.org',
+                'path' => '',
+            ],
+            '24' => [
+                'base_url' => 'https://manuscripts.museumwnf.org',
+                'path' => '',
+            ],
+            '25' => [
+                'base_url' => 'https://metalwork.museumwnf.org',
+                'path' => '',
+            ],
+            '26' => [
+                'base_url' => 'https://mosaics.museumwnf.org',
+                'path' => '',
+            ],
+            '27' => [
+                'base_url' => 'https://musical-instruments.museumwnf.org',
+                'path' => '',
+            ],
+            '28' => [
+                'base_url' => 'https://paintings.museumwnf.org',
+                'path' => '',
+            ],
+            '29' => [
+                'base_url' => 'https://photographs.museumwnf.org',
+                'path' => '',
+            ],
+            '30' => [
+                'base_url' => 'https://porcelain.museumwnf.org',
+                'path' => '',
+            ],
+            '31' => [
+                'base_url' => 'https://portraits.museumwnf.org',
+                'path' => '',
+            ],
+            '32' => [
+                'base_url' => 'https://prints-drawings.museumwnf.org',
+                'path' => '',
+            ],
+            '33' => [
+                'base_url' => 'https://religious-life.museumwnf.org',
+                'path' => '',
+            ],
+            '34' => [
+                'base_url' => 'https://scientific-objects.museumwnf.org',
+                'path' => '',
+            ],
+            '35' => [
+                'base_url' => 'https://sculptures.museumwnf.org',
+                'path' => '',
+            ],
+            '37' => [
+                'base_url' => 'https://textiles.museumwnf.org',
+                'path' => '',
+            ],
+            '38' => [
+                'base_url' => 'https://theatre.museumwnf.org',
+                'path' => '',
+            ],
+            '39' => [
+                'base_url' => 'https://toys-games.museumwnf.org',
+                'path' => '',
+            ],
+            '40' => [
+                'base_url' => 'https://wallpaintings.museumwnf.org',
+                'path' => '',
+            ],
+            '41' => [
+                'base_url' => 'https://weights-measures.museumwnf.org',
+                'path' => '',
+            ],
+            '43' => [
+                'base_url' => 'https://unclear-doubts-excluded.museumwnf.org',
+                'path' => '',
+            ],
+            '45' => [
+                'base_url' => 'https://gallery-partners.museumwnf.org',
+                'path' => '',
+            ],
+            '46' => [
+                'base_url' => 'https://precious-stones.museumwnf.org',
+                'path' => '',
+            ],
             '47' => [
                 'base_url' => 'https://exhibitions.museumwnf.org',
                 'path' => 'the_use_of_colours_in_art/{lang}',
+            ],
+            '49' => [
+                'base_url' => 'https://cars.museumwnf.org',
+                'path' => '',
+            ],
+            '50' => [
+                'base_url' => 'https://exhibitions.museumwnf.org',
+                'path' => 'with_brush_and_qalam/{lang}',
+            ],
+            '52' => [
+                'base_url' => 'https://exhibitions.museumwnf.org',
+                'path' => 'the_table_is_set/{lang}',
+            ],
+            '54' => [
+                'base_url' => 'https://exhibitions.museumwnf.org',
+                'path' => 'arts_in_dialogue/{lang}',
+            ],
+            '55' => [
+                'base_url' => 'https://exhibitions.museumwnf.org',
+                'path' => 'lost_memories_along_the_hijaz_railway_from_istanbul_to_mecca/{lang}',
+            ],
+            '56' => [
+                'base_url' => 'https://exhibitions.museumwnf.org',
+                'path' => 'water/{lang}',
             ],
         ],
     ],

--- a/tests/Filament/Resources/CombinedRelationManagerContentTabLayoutTest.php
+++ b/tests/Filament/Resources/CombinedRelationManagerContentTabLayoutTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Filament\Resources;
+
+use App\Enums\Permission;
+use App\Filament\Resources\CollectionResource\Pages\ViewCollection;
+use App\Models\Collection;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class CombinedRelationManagerContentTabLayoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_combined_relation_manager_content_tab_infolist_uses_full_width_layout(): void
+    {
+        $user = $this->createViewUser();
+        $collection = Collection::factory()->create();
+
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+        $component = Livewire::actingAs($user)
+            ->test(ViewCollection::class, ['record' => $collection->getRouteKey()]);
+
+        $this->assertSame(1, $component->instance()->getInfolist('infolist')->getColumns('lg'));
+    }
+
+    protected function createViewUser(): User
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $user->givePermissionTo([
+            Permission::ACCESS_ADMIN_PANEL->value,
+            Permission::VIEW_DATA->value,
+        ]);
+
+        return $user;
+    }
+}

--- a/tests/Unit/Support/LegacyLinks/LegacyUrlResolverTest.php
+++ b/tests/Unit/Support/LegacyLinks/LegacyUrlResolverTest.php
@@ -102,6 +102,81 @@ class LegacyUrlResolverTest extends TestCase
         $this->assertBackofficeUrl($links, 'https://virtual-office.museumwnf.org/?section=thg/thg_galleries&edit=1;47&');
     }
 
+    public function test_mwnf3_object_keeps_project_link_and_adds_thematic_exhibition_participation_link(): void
+    {
+        $root = Collection::factory()->collection()->create([
+            'internal_name' => 'thg_exhibitions_root',
+            'backward_compatibility' => 'mwnf3_thematic_gallery:exhibitions_root',
+        ]);
+        $exhibition = Collection::factory()->exhibition()->withParent($root->id)->create([
+            'internal_name' => 'exhibition_the_use_of_colours_in_art',
+            'backward_compatibility' => 'mwnf3_thematic_gallery:thg_gallery:47',
+        ]);
+        $theme = Collection::factory()->theme()->withParent($exhibition->id)->create([
+            'backward_compatibility' => 'mwnf3_thematic_gallery:theme:47:1',
+        ]);
+        $item = Item::factory()->Object()->create(['backward_compatibility' => 'mwnf3:objects:EXHCOLOUR:uk:Mus52:1']);
+
+        $theme->attachedItems()->attach($item->id);
+
+        $links = $this->resolver->resolveFor($item)->links;
+
+        $this->assertPublicUrl($links, 'https://exhibitions.museumwnf.org/database_item.php?id=object;EXHCOLOUR;uk;Mus52;1;en');
+        $this->assertPublicUrl($links, 'https://exhibitions.museumwnf.org/the_use_of_colours_in_art/en/database-item/mwnf3/objects/EXHCOLOUR/uk/Mus52/1/en');
+        $this->assertBackofficeUrl($links, 'https://virtual-office.museumwnf.org/?section=database/dba_objects&edit=1;EXHCOLOUR;uk;Mus52;1&');
+        $this->assertSame(1, $this->countBackofficeLinks($links));
+    }
+
+    public function test_mwnf3_object_adds_thematic_gallery_participation_link_with_gallery_host(): void
+    {
+        $root = Collection::factory()->collection()->create([
+            'internal_name' => 'thg_galleries_root',
+            'backward_compatibility' => 'mwnf3_thematic_gallery:galleries_root',
+        ]);
+        $gallery = Collection::factory()->gallery()->withParent($root->id)->create([
+            'internal_name' => 'gallery_clothing_and_costume',
+            'backward_compatibility' => 'mwnf3_thematic_gallery:thg_gallery:12',
+        ]);
+        $item = Item::factory()->Object()->create(['backward_compatibility' => 'mwnf3:objects:ISL:jo:Mus01:4']);
+
+        $gallery->attachedItems()->attach($item->id);
+
+        $links = $this->resolver->resolveFor($item)->links;
+
+        $this->assertPublicUrl($links, 'https://islamicart.museumwnf.org/database_item.php?id=object;ISL;jo;Mus01;4;en');
+        $this->assertPublicUrl($links, 'https://clothing.museumwnf.org/database-item/mwnf3/objects/ISL/jo/Mus01/4/en');
+        $this->assertBackofficeUrl($links, 'https://virtual-office.museumwnf.org/?section=database/dba_objects&edit=1;ISL;jo;Mus01;4&');
+        $this->assertSame(1, $this->countBackofficeLinks($links));
+    }
+
+    public function test_mwnf3_object_adds_one_thematic_link_per_thematic_collection_participation(): void
+    {
+        $galleriesRoot = Collection::factory()->collection()->create([
+            'internal_name' => 'thg_galleries_root',
+            'backward_compatibility' => 'mwnf3_thematic_gallery:galleries_root',
+        ]);
+        $exhibitionsRoot = Collection::factory()->collection()->create([
+            'internal_name' => 'thg_exhibitions_root',
+            'backward_compatibility' => 'mwnf3_thematic_gallery:exhibitions_root',
+        ]);
+        $gallery = Collection::factory()->gallery()->withParent($galleriesRoot->id)->create([
+            'backward_compatibility' => 'mwnf3_thematic_gallery:thg_gallery:12',
+        ]);
+        $exhibition = Collection::factory()->exhibition()->withParent($exhibitionsRoot->id)->create([
+            'internal_name' => 'exhibition_the_use_of_colours_in_art',
+            'backward_compatibility' => 'mwnf3_thematic_gallery:thg_gallery:47',
+        ]);
+        $item = Item::factory()->Object()->create(['backward_compatibility' => 'mwnf3:objects:EXHCOLOUR:uk:Mus52:1']);
+
+        $item->attachedToCollections()->attach([$gallery->id, $exhibition->id]);
+
+        $links = $this->resolver->resolveFor($item)->links;
+
+        $this->assertPublicUrl($links, 'https://clothing.museumwnf.org/database-item/mwnf3/objects/EXHCOLOUR/uk/Mus52/1/en');
+        $this->assertPublicUrl($links, 'https://exhibitions.museumwnf.org/the_use_of_colours_in_art/en/database-item/mwnf3/objects/EXHCOLOUR/uk/Mus52/1/en');
+        $this->assertSame(1, $this->countBackofficeLinks($links));
+    }
+
     public function test_resolves_mwnf3_partner_with_project_context(): void
     {
         $project = Project::factory()->create(['backward_compatibility' => 'ISL']);
@@ -154,5 +229,21 @@ class LegacyUrlResolverTest extends TestCase
 
         $this->assertNotEmpty($backofficeLinks);
         $this->assertSame($expectedUrl, $backofficeLinks[0]->url);
+    }
+
+    private function assertPublicUrl(array $links, string $expectedUrl): void
+    {
+        $this->assertContains($expectedUrl, array_map(
+            fn ($link): ?string => $link->type === LegacyLinkType::PUBLIC ? $link->url : null,
+            $links,
+        ));
+    }
+
+    private function countBackofficeLinks(array $links): int
+    {
+        return count(array_filter(
+            $links,
+            fn ($link): bool => $link->type === LegacyLinkType::BACKOFFICE,
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- add THG contextual object links for item collection participations while preserving the project-based legacy URL and single back-office link
- expand THG gallery host configuration from the legacy `thg_gallery_url` data
- make combined relation-manager content tabs render their infolist content full width, matching relation-manager tabs
