### PR TITLE
Fix: Add relation manager for timeline events in Items

### DIFF
--- a/app/Filament/Resources/ItemResource.php
+++ b/app/Filament/Resources/ItemResource.php
@@ -20,6 +20,7 @@ use App\Filament\Resources\ItemResource\RelationManagers\IncomingLinksRelationMa
 use App\Filament\Resources\ItemResource\RelationManagers\OutgoingLinksRelationManager;
 use App\Filament\Resources\ItemResource\RelationManagers\PicturesRelationManager;
 use App\Filament\Resources\ItemResource\RelationManagers\TagsRelationManager;
+use App\Filament\Resources\ItemResource\RelationManagers\TimelineEventsRelationManager;
 use App\Filament\Resources\ItemResource\RelationManagers\TranslationsRelationManager;
 use App\Filament\Resources\RelationManagers\LegacyLinksRelationManager;
 use App\Models\Collection;
@@ -522,6 +523,7 @@ class ItemResource extends Resource
             OutgoingLinksRelationManager::class,
             IncomingLinksRelationManager::class,
             TagsRelationManager::class,
+            TimelineEventsRelationManager::class,
             DisplayedInCollectionsRelationManager::class,
             LegacyLinksRelationManager::class,
         ];

--- a/app/Filament/Resources/ItemResource/RelationManagers/TimelineEventsRelationManager.php
+++ b/app/Filament/Resources/ItemResource/RelationManagers/TimelineEventsRelationManager.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Filament\Resources\ItemResource\RelationManagers;
+
+use App\Filament\Resources\TimelineEventResource;
+use App\Filament\Resources\TimelineResource;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class TimelineEventsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'timelineEvents';
+
+    protected static ?string $recordTitleAttribute = 'internal_name';
+
+    protected static ?string $title = 'Timeline events';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->inverseRelationship('items')
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->with([
+                'timeline:id,internal_name',
+            ]))
+            ->defaultSort('timeline.internal_name', 'asc')
+            ->paginated([25, 50, 100])
+            ->defaultPaginationPageOption(25)
+            ->columns([
+                TextColumn::make('timeline.internal_name')
+                    ->label('Timeline')
+                    ->sortable()
+                    ->url(fn ($record): ?string => $record->timeline && auth()->user()?->can('view', $record->timeline)
+                        ? TimelineResource::getUrl('view', ['record' => $record->timeline])
+                        : null),
+                TextColumn::make('internal_name')
+                    ->label('Event')
+                    ->searchable()
+                    ->sortable()
+                    ->url(fn ($record): ?string => auth()->user()?->can('view', $record)
+                        ? TimelineEventResource::getUrl('view', ['record' => $record])
+                        : null),
+                TextColumn::make('year_from')
+                    ->label('Year from')
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('year_to')
+                    ->label('Year to')
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('pivot.display_order')
+                    ->label('Display order')
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('created_at')
+                    ->label('Created')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ]);
+    }
+}

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -250,6 +250,16 @@ class Item extends Model
     }
 
     /**
+     * Get all timeline events this item is associated with.
+     */
+    public function timelineEvents(): BelongsToMany
+    {
+        return $this->belongsToMany(TimelineEvent::class, 'timeline_event_item')
+            ->withPivot('display_order', 'backward_compatibility', 'extra')
+            ->withTimestamps();
+    }
+
+    /**
      * Get all collections this item is attached to via many-to-many relationship.
      */
     public function attachedToCollections(): BelongsToMany


### PR DESCRIPTION
- Item.php — added `timelineEvents()` `BelongsToMany` relationship (inverse of `TimelineEvent::items()`, same pivot table and columns).
- TimelineEventsRelationManager.php — new read-only relation manager showing Timeline name (linked to its resource), event name (linked to its resource), year range, and pivot display order. No attach/detach — the link is managed from the Timeline Event side.
- ItemResource.php — imported and registered `TimelineEventsRelationManager` after `TagsRelationManager` and before `DisplayedInCollectionsRelationManager`.