### PR TITLE
All stories in Epic #1221 are implemented. Here's a summary of what was done:

### DIFF
--- a/scripts/importer/src/importers/phase-01/mwnf3-exhibition-item-importer.ts
+++ b/scripts/importer/src/importers/phase-01/mwnf3-exhibition-item-importer.ts
@@ -14,8 +14,8 @@
  * - 92 item references + 2 custom images
  *
  * EAV metadata (exhibition_page_images_fields):
- * - detail_justification, detail_name → stored in collection_item pivot extra
- * - item_* fields → denormalized copies, skipped
+ * - detail_justification, detail_name, item_artist, item_date, item_dynasty,
+ *   item_location, item_material, item_museum, item_name → stored in collection_item pivot extra
  *
  * Image detail annotations (exhibition_page_image_details + fields):
  * - Stored as nested array in the parent page-image's collection_item extra
@@ -31,7 +31,6 @@ import type {
   Mwnf3LegacyExhibitionPageImage,
   Mwnf3LegacyExhibitionPageImageDetail,
   Mwnf3LegacyExhibitionLevelImage,
-  Mwnf3LegacyEavField,
   Mwnf3LegacyArtintroPageImage,
 } from '../../domain/types/index.js';
 import { convertHtmlToMarkdown } from '../../utils/html-to-markdown.js';
@@ -50,12 +49,46 @@ interface ParsedRefItem {
 }
 
 /**
- * Pivoted EAV: non-empty editorial fields only.
+ * Supported EAV field names for image placement metadata.
  */
-interface ImageEav {
-  detail_name?: Record<string, string>; // lang → text
-  detail_justification?: Record<string, string>; // lang → text
-}
+const IMAGE_EAV_FIELDS_PAGE = [
+  'detail_name',
+  'detail_justification',
+  'item_artist',
+  'item_date',
+  'item_dynasty',
+  'item_location',
+  'item_material',
+  'item_museum',
+  'item_name',
+] as const;
+
+const IMAGE_EAV_FIELDS_EXHIBITION = [
+  'item_date',
+  'item_description',
+  'item_dynasty',
+  'item_location',
+  'item_museum',
+  'item_name',
+] as const;
+
+const IMAGE_EAV_FIELDS_ARTINTRO = [
+  'detail_name',
+  'detail_justification',
+  'item_date',
+  'item_dynasty',
+  'item_location',
+  'item_museum',
+  'item_name',
+] as const;
+
+type ImageEavFieldName = string;
+
+/**
+ * Pivoted EAV: non-empty image placement metadata fields.
+ * Each supported field is a language-keyed map.
+ */
+type ImageEav = Record<ImageEavFieldName, Record<string, string>>;
 
 export class Mwnf3ExhibitionItemImporter extends BaseImporter {
   getName(): string {
@@ -155,11 +188,12 @@ export class Mwnf3ExhibitionItemImporter extends BaseImporter {
             picture: img.picture,
           };
 
-          // Merge EAV editorial data
+          // Merge EAV placement metadata
           const eav = imageEavMap.get(img.image_id);
           if (eav) {
-            if (eav.detail_name) extra.detail_name = eav.detail_name;
-            if (eav.detail_justification) extra.detail_justification = eav.detail_justification;
+            for (const [field, langMap] of Object.entries(eav)) {
+              extra[field] = langMap;
+            }
           }
 
           // Merge detail annotations
@@ -225,6 +259,9 @@ export class Mwnf3ExhibitionItemImporter extends BaseImporter {
 
     this.logInfo(`Found ${images.length} exhibition-level images`);
 
+    // Pre-load EAV placement metadata for exhibition-level images
+    const exhibitionImageEavMap = await this.loadExhibitionImageEav();
+
     for (const img of images) {
       try {
         const collectionBackwardCompat = `${MWNF3_SCHEMA}:exhibitions:${img.exhibition_id}`;
@@ -267,15 +304,26 @@ export class Mwnf3ExhibitionItemImporter extends BaseImporter {
             continue;
           }
 
+          // Build extra with ordering, picture path, and EAV placement metadata
+          const extra: Record<string, unknown> = {
+            n: img.n,
+            n2: img.n2,
+            picture: img.picture,
+          };
+
+          // Merge exhibition-level EAV placement metadata
+          const exhEav = exhibitionImageEavMap.get(img.image_id);
+          if (exhEav) {
+            for (const [field, langMap] of Object.entries(exhEav)) {
+              extra[field] = langMap;
+            }
+          }
+
           await this.context.strategy.writeCollectionItem({
             collection_id: collectionId,
             item_id: itemId,
             display_order: img.n,
-            extra: {
-              n: img.n,
-              n2: img.n2,
-              picture: img.picture,
-            },
+            extra,
           });
 
           result.imported++;
@@ -321,6 +369,9 @@ export class Mwnf3ExhibitionItemImporter extends BaseImporter {
     );
 
     this.logInfo(`Found ${images.length} artintro page images`);
+
+    // Pre-load EAV placement metadata for artintro page images
+    const artintroImageEavMap = await this.loadArtintroImageEav();
 
     for (const img of images) {
       try {
@@ -374,15 +425,26 @@ export class Mwnf3ExhibitionItemImporter extends BaseImporter {
           continue;
         }
 
+        // Build extra with ordering, picture path, and EAV placement metadata
+        const artintroExtra: Record<string, unknown> = {
+          n: img.n,
+          n2: img.n2,
+          picture: img.picture,
+        };
+
+        // Merge artintro EAV placement metadata
+        const artintroEav = artintroImageEavMap.get(img.image_id);
+        if (artintroEav) {
+          for (const [field, langMap] of Object.entries(artintroEav)) {
+            artintroExtra[field] = langMap;
+          }
+        }
+
         await this.context.strategy.writeCollectionItem({
           collection_id: collectionId,
           item_id: itemId,
           display_order: img.n,
-          extra: {
-            n: img.n,
-            n2: img.n2,
-            picture: img.picture,
-          },
+          extra: artintroExtra,
         });
 
         result.imported++;
@@ -449,43 +511,47 @@ export class Mwnf3ExhibitionItemImporter extends BaseImporter {
   }
 
   /**
-   * Load and pivot exhibition_page_images_fields EAV for editorial fields only.
-   * Returns Map<image_id, ImageEav>.
+   * Pivot EAV rows from a query result into Map<image_id, ImageEav>.
    */
-  private async loadImageEav(): Promise<Map<number, ImageEav>> {
-    const rows = await this.context.legacyDb.query<
-      Mwnf3LegacyEavField & { image_id: number; n: number; n2: number }
-    >(
-      `SELECT image_id AS entity_id, n, n2, lang_id, field, value
-       FROM ${MWNF3_SCHEMA}.exhibition_page_images_fields
-       WHERE field IN ('detail_name', 'detail_justification')
-         AND value IS NOT NULL AND value != ''
-       ORDER BY image_id, lang_id, field`
-    );
-
+  private pivotImageEav(
+    rows: Array<{ entity_id: number; lang_id: string; field: string; value: string }>
+  ): Map<number, ImageEav> {
     const map = new Map<number, ImageEav>();
     for (const row of rows) {
-      const imageId = row.entity_id;
-      if (!map.has(imageId)) {
-        map.set(imageId, {});
+      if (row.value == null || !row.value.trim()) continue;
+      if (!map.has(row.entity_id)) {
+        map.set(row.entity_id, {});
       }
-      const eav = map.get(imageId)!;
-
-      if (row.field === 'detail_name') {
-        if (!eav.detail_name) eav.detail_name = {};
-        eav.detail_name[row.lang_id] = convertHtmlToMarkdown(row.value);
-      } else if (row.field === 'detail_justification') {
-        if (!eav.detail_justification) eav.detail_justification = {};
-        eav.detail_justification[row.lang_id] = convertHtmlToMarkdown(row.value);
-      }
+      const eav = map.get(row.entity_id)!;
+      if (!eav[row.field]) eav[row.field] = {};
+      eav[row.field]![row.lang_id] = convertHtmlToMarkdown(row.value);
     }
-
-    this.logInfo(`Loaded editorial EAV for ${map.size} page images`);
     return map;
   }
 
   /**
-   * Load exhibition_page_image_details + EAV fields.
+   * Load and pivot exhibition_page_images_fields EAV for all supported placement fields.
+   * Returns Map<image_id, ImageEav>.
+   */
+  private async loadImageEav(): Promise<Map<number, ImageEav>> {
+    const fieldList = IMAGE_EAV_FIELDS_PAGE.map((f) => `'${f}'`).join(', ');
+    const rows = await this.context.legacyDb.query<
+      { entity_id: number; lang_id: string; field: string; value: string }
+    >(
+      `SELECT image_id AS entity_id, lang_id, field, value
+       FROM ${MWNF3_SCHEMA}.exhibition_page_images_fields
+       WHERE field IN (${fieldList})
+         AND value IS NOT NULL AND TRIM(value) != ''
+       ORDER BY image_id, lang_id, field`
+    );
+
+    const map = this.pivotImageEav(rows);
+    this.logInfo(`Loaded placement EAV for ${map.size} page images`);
+    return map;
+  }
+
+  /**
+   * Load exhibition_page_image_details + EAV fields (all supported placement fields).
    * Returns Map<parent_image_id, detail_annotation[]>.
    */
   private async loadImageDetails(): Promise<Map<number, Array<Record<string, unknown>>>> {
@@ -495,33 +561,18 @@ export class Mwnf3ExhibitionItemImporter extends BaseImporter {
        ORDER BY image_id, n, n2`
     );
 
-    // Load EAV for details
+    const detailFieldList = IMAGE_EAV_FIELDS_PAGE.map((f) => `'${f}'`).join(', ');
     const detailEavRows = await this.context.legacyDb.query<
-      Mwnf3LegacyEavField & { detail_id: number }
+      { entity_id: number; lang_id: string; field: string; value: string }
     >(
       `SELECT image_detail_id AS entity_id, lang_id, field, value
        FROM ${MWNF3_SCHEMA}.exhibition_page_image_details_fields
-       WHERE field IN ('detail_name', 'detail_justification')
-         AND value IS NOT NULL AND value != ''
+       WHERE field IN (${detailFieldList})
+         AND value IS NOT NULL AND TRIM(value) != ''
        ORDER BY image_detail_id, lang_id, field`
     );
 
-    // Pivot detail EAV
-    const detailEav = new Map<number, ImageEav>();
-    for (const row of detailEavRows) {
-      const detailId = row.entity_id;
-      if (!detailEav.has(detailId)) {
-        detailEav.set(detailId, {});
-      }
-      const eav = detailEav.get(detailId)!;
-      if (row.field === 'detail_name') {
-        if (!eav.detail_name) eav.detail_name = {};
-        eav.detail_name[row.lang_id] = convertHtmlToMarkdown(row.value);
-      } else if (row.field === 'detail_justification') {
-        if (!eav.detail_justification) eav.detail_justification = {};
-        eav.detail_justification[row.lang_id] = convertHtmlToMarkdown(row.value);
-      }
-    }
+    const detailEav = this.pivotImageEav(detailEavRows);
 
     // Group by parent image_id
     const map = new Map<number, Array<Record<string, unknown>>>();
@@ -538,14 +589,57 @@ export class Mwnf3ExhibitionItemImporter extends BaseImporter {
 
       const eav = detailEav.get(d.detail_id);
       if (eav) {
-        if (eav.detail_name) annotation.detail_name = eav.detail_name;
-        if (eav.detail_justification) annotation.detail_justification = eav.detail_justification;
+        for (const [field, langMap] of Object.entries(eav)) {
+          annotation[field] = langMap;
+        }
       }
 
       map.get(d.image_id)!.push(annotation);
     }
 
     this.logInfo(`Loaded ${details.length} detail annotations across ${map.size} parent images`);
+    return map;
+  }
+
+  /**
+   * Load and pivot exhibition_images_fields EAV for all supported placement fields.
+   * Returns Map<image_id, ImageEav>.
+   */
+  private async loadExhibitionImageEav(): Promise<Map<number, ImageEav>> {
+    const fieldList = IMAGE_EAV_FIELDS_EXHIBITION.map((f) => `'${f}'`).join(', ');
+    const rows = await this.context.legacyDb.query<
+      { entity_id: number; lang_id: string; field: string; value: string }
+    >(
+      `SELECT image_id AS entity_id, lang_id, field, value
+       FROM ${MWNF3_SCHEMA}.exhibition_images_fields
+       WHERE field IN (${fieldList})
+         AND value IS NOT NULL AND TRIM(value) != ''
+       ORDER BY image_id, lang_id, field`
+    );
+
+    const map = this.pivotImageEav(rows);
+    this.logInfo(`Loaded placement EAV for ${map.size} exhibition-level images`);
+    return map;
+  }
+
+  /**
+   * Load and pivot artintro_page_images_fields EAV for all supported placement fields.
+   * Returns Map<image_id, ImageEav>.
+   */
+  private async loadArtintroImageEav(): Promise<Map<number, ImageEav>> {
+    const fieldList = IMAGE_EAV_FIELDS_ARTINTRO.map((f) => `'${f}'`).join(', ');
+    const rows = await this.context.legacyDb.query<
+      { entity_id: number; lang_id: string; field: string; value: string }
+    >(
+      `SELECT image_id AS entity_id, lang_id, field, value
+       FROM ${MWNF3_SCHEMA}.artintro_page_images_fields
+       WHERE field IN (${fieldList})
+         AND value IS NOT NULL AND TRIM(value) != ''
+       ORDER BY image_id, lang_id, field`
+    );
+
+    const map = this.pivotImageEav(rows);
+    this.logInfo(`Loaded placement EAV for ${map.size} artintro page images`);
     return map;
   }
 }

--- a/scripts/importer/tests/unit/mwnf3-exhibition-item-importer.test.ts
+++ b/scripts/importer/tests/unit/mwnf3-exhibition-item-importer.test.ts
@@ -1,0 +1,554 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Mwnf3ExhibitionItemImporter } from '../../src/importers/phase-01/mwnf3-exhibition-item-importer.js';
+import { UnifiedTracker } from '../../src/core/tracker.js';
+import type { ImportContext, ILegacyDatabase, ILogger } from '../../src/core/base-importer.js';
+import type { IWriteStrategy } from '../../src/core/strategy.js';
+
+// ===========================================================================
+// Test constants
+// ===========================================================================
+
+const PAGE_ID = 7;
+const PAGE_COLLECTION_BC = `mwnf3:exhibition_pages:${PAGE_ID}`;
+
+const EXHIBITION_ID = 10;
+const EXHIBITION_COLLECTION_BC = `mwnf3:exhibitions:${EXHIBITION_ID}`;
+
+const ARTINTRO_PAGE_ID = 3;
+const ARTINTRO_PAGE_COLLECTION_BC = `mwnf3:artintro_pages:${ARTINTRO_PAGE_ID}`;
+
+const IMAGE_ID = 42;
+const ITEM_BC = 'mwnf3:objects:isl:jo:Mus01:8';
+
+// ===========================================================================
+// Shared fixtures
+// ===========================================================================
+
+/** A page image row referencing item 'O;ISL;jo;1;8'. */
+const PAGE_IMAGE_ROW = {
+  image_id: IMAGE_ID,
+  page_id: PAGE_ID,
+  n: 1,
+  n2: 0,
+  ref_item: 'O;ISL;jo;1;8',
+  picture: 'images/item.jpg',
+};
+
+/** An exhibition-level image row referencing the same item. */
+const EXHIBITION_IMAGE_ROW = {
+  image_id: IMAGE_ID,
+  exhibition_id: EXHIBITION_ID,
+  n: 1,
+  n2: 0,
+  ref_item: 'O;ISL;jo;1;8',
+  picture: 'images/exh.jpg',
+};
+
+/** An artintro page image row referencing the same item. */
+const ARTINTRO_IMAGE_ROW = {
+  image_id: IMAGE_ID,
+  page_id: ARTINTRO_PAGE_ID,
+  n: 1,
+  n2: 0,
+  ref_item: 'O;ISL;jo;1;8',
+  picture: 'images/artintro.jpg',
+};
+
+// ===========================================================================
+// Logger stub
+// ===========================================================================
+
+const logger: ILogger = {
+  info: vi.fn(),
+  warning: vi.fn(),
+  skip: vi.fn(),
+  error: vi.fn(),
+  exception: vi.fn(),
+  showProgress: vi.fn(),
+  showSkipped: vi.fn(),
+  showError: vi.fn(),
+  showSummary: vi.fn(),
+};
+
+// ===========================================================================
+// Helpers
+// ===========================================================================
+
+/**
+ * Build a query mock for page-image tests.
+ * Supplies exhibition_page_images + exhibition_page_images_fields EAV,
+ * and returns empty arrays for all other tables.
+ */
+function makePageImageQueryMock(
+  pageImages: typeof PAGE_IMAGE_ROW[],
+  eavRows: Array<{ entity_id: number; lang_id: string; field: string; value: string }>,
+  detailRows: Array<Record<string, unknown>> = [],
+  detailEavRows: Array<{ entity_id: number; lang_id: string; field: string; value: string }> = []
+): ReturnType<typeof vi.fn> {
+  return vi.fn(async (sql: string) => {
+    if (sql.includes('exhibition_page_images_fields')) return eavRows;
+    if (sql.includes('exhibition_page_image_details_fields')) return detailEavRows;
+    if (sql.includes('exhibition_page_image_details') && !sql.includes('_fields')) return detailRows;
+    if (sql.includes('exhibition_page_images') && !sql.includes('_fields') && !sql.includes('details')) return pageImages;
+    // exhibition_images and artintro_page_images return empty
+    return [];
+  });
+}
+
+/**
+ * Build a query mock for exhibition-level image tests.
+ */
+function makeExhibitionImageQueryMock(
+  exhibitionImages: typeof EXHIBITION_IMAGE_ROW[],
+  eavRows: Array<{ entity_id: number; lang_id: string; field: string; value: string }>
+): ReturnType<typeof vi.fn> {
+  return vi.fn(async (sql: string) => {
+    if (sql.includes('exhibition_images_fields')) return eavRows;
+    if (sql.includes('exhibition_images') && !sql.includes('_fields') && !sql.includes('page')) return exhibitionImages;
+    // page images and artintro return empty
+    return [];
+  });
+}
+
+/**
+ * Build a query mock for artintro page image tests.
+ */
+function makeArtintroImageQueryMock(
+  artintroImages: typeof ARTINTRO_IMAGE_ROW[],
+  eavRows: Array<{ entity_id: number; lang_id: string; field: string; value: string }>
+): ReturnType<typeof vi.fn> {
+  return vi.fn(async (sql: string) => {
+    if (sql.includes('artintro_page_images_fields')) return eavRows;
+    if (sql.includes('artintro_page_images') && !sql.includes('_fields')) return artintroImages;
+    // page images and exhibition_images return empty
+    return [];
+  });
+}
+
+function makeContext(
+  queryMock: ReturnType<typeof vi.fn>,
+  tracker: UnifiedTracker,
+  writeCollectionItemMock: ReturnType<typeof vi.fn>
+): ImportContext {
+  const legacyDb: ILegacyDatabase = {
+    query: queryMock as ILegacyDatabase['query'],
+    execute: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  };
+
+  const strategy = {
+    exists: vi.fn().mockResolvedValue(false),
+    findByBackwardCompatibility: vi.fn().mockResolvedValue(null),
+    writeCollectionItem: writeCollectionItemMock,
+    writeCollectionImage: vi.fn().mockResolvedValue(undefined),
+  } as unknown as IWriteStrategy;
+
+  return {
+    legacyDb,
+    strategy,
+    tracker,
+    logger,
+    dryRun: false,
+  };
+}
+
+// ===========================================================================
+// Tests: story #1225 — exhibition_page_images_fields extended fields
+// ===========================================================================
+
+describe('Mwnf3ExhibitionItemImporter — story #1225: page image EAV fields', () => {
+  let tracker: UnifiedTracker;
+  let writeCollectionItemMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tracker = new UnifiedTracker();
+    tracker.set(PAGE_COLLECTION_BC, 'page-collection-uuid', 'collection');
+    tracker.set(ITEM_BC, 'item-uuid', 'item');
+    writeCollectionItemMock = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it('stores item_name, item_date, item_dynasty, item_location on collection_item.extra', async () => {
+    const eavRows = [
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_name', value: 'Golden Vase' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_date', value: '12th century' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_dynasty', value: 'Abbasid' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_location', value: 'Baghdad Museum' },
+    ];
+
+    const ctx = makeContext(
+      makePageImageQueryMock([PAGE_IMAGE_ROW], eavRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    expect(writeCollectionItemMock).toHaveBeenCalledTimes(1);
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    expect(extra.item_name).toEqual({ en: 'Golden Vase' });
+    expect(extra.item_date).toEqual({ en: '12th century' });
+    expect(extra.item_dynasty).toEqual({ en: 'Abbasid' });
+    expect(extra.item_location).toEqual({ en: 'Baghdad Museum' });
+  });
+
+  it('stores item_artist, item_material, item_museum on collection_item.extra', async () => {
+    const eavRows = [
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_artist', value: 'Unknown Artist' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_material', value: 'Ceramic' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_museum', value: 'Cairo Museum' },
+    ];
+
+    const ctx = makeContext(
+      makePageImageQueryMock([PAGE_IMAGE_ROW], eavRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    expect(extra.item_artist).toEqual({ en: 'Unknown Artist' });
+    expect(extra.item_material).toEqual({ en: 'Ceramic' });
+    expect(extra.item_museum).toEqual({ en: 'Cairo Museum' });
+  });
+
+  it('regression: detail_justification still lands in collection_item.extra', async () => {
+    const eavRows = [
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'detail_justification', value: 'The detail text.' },
+    ];
+
+    const ctx = makeContext(
+      makePageImageQueryMock([PAGE_IMAGE_ROW], eavRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    expect(extra.detail_justification).toEqual({ en: 'The detail text.' });
+  });
+
+  it('preserves n, n2, picture, and details alongside new EAV fields', async () => {
+    const eavRows = [
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_name', value: 'Vessel' },
+    ];
+
+    const ctx = makeContext(
+      makePageImageQueryMock([PAGE_IMAGE_ROW], eavRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    expect(extra.n).toBe(1);
+    expect(extra.n2).toBe(0);
+    expect(extra.picture).toBe('images/item.jpg');
+  });
+
+  it('stores multi-language values as separate lang keys', async () => {
+    const eavRows = [
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_name', value: 'Golden Vase' },
+      { entity_id: IMAGE_ID, lang_id: 'de', field: 'item_name', value: 'Goldene Vase' },
+    ];
+
+    const ctx = makeContext(
+      makePageImageQueryMock([PAGE_IMAGE_ROW], eavRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    expect(extra.item_name).toEqual({ en: 'Golden Vase', de: 'Goldene Vase' });
+  });
+
+  it('omits fields whose source values are empty or whitespace-only', async () => {
+    const eavRows = [
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_name', value: '' },
+    ];
+
+    const ctx = makeContext(
+      makePageImageQueryMock([PAGE_IMAGE_ROW], eavRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    expect(extra.item_name).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// Tests: story #1222 — exhibition_page_image_details_fields extended fields
+// ===========================================================================
+
+describe('Mwnf3ExhibitionItemImporter — story #1222: page image detail annotation EAV fields', () => {
+  let tracker: UnifiedTracker;
+  let writeCollectionItemMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tracker = new UnifiedTracker();
+    tracker.set(PAGE_COLLECTION_BC, 'page-collection-uuid', 'collection');
+    tracker.set(ITEM_BC, 'item-uuid', 'item');
+    writeCollectionItemMock = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it('stores item_name, item_date, item_dynasty, item_location on nested detail annotation', async () => {
+    const DETAIL_ID = 99;
+    const detailRows = [
+      { detail_id: DETAIL_ID, image_id: IMAGE_ID, n: 1, n2: 0, ref_detail_item: null, picture_details: null },
+    ];
+    const detailEavRows = [
+      { entity_id: DETAIL_ID, lang_id: 'en', field: 'item_name', value: 'Fragment' },
+      { entity_id: DETAIL_ID, lang_id: 'en', field: 'item_date', value: '10th century' },
+      { entity_id: DETAIL_ID, lang_id: 'en', field: 'item_dynasty', value: 'Fatimid' },
+      { entity_id: DETAIL_ID, lang_id: 'en', field: 'item_location', value: 'Cairo' },
+    ];
+
+    const ctx = makeContext(
+      makePageImageQueryMock([PAGE_IMAGE_ROW], [], detailRows, detailEavRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    const details = extra.details as Array<Record<string, unknown>>;
+    expect(details).toHaveLength(1);
+    expect(details[0].item_name).toEqual({ en: 'Fragment' });
+    expect(details[0].item_date).toEqual({ en: '10th century' });
+    expect(details[0].item_dynasty).toEqual({ en: 'Fatimid' });
+    expect(details[0].item_location).toEqual({ en: 'Cairo' });
+  });
+
+  it('regression: detail_name and detail_justification remain present on nested annotations', async () => {
+    const DETAIL_ID = 100;
+    const detailRows = [
+      { detail_id: DETAIL_ID, image_id: IMAGE_ID, n: 1, n2: 0, ref_detail_item: null, picture_details: null },
+    ];
+    const detailEavRows = [
+      { entity_id: DETAIL_ID, lang_id: 'en', field: 'detail_name', value: 'Close-up' },
+      { entity_id: DETAIL_ID, lang_id: 'en', field: 'detail_justification', value: 'Shows craftsmanship.' },
+    ];
+
+    const ctx = makeContext(
+      makePageImageQueryMock([PAGE_IMAGE_ROW], [], detailRows, detailEavRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    const details = extra.details as Array<Record<string, unknown>>;
+    expect(details[0].detail_name).toEqual({ en: 'Close-up' });
+    expect(details[0].detail_justification).toEqual({ en: 'Shows craftsmanship.' });
+  });
+
+  it('preserves n, n2, ref_detail_item, and picture_details on annotation', async () => {
+    const DETAIL_ID = 101;
+    const detailRows = [
+      {
+        detail_id: DETAIL_ID,
+        image_id: IMAGE_ID,
+        n: 2,
+        n2: 1,
+        ref_detail_item: 'O;ISL;jo;1;9',
+        picture_details: 'detail.jpg',
+      },
+    ];
+
+    const ctx = makeContext(
+      makePageImageQueryMock([PAGE_IMAGE_ROW], [], detailRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    const details = extra.details as Array<Record<string, unknown>>;
+    expect(details[0].n).toBe(2);
+    expect(details[0].n2).toBe(1);
+    expect(details[0].ref_detail_item).toBe('O;ISL;jo;1;9');
+    expect(details[0].picture_details).toBe('detail.jpg');
+  });
+});
+
+// ===========================================================================
+// Tests: story #1224 — exhibition_images_fields
+// ===========================================================================
+
+describe('Mwnf3ExhibitionItemImporter — story #1224: exhibition-level image EAV fields', () => {
+  let tracker: UnifiedTracker;
+  let writeCollectionItemMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tracker = new UnifiedTracker();
+    tracker.set(EXHIBITION_COLLECTION_BC, 'exh-collection-uuid', 'collection');
+    tracker.set(ITEM_BC, 'item-uuid', 'item');
+    writeCollectionItemMock = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it('stores item_name, item_date, item_dynasty, item_location on collection_item.extra', async () => {
+    const eavRows = [
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_name', value: 'Bronze Bowl' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_date', value: '9th century' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_dynasty', value: 'Umayyad' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_location', value: 'Damascus' },
+    ];
+
+    const ctx = makeContext(
+      makeExhibitionImageQueryMock([EXHIBITION_IMAGE_ROW], eavRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    expect(writeCollectionItemMock).toHaveBeenCalledTimes(1);
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    expect(extra.item_name).toEqual({ en: 'Bronze Bowl' });
+    expect(extra.item_date).toEqual({ en: '9th century' });
+    expect(extra.item_dynasty).toEqual({ en: 'Umayyad' });
+    expect(extra.item_location).toEqual({ en: 'Damascus' });
+  });
+
+  it('stores item_description and item_museum on collection_item.extra', async () => {
+    const eavRows = [
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_description', value: 'A rare example.' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_museum', value: 'National Museum' },
+    ];
+
+    const ctx = makeContext(
+      makeExhibitionImageQueryMock([EXHIBITION_IMAGE_ROW], eavRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    expect(extra.item_description).toEqual({ en: 'A rare example.' });
+    expect(extra.item_museum).toEqual({ en: 'National Museum' });
+  });
+
+  it('regression: n, n2, and picture are still written to extra', async () => {
+    const ctx = makeContext(
+      makeExhibitionImageQueryMock([EXHIBITION_IMAGE_ROW], []),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    expect(extra.n).toBe(1);
+    expect(extra.n2).toBe(0);
+    expect(extra.picture).toBe('images/exh.jpg');
+  });
+});
+
+// ===========================================================================
+// Tests: story #1223 — artintro_page_images_fields
+// ===========================================================================
+
+describe('Mwnf3ExhibitionItemImporter — story #1223: artintro page image EAV fields', () => {
+  let tracker: UnifiedTracker;
+  let writeCollectionItemMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tracker = new UnifiedTracker();
+    tracker.set(ARTINTRO_PAGE_COLLECTION_BC, 'artintro-page-uuid', 'collection');
+    tracker.set(ITEM_BC, 'item-uuid', 'item');
+    writeCollectionItemMock = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it('stores detail_justification, item_name, item_date, item_location on collection_item.extra', async () => {
+    const eavRows = [
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'detail_justification', value: 'Context note.' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_name', value: 'Marble Slab' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_date', value: '11th century' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_location', value: 'Jordan' },
+    ];
+
+    const ctx = makeContext(
+      makeArtintroImageQueryMock([ARTINTRO_IMAGE_ROW], eavRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    expect(writeCollectionItemMock).toHaveBeenCalledTimes(1);
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    expect(extra.detail_justification).toEqual({ en: 'Context note.' });
+    expect(extra.item_name).toEqual({ en: 'Marble Slab' });
+    expect(extra.item_date).toEqual({ en: '11th century' });
+    expect(extra.item_location).toEqual({ en: 'Jordan' });
+  });
+
+  it('stores detail_name, item_dynasty, item_museum on collection_item.extra', async () => {
+    const eavRows = [
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'detail_name', value: 'Detail shot' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_dynasty', value: 'Ayyubid' },
+      { entity_id: IMAGE_ID, lang_id: 'en', field: 'item_museum', value: 'Amman Museum' },
+    ];
+
+    const ctx = makeContext(
+      makeArtintroImageQueryMock([ARTINTRO_IMAGE_ROW], eavRows),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    expect(extra.detail_name).toEqual({ en: 'Detail shot' });
+    expect(extra.item_dynasty).toEqual({ en: 'Ayyubid' });
+    expect(extra.item_museum).toEqual({ en: 'Amman Museum' });
+  });
+
+  it('regression: n, n2, and picture are still written to extra', async () => {
+    const ctx = makeContext(
+      makeArtintroImageQueryMock([ARTINTRO_IMAGE_ROW], []),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    await importer.import();
+
+    const extra = writeCollectionItemMock.mock.calls[0][0].extra as Record<string, unknown>;
+    expect(extra.n).toBe(1);
+    expect(extra.n2).toBe(0);
+    expect(extra.picture).toBe('images/artintro.jpg');
+  });
+});


### PR DESCRIPTION
**Changes to mwnf3-exhibition-item-importer.ts:**

- Replaced the narrow `ImageEav` interface (only `detail_name`/`detail_justification`) with a flexible `type ImageEav = Record<ImageEavFieldName, Record<string, string>>` that covers any field name
- Added three field-name const arrays: `IMAGE_EAV_FIELDS_PAGE` (9 fields), `IMAGE_EAV_FIELDS_EXHIBITION` (6 fields), `IMAGE_EAV_FIELDS_ARTINTRO` (7 fields)
- Added `pivotImageEav()` helper — shared pivot logic with null/trim guard, so defensive filtering works even when mocks bypass SQL `WHERE` clauses
- **Story #1225**: Updated `loadImageEav()` to query all 9 `exhibition_page_images_fields` supported fields and merge them all into `collection_item.extra`
- **Story #1222**: Updated `loadImageDetails()` to query all 9 `exhibition_page_image_details_fields` fields and merge them all onto each annotation object
- **Story #1224**: Added `loadExhibitionImageEav()` + pre-loading in `importExhibitionLevelImages()` — now merges 6 `exhibition_images_fields` fields into `collection_item.extra` for item-reference rows
- **Story #1223**: Added `loadArtintroImageEav()` + pre-loading in `importArtintroPageImages()` — now merges 7 `artintro_page_images_fields` fields into `collection_item.extra`

---

Fixes #1221 
Fixes #1222 
Fixes #1223 
Fixes #1224 
Fixes #1225