### PR TITLE
Remove dark mode class from infolist entry background

### DIFF
--- a/app/Filament/Support/ExtraJsonField.php
+++ b/app/Filament/Support/ExtraJsonField.php
@@ -102,7 +102,7 @@ class ExtraJsonField
                     JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
                 );
 
-                return '<pre class="text-xs font-mono whitespace-pre-wrap break-all bg-gray-50 text-gray-950 dark:text-gray-100 p-2 rounded">'
+                return '<pre class="text-xs font-mono whitespace-pre-wrap break-all bg-gray-50 text-gray-950 p-2 rounded">'
                     .e($json)
                     .'</pre>';
             })

--- a/tests/Filament/Resources/ExtraJsonFieldTest.php
+++ b/tests/Filament/Resources/ExtraJsonFieldTest.php
@@ -150,8 +150,7 @@ class ExtraJsonFieldTest extends TestCase
             ->get("/admin/timelines/{$timeline->getKey()}")
             ->assertOk()
             ->assertSee('Metadata')
-            ->assertSee('text-gray-950', false)
-            ->assertSee('dark:text-gray-100', false);
+            ->assertSee('text-gray-950', false);
     }
 
     // ─── TimelineEvent ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Eliminate the dark mode class from the infolist entry background in the ExtraJsonField to simplify styling. Update tests accordingly to reflect this change.