### PR TITLE
fix(deploy-ovh): set bootstrap/cache group-write and use php artisan optimize

### DIFF
--- a/scripts/deploy-ovh.sh
+++ b/scripts/deploy-ovh.sh
@@ -76,8 +76,10 @@ deploy_release() {
     rm -rf "${RELEASE_DIR}/storage"
     ln -sfn "${APP_DIR}/shared/storage" "${RELEASE_DIR}/storage"
 
-    # Ensure bootstrap/cache exists
+    # Ensure bootstrap/cache exists and is writable by www-data (PHP-FPM)
     mkdir -p "${RELEASE_DIR}/bootstrap/cache"
+    chgrp www-data "${RELEASE_DIR}/bootstrap/cache" 2>/dev/null || true
+    chmod g+w "${RELEASE_DIR}/bootstrap/cache"
 
     # If provisioning created CURRENT as a real directory, replace it.
     if [[ -d "${CURRENT}" && ! -L "${CURRENT}" ]]; then
@@ -157,9 +159,11 @@ run_migrations() {
 warm_caches() {
     cd "$CURRENT"
     info "Warming Laravel caches..."
-    php artisan config:cache
-    php artisan route:cache
-    php artisan view:cache
+    # optimize generates config, events, routes, views, package manifest, and
+    # any framework-registered caches (e.g. Filament, blade-icons) in one pass.
+    # Pre-generating all cache files means PHP-FPM (www-data) only needs read
+    # access to bootstrap/cache at runtime — no runtime writes required.
+    php artisan optimize
 }
 
 # --- 5. Restart queue worker -------------------------------------------------


### PR DESCRIPTION
## Problem

Every deploy left `bootstrap/cache` owned by `deploy:deploy` with mode `0755`. PHP-FPM runs as `www-data`, which has no write access. On the first web request, Laravel's `PackageManifest` attempted to write `packages.php` to `bootstrap/cache` and failed, cascading into:

```
PHP Fatal error: Uncaught ReflectionException: Class "view" does not exist
```

This brought down every web request and crash-looped the queue worker (`inventory-queue.service`).

**Discovered and recovered on 2026-05-08** — the active release (`20260508014633`) was manually fixed with `sudo chown`/`chmod` + `php artisan optimize`.

## Fix

Two changes to `scripts/deploy-ovh.sh`:

### 1. `bootstrap/cache` — group-write for `www-data`

After `mkdir -p "${RELEASE_DIR}/bootstrap/cache"`:

```bash
chgrp www-data "${RELEASE_DIR}/bootstrap/cache" 2>/dev/null || true
chmod g+w "${RELEASE_DIR}/bootstrap/cache"
```

This ensures `www-data` can write to the directory at runtime if any cache file is missing (belt-and-suspenders).

### 2. Replace individual cache commands with `php artisan optimize`

`warm_caches()` previously ran:
```bash
php artisan config:cache
php artisan route:cache
php artisan view:cache
```

It now runs:
```bash
php artisan optimize
```

`optimize` generates **all** cache files in one pass — including `packages.php` (via `package:discover`), events, Filament, and blade-icons — so PHP-FPM only needs read access to `bootstrap/cache` at runtime. No runtime writes required.

## Testing

- Deploy the next release to OVH and verify the app responds immediately on the first request without needing manual cache generation.
- Confirm `bootstrap/cache` permissions: `stat /opt/inventory/releases/<new>/bootstrap/cache` should show `drwxrwxr-x deploy www-data` (or equivalent).
- Confirm queue worker starts cleanly without a `bootstrap/cache writable` error.