### PR TITLE
Fix agent importer and update deployment documentation

### DIFF
--- a/.copilot/local/README.md
+++ b/.copilot/local/README.md
@@ -1,0 +1,10 @@
+# Contributor-Local Copilot Config
+
+Files in this directory let shared Copilot agents and instructions stay valid for every contributor while each contributor keeps local paths, host aliases, SSH key paths, and bootstrap user lists on their own machine.
+
+- `*.template.md` files are committed and safe to share.
+- Copy a template to the same name without `.template`, then fill in your local values.
+- Non-template files in this directory are ignored by Git.
+- Do not store secrets, passwords, private key contents, tokens, or production `.env` values here.
+
+Shared agents and instructions must read the relevant local file first. If it is missing or incomplete, they must ask the user for the missing values before executing commands.

--- a/.copilot/local/legacy-importer.template.md
+++ b/.copilot/local/legacy-importer.template.md
@@ -1,0 +1,54 @@
+# Legacy Importer Local Config Template
+
+Copy this file to `.copilot/local/legacy-importer.md` and fill values for your machine. Do not commit the copied file.
+
+## Workspace
+
+- workspace_root: `<ABSOLUTE_WORKSPACE_ROOT>`
+- importer_dir: `<ABSOLUTE_WORKSPACE_ROOT>/scripts/importer`
+- local_laravel_root: `<ABSOLUTE_WORKSPACE_ROOT>`
+
+## Local Target Profile
+
+- legacy_db_host: `<LEGACY_DB_HOST>`
+- legacy_db_port: `<LEGACY_DB_PORT>`
+- legacy_db_database: `<LEGACY_DB_DATABASE>`
+- local_target_db_host: `<LOCAL_TARGET_DB_HOST>`
+- local_target_db_port: `<LOCAL_TARGET_DB_PORT>`
+- local_target_db_database: `<LOCAL_TARGET_DB_DATABASE>`
+- legacy_images_root: `<LEGACY_IMAGES_ROOT>`
+- local_target_images_root: `<LOCAL_TARGET_IMAGES_ROOT>`
+
+## Production Windows Target Profile
+
+- pssession_computer_name: `<WINDOWS_SERVER_HOST_OR_ALIAS>`
+- production_app_root: `<WINDOWS_PRODUCTION_APP_ROOT>`
+- temp_app_root: `<WINDOWS_TEMP_APP_ROOT>`
+- temp_importer_dir: `<WINDOWS_TEMP_IMPORTER_DIR>`
+- legacy_images_root: `<WINDOWS_LEGACY_IMAGES_ROOT>`
+
+## OVH Target Profile
+
+- ovh_host: `<OVH_HOST_OR_ALIAS>`
+- ovh_deploy_user: `<OVH_DEPLOY_USER>`
+- ovh_deploy_ssh_key: `<LOCAL_PATH_TO_DEPLOY_KEY>`
+- ovh_app_root: `<OVH_APP_ROOT>`
+- ovh_shared_pictures_dir: `<OVH_SHARED_PICTURES_DIR>`
+- ovh_db_tunnel_local_host: `127.0.0.1`
+- ovh_db_tunnel_local_port: `<LOCAL_TUNNEL_PORT>`
+- ovh_db_tunnel_remote_host: `127.0.0.1`
+- ovh_db_tunnel_remote_port: `3306`
+- ovh_local_image_temp_dir: `<LOCAL_TEMP_IMAGE_DIR>`
+- ovh_db_credentials_path: `<OVH_DB_CREDENTIALS_PATH>`
+
+## Users To Recreate After Full Reset
+
+List only non-secret user bootstrap data you are allowed to use in this environment.
+
+| email | password_or_policy | role | verify_email |
+|-------|--------------------|------|--------------|
+| `<EMAIL>` | `<PASSWORD_OR_POLICY>` | `<ROLE>` | `<true_or_false>` |
+
+## Secrets
+
+Do not store passwords, private keys, or tokens here. Read secrets from the environment-specific `.env`, GitHub Environment secrets, or the server-side credentials file named above.

--- a/.copilot/local/legacy-link-resolver.template.md
+++ b/.copilot/local/legacy-link-resolver.template.md
@@ -1,0 +1,12 @@
+# Legacy Link Resolver Local Config Template
+
+Copy this file to `.copilot/local/legacy-link-resolver.md` and fill values for your access path. Do not commit the copied file.
+
+## Private Back Office
+
+- backoffice_host: `<PRIVATE_BACKOFFICE_HOST>`
+- vpn_required: `<true_or_false>`
+
+## Notes
+
+Keep credentials out of this file.

--- a/.copilot/local/php-test-runner.template.md
+++ b/.copilot/local/php-test-runner.template.md
@@ -1,0 +1,20 @@
+# PHP Test Runner Local Config Template
+
+Copy this file to `.copilot/local/php-test-runner.md` and fill values for your machine. Do not commit the copied file.
+
+## Workspace
+
+- host_workspace_root: `<ABSOLUTE_HOST_WORKSPACE_ROOT>`
+- container_workspace_root: `/workspaces/inventory-app`
+- devcontainer_image: `inventory-app-dev`
+
+## Docker Volumes
+
+- php_vendor_volume: `inv-app-php-vendor`
+- root_node_modules_volume: `inv-app-node-modules`
+- spa_node_modules_volume: `inv-app-spa-node-modules`
+- importer_node_modules_volume: `inv-app-importer-node-modules`
+
+## Notes
+
+Only needed when running the manual Docker commands outside the VS Code Dev Container.

--- a/.copilot/local/server-ovh.template.md
+++ b/.copilot/local/server-ovh.template.md
@@ -1,0 +1,37 @@
+# OVH Server Local Config Template
+
+Copy this file to `.copilot/local/server-ovh.md` and fill values for your access path. Do not commit the copied file.
+
+## Connection
+
+- host: `<OVH_HOST_OR_ALIAS>`
+- deploy_user: `<DEPLOY_USER>`
+- deploy_ssh_key: `<LOCAL_PATH_TO_DEPLOY_KEY>`
+- admin_user: `<ADMIN_USER>`
+- admin_ssh_key: `<LOCAL_PATH_TO_ADMIN_KEY>`
+
+## Application Paths
+
+- app_root: `<OVH_APP_ROOT>`
+- current_symlink: `<OVH_CURRENT_SYMLINK>`
+- releases_root: `<OVH_RELEASES_ROOT>`
+- shared_root: `<OVH_SHARED_ROOT>`
+- shared_env: `<OVH_SHARED_ENV>`
+- shared_storage: `<OVH_SHARED_STORAGE>`
+- shared_pictures_dir: `<OVH_SHARED_PICTURES_DIR>`
+- laravel_log: `<OVH_LARAVEL_LOG>`
+- queue_worker_log: `<OVH_QUEUE_WORKER_LOG>`
+- backups_root: `<OVH_BACKUPS_ROOT>`
+
+## Runtime
+
+- domain: `<OVH_DOMAIN>`
+- nginx_vhost: `<OVH_NGINX_VHOST>`
+- queue_service: `<OVH_QUEUE_SERVICE>`
+- redis_db: `<REDIS_DB>`
+- redis_cache_db: `<REDIS_CACHE_DB>`
+- db_credentials_path: `<OVH_DB_CREDENTIALS_PATH>`
+
+## Notes
+
+Keep secrets and private key contents out of this file.

--- a/.copilot/local/server-windows.template.md
+++ b/.copilot/local/server-windows.template.md
@@ -1,0 +1,30 @@
+# Windows Server Local Config Template
+
+Copy this file to `.copilot/local/server-windows.md` and fill values for your access path. Do not commit the copied file.
+
+## Connection
+
+- pssession_computer_name: `<WINDOWS_SERVER_HOST_OR_ALIAS>`
+- vpn_required: `<true_or_false>`
+
+## Paths
+
+- server_root: `<WINDOWS_SERVER_ROOT>`
+- apps_root: `<WINDOWS_APPS_ROOT>`
+- dynapps_root: `<WINDOWS_DYNAPPS_ROOT>`
+- configuration_root: `<WINDOWS_CONFIGURATION_ROOT>`
+- software_root: `<WINDOWS_SOFTWARE_ROOT>`
+- pictures_root: `<WINDOWS_PICTURES_ROOT>`
+- github_apps_root: `<WINDOWS_GITHUB_APPS_ROOT>`
+- inventory_production_root: `<WINDOWS_INVENTORY_PRODUCTION_ROOT>`
+- inventory_temp_root: `<WINDOWS_INVENTORY_TEMP_ROOT>`
+- inventory_laravel_log: `<WINDOWS_INVENTORY_LARAVEL_LOG>`
+
+## Public And Private Hosts
+
+- inventory_url: `<INVENTORY_URL>`
+- backoffice_host: `<BACKOFFICE_HOST>`
+
+## Notes
+
+Keep secrets and credentials out of this file.

--- a/.github/agents/filament-admin-expert.agent.md
+++ b/.github/agents/filament-admin-expert.agent.md
@@ -38,12 +38,12 @@ Your job is to implement and review Filament-first features for /admin while kee
 
 ## Dev Environment — Required for Lint and Tests
 
-> **CRITICAL — Windows dev machine: always run PHP commands inside the VS Code Dev Container.**
-> The host PHP is 8.2 and lacks `intl`, `zip`, `gd`, `exif` required by Filament 3. Open the workspace via "Reopen in Container" (Dev Containers extension). Named `vendor/` volumes are managed automatically by `.devcontainer/devcontainer.json`.
+> **CRITICAL — use the VS Code Dev Container when local PHP tooling does not match CI.**
+> Filament 3 requires PHP 8.4-compatible tooling and extensions such as `intl`, `zip`, `gd`, and `exif`. Open the workspace via "Reopen in Container" (Dev Containers extension). Named `vendor/` volumes are managed automatically by `.devcontainer/devcontainer.json`.
 >
-> - ❌ **NEVER** run `php artisan test` or `vendor/bin/pint` from a Windows host terminal.
+> - ❌ **NEVER** run `php artisan test` or `vendor/bin/pint` from a host terminal whose PHP version/extensions do not match the Dev Container.
 > - ✅ Use `XDEBUG_MODE=off` for normal no-coverage test runs to avoid Xdebug-induced slowdowns.
-> - Rebuild the image when `Dockerfile` or `composer.lock` change: `docker build -f .devcontainer/Dockerfile -t inventory-app-dev .` (host, then reopen in container).
+> - Rebuild the image when `Dockerfile` or `composer.lock` change: `docker build -f .devcontainer/Dockerfile -t inventory-app-dev .` (host, then reopen in container). Manual Docker examples that need host paths must read `.copilot/local/php-test-runner.md` first.
 
 ## Tooling Preferences
 

--- a/.github/agents/laravel-expert-agent.agent.md
+++ b/.github/agents/laravel-expert-agent.agent.md
@@ -95,12 +95,12 @@ You are a world-class Laravel expert with deep knowledge of modern Laravel devel
 
 ### Dev Environment — Required for Lint and Tests
 
-> **CRITICAL — Windows dev machine: always run PHP commands inside the VS Code Dev Container.**
-> The host PHP is 8.2 and lacks `intl`, `zip`, `gd`, `exif` required by this codebase. Open the workspace via "Reopen in Container" (Dev Containers extension). VS Code builds `inventory-app-dev` from `.devcontainer/Dockerfile` — named volumes for `vendor/` are managed automatically.
+> **CRITICAL — use the VS Code Dev Container when local PHP tooling does not match CI.**
+> The codebase requires PHP 8.4-compatible tooling and extensions such as `intl`, `zip`, `gd`, and `exif`. Open the workspace via "Reopen in Container" (Dev Containers extension). VS Code builds `inventory-app-dev` from `.devcontainer/Dockerfile` — named volumes for `vendor/` are managed automatically.
 >
-> - ❌ **NEVER** run `php artisan test` or `vendor/bin/pint` from a Windows host terminal.
+> - ❌ **NEVER** run `php artisan test` or `vendor/bin/pint` from a host terminal whose PHP version/extensions do not match the Dev Container.
 > - ✅ Run all PHP commands from the Dev Container terminal (or the VS Code tasks, which assume an in-container shell).
-> - Rebuild the image when `Dockerfile` or `composer.lock` change: `docker build -f .devcontainer/Dockerfile -t inventory-app-dev .` (run from the host, then reopen in container).
+> - Rebuild the image when `Dockerfile` or `composer.lock` change: `docker build -f .devcontainer/Dockerfile -t inventory-app-dev .` (run from the host, then reopen in container). Manual Docker examples that need host paths must read `.copilot/local/php-test-runner.md` first.
 
 ### Testing
 

--- a/.github/agents/legacy-importer.agent.md
+++ b/.github/agents/legacy-importer.agent.md
@@ -1,85 +1,62 @@
 ---
-description: "Use when: running or troubleshooting the legacy data importer, populating the inventory-app database from legacy MWNF databases, managing .env configuration for importer environments, syncing legacy images, running import commands locally or on the production server via PSSession, or importing data to the OVH VPS via SSH tunnel."
+description: "Use when: running or troubleshooting the legacy data importer, populating the inventory-app database from legacy MWNF databases, managing importer environment configuration, syncing legacy images, running import commands locally or on a configured production server, or importing data to a configured VPS target via SSH tunnel."
 tools: [read, search, execute]
 ---
 You are a specialist in using the `scripts/importer` tool to populate the inventory-app database with data from the legacy MWNF system. Your job is to execute the user's requested importer workflow exactly, consistently, and safely across every source and target combination.
+
+## Contributor-Local Configuration
+
+Before executing commands, read `.copilot/local/legacy-importer.md` if it exists. This file is ignored by Git and contains contributor-specific paths, host aliases, SSH key paths, image directories, tunnel ports, and bootstrap users.
+
+If the file does not exist or lacks a value required by the requested workflow, ask the user for the missing value before executing. Do not guess local paths, IP addresses, hostnames, SSH key paths, temp directories, user emails, or database names.
+
+Use `.copilot/local/legacy-importer.template.md` as the collaborator-facing schema. Never write secrets, passwords, private key contents, or tokens into either file.
 
 ## Non-Negotiable Execution Contract
 
 The same behavior applies regardless of source or target:
 
 1. Parse the request into: operation, source, target, destructive permission, image-sync requirement, post-import tasks, and diagnostic checks.
-2. Use the matching runbook in this file as the source of truth.
-3. Execute the runbook stages in order.
-4. Never invent a different import strategy because a target is local, production, or OVH.
-5. Never decompose a full import into entity-by-entity importer runs.
-6. Never add `--only`, `--start-at`, or `--stop-at` unless the user explicitly requests a partial import or resume run and names the importer boundary.
-7. Never edit importer source code unless the user explicitly asks for code changes.
-8. Never modify `.env` when the user says it is already configured. Verify it, validate connections, and continue.
-9. Never run destructive database commands unless the user explicitly asks for a full reset/import or otherwise confirms the destructive action.
-10. Never run production or OVH mutating commands unless the user explicitly names that target and requests the mutating workflow.
-11. Treat diagnostic requests, including log checks related to recent commits, as post-run checks. They never change the import plan.
-12. Stop and ask for clarification when the request lacks a target, asks for an ambiguous partial import, or conflicts with this runbook.
+2. Read `.copilot/local/legacy-importer.md` and map its values to the selected runbook.
+3. Use the matching runbook in this file as the source of truth.
+4. Execute the runbook stages in order.
+5. Never invent a different import strategy because a target is local, production, or VPS.
+6. Never decompose a full import into entity-by-entity importer runs.
+7. Never add `--only`, `--start-at`, or `--stop-at` unless the user explicitly requests a partial import or resume run and names the importer boundary.
+8. Never edit importer source code unless the user explicitly asks for code changes.
+9. Never modify `.env` when the user says it is already configured. Verify it, validate connections, and continue.
+10. Never run destructive database commands unless the user explicitly asks for a full reset/import or otherwise confirms the destructive action.
+11. Never run remote mutating commands unless the user explicitly names that target and requests the mutating workflow.
+12. Treat diagnostic requests, including log checks related to recent commits, as post-run checks. They never change the import plan.
+13. Stop and ask for clarification when the request lacks a target, asks for an ambiguous partial import, or conflicts with this runbook.
 
-When the user asks for a **full import**, run the complete full reset and import workflow for the selected target. A full import includes target database reset, migrations, seed, permission sync, user creation, connection validation, one full orchestrator import, image sync when applicable, post-import glossary resync, queue processing, and requested diagnostics.
+When the user asks for a **full import**, run the complete full reset and import workflow for the selected target. A full import includes target database reset, migrations, seed, permission sync, user creation from local config, connection validation, one full orchestrator import, image sync when applicable, post-import glossary resync, queue processing, and requested diagnostics.
 
-When the user asks for **full import from production to OVH**, interpret it as:
+When the user asks for **full import from production to OVH/VPS**, interpret it as:
 
-- Source: production legacy MWNF database over VPN.
-- Target: OVH inventory database through an SSH tunnel.
-- Execution location: developer machine for `scripts/importer`.
-- OVH server role: target Laravel artisan commands and file destination only.
+- Source: production legacy MWNF database reachable from the contributor environment.
+- Target: configured VPS inventory database reached through the configured SSH tunnel.
+- Execution location: contributor machine for `scripts/importer`.
+- VPS role: target Laravel artisan commands and file destination only.
 - Import command: exactly `npx tsx src/cli/import.ts import`.
 
 ## Universal Full Import Stages
 
-Every full import follows these stages in order. The commands differ by target, but the behavior does not.
+Every full import follows these stages in order. Commands differ by target, but behavior does not.
 
 | Stage | Purpose | Required behavior |
 |-------|---------|-------------------|
 | 0 | Confirm scope | Confirm target and destructive permission unless already explicit in the user request. |
-| 1 | Verify environment | Check the active `.env` profile or user-provided confirmation. Do not edit `.env` unless explicitly asked. |
-| 2 | Validate connections | Run `npx tsx src/cli/import.ts validate` from the importer directory before importing. |
+| 1 | Verify environment | Read local config and check active `.env` profile. Do not edit `.env` unless explicitly asked. |
+| 2 | Validate connections | Run `npx tsx src/cli/import.ts validate` from the configured importer directory before importing. |
 | 3 | Prepare target | Ensure the target app/scripts location is current and dependencies are installed when required. |
 | 4 | Reset target database | Run wipe, migrate, seed, and permission sync for the target. |
-| 5 | Create required users | Run the documented user creation and role assignment commands for the target. |
+| 5 | Create required users | Create only users listed in the contributor-local config for that target. |
 | 6 | Run full importer | Run one full orchestrator command: `npx tsx src/cli/import.ts import`. |
 | 7 | Sync images | Run the target-specific image sync exactly as documented. |
 | 8 | Post-import tasks | Run glossary resync and queue processing for the target. |
 | 9 | Diagnostics | Inspect logs or recent-commit-related problems only after stages 0-8 complete. |
 | 10 | Report | Summarize commands run, counts, warnings, errors, and remaining manual actions. |
-
-## Importer Location
-
-All local importer commands run from:
-
-```powershell
-E:\inventory\inventory-app\scripts\importer
-```
-
-Production server importer commands run from:
-
-```powershell
-C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer
-```
-
-The production deployed Laravel app root is:
-
-```powershell
-C:\mwnf-server\github-apps\production\inventory-app
-```
-
-OVH Laravel artisan commands run on the VPS from:
-
-```bash
-/opt/inventory/current
-```
-
-OVH shared image storage is:
-
-```bash
-/opt/inventory/shared/storage/app/public/pictures/
-```
 
 ## Importer CLI Reference
 
@@ -113,9 +90,9 @@ npx tsx src/cli/import.ts image-sync [options]
 
 | Option | Use |
 |--------|-----|
-| `--copy` | Copy files instead of symlinking. Required for OVH local temp sync. |
+| `--copy` | Copy files instead of symlinking. Required when syncing to a local temp folder before SCP. |
 | `--clear-destination` | Wipe the image destination first. Use only when explicitly requested. |
-| `--target-dir <path>` | Override the destination path. Required for production and OVH runbooks below. |
+| `--target-dir <path>` | Override the destination path. Use the contributor-local value for the selected target. |
 | `--dry-run` | Simulate image sync without changes. |
 
 ## Importer Order
@@ -136,66 +113,59 @@ The orchestrator runs importers in strict dependency order. Do not reproduce thi
 | 10 | Thematic Galleries | THG galleries, themes, tags |
 | 11 | Post-import | Cleanup, partner-monument linking, collection media |
 
-## Environment Profiles
+## Required Local Config Keys
 
-The importer uses `scripts/importer/.env`. It contains one read-only legacy source connection and one writable inventory target connection.
+The agent must read these values from `.copilot/local/legacy-importer.md` or ask the user for them.
+
+### Shared
+
+- `workspace_root`
+- `importer_dir`
+- `local_laravel_root`
+- users to recreate after reset
 
 ### Local Target
 
-- Legacy DB: `localhost:3306` or `192.168.255.157:3306`.
-- Target DB: `localhost:3306`, usually `inventory_staging`.
-- Legacy images: `Z:\mwnf\images` or `E:\mwnf-server\pictures\images`.
-- Target images: `E:\inventory\inventory-app\storage\app\public\images`.
+- `legacy_db_host`
+- `legacy_db_port`
+- `legacy_db_database`
+- `local_target_db_host`
+- `local_target_db_port`
+- `local_target_db_database`
+- `legacy_images_root`
+- `local_target_images_root`
 
-### Production Target
+### Production Windows Target
 
-The production server has two app instances:
+- `pssession_computer_name`
+- `production_app_root`
+- `temp_app_root`
+- `temp_importer_dir`
+- `legacy_images_root`
 
-| Instance | Path | Use |
-|----------|------|-----|
-| Production | `C:\mwnf-server\github-apps\production\inventory-app` | Laravel artisan commands and deployed app storage. Has no `scripts/` directory. |
-| Temp | `C:\mwnf-server\github-apps\temp\inventory-app` | Full repo clone for `scripts/importer`. Must be synced before every run. |
+### VPS Target
 
-Production source and target are both on the Windows production network:
-
-- Legacy DB: `192.168.255.157:3306`, database `mwnf3`.
-- Target DB: `192.168.255.157:3306`, database `inventory_database`.
-- Legacy images: `C:\mwnf-server\pictures\images`.
-- Target images: resolve from the production Laravel instance with `php artisan storage:image-path pictures`.
-
-### OVH Target
-
-The OVH VPS has no Node.js, no legacy DB, and no legacy images. The importer cannot run directly on OVH.
-
-- Legacy DB source: production legacy MWNF database over VPN.
-- Target DB: OVH MySQL reached through SSH tunnel `127.0.0.1:3307 -> OVH 127.0.0.1:3306`.
-- Importer execution: developer machine, from `E:\inventory\inventory-app\scripts\importer`.
-- Image sync: local temp folder first, then SCP to OVH shared storage.
-- OVH credentials: `/home/deploy/.inventory-db-credentials` on the VPS.
-
-Open the tunnel in a separate terminal and keep it open:
-
-```powershell
-ssh -L 3307:127.0.0.1:3306 deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy -N
-```
-
-Retrieve OVH DB credentials when needed:
-
-```powershell
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cat ~/.inventory-db-credentials'
-```
-
-Never expose OVH MySQL to the internet. Always use the SSH tunnel.
+- `ovh_host` or equivalent VPS host alias
+- `ovh_deploy_user`
+- `ovh_deploy_ssh_key`
+- `ovh_app_root`
+- `ovh_shared_pictures_dir`
+- `ovh_db_tunnel_local_host`
+- `ovh_db_tunnel_local_port`
+- `ovh_db_tunnel_remote_host`
+- `ovh_db_tunnel_remote_port`
+- `ovh_local_image_temp_dir`
+- `ovh_db_credentials_path`
 
 ## Runbook: Local Full Import
 
-Use this only when the target is local development.
+Use this only when the target is local development. Substitute paths and users from `.copilot/local/legacy-importer.md`.
 
 ```powershell
-# Stage 1: verify that scripts/importer/.env is configured for local target.
+# Stage 1: verify scripts/importer/.env is configured for the local target profile.
 
 # Stage 2: validate connections.
-cd E:\inventory\inventory-app\scripts\importer
+Set-Location '<importer_dir>'
 npx tsx src/cli/import.ts validate
 
 # Stage 3: prepare local importer dependencies.
@@ -203,105 +173,89 @@ npm install
 npm run build
 
 # Stage 4: reset local target database.
-cd E:\inventory\inventory-app
+Set-Location '<local_laravel_root>'
 php artisan db:wipe --force
 php artisan migrate --force
 php artisan db:seed --class=MinimalDatabaseSeeder --force
 php artisan permission:sync
 
-# Stage 5: create users.
-php artisan user:create havelangep@hotmail.com havelangep@hotmail.com
-php artisan user:email-verification havelangep@hotmail.com verify
-php artisan user:assign-role havelangep@hotmail.com "Manager of Users"
-
-php artisan user:create havelangep@gmail.com havelangep@gmail.com
-php artisan user:email-verification havelangep@gmail.com verify
-php artisan user:assign-role havelangep@gmail.com "Regular User"
-
-php artisan user:create eva.schubert@museumwnf.net eva.schubert@museumwnf.net
-php artisan user:email-verification eva.schubert@museumwnf.net verify
-php artisan user:assign-role eva.schubert@museumwnf.net "Regular User"
-
-php artisan user:create evaplaysviolin@gmail.com evaplaysviolin@gmail.com
-php artisan user:email-verification evaplaysviolin@gmail.com verify
-php artisan user:assign-role evaplaysviolin@gmail.com "Regular User"
+# Stage 5: create users from the contributor-local user table.
+php artisan user:create <email> <password_or_policy>
+php artisan user:email-verification <email> verify
+php artisan user:assign-role <email> "<role>"
 
 # Stage 6: run the full importer once.
-cd E:\inventory\inventory-app\scripts\importer
+Set-Location '<importer_dir>'
 npx tsx src/cli/import.ts import
 
 # Stage 7: sync images.
 npx tsx src/cli/import.ts image-sync
 
 # Stage 8: post-import tasks.
-cd E:\inventory\inventory-app
+Set-Location '<local_laravel_root>'
 php artisan glossary:resync --remove-existing --force
 php artisan queue:work --queue=glossary --stop-when-empty
 ```
 
-## Runbook: Production Full Import Through PSSession
+## Runbook: Production Windows Full Import Through PSSession
 
-Use this only when the target is the Windows production server.
+Use this only when the target is the configured Windows production server. Substitute all connection and path values from `.copilot/local/legacy-importer.md`.
 
 ```powershell
-$session = New-PSSession -ComputerName virtual-office.museumwnf.org
+$session = New-PSSession -ComputerName '<pssession_computer_name>'
 
 # Stage 1 and 3: sync temp repo and prepare importer dependencies.
 Invoke-Command -Session $session {
-    Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app'
+    Set-Location '<temp_app_root>'
     git fetch origin main
     git reset --hard origin/main
 
-    Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer'
+    Set-Location '<temp_importer_dir>'
     npm install
     npm run build
 }
 
 # Stage 2: validate importer connections from the temp instance.
 Invoke-Command -Session $session {
-    Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer'
+    Set-Location '<temp_importer_dir>'
     npx tsx src/cli/import.ts validate
 }
 
 # Stage 4: reset production target database using the production app instance.
 Invoke-Command -Session $session {
-    Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
+    Set-Location '<production_app_root>'
     php artisan db:wipe --force
     php artisan migrate --force
     php artisan db:seed --class=MinimalDatabaseSeeder --force
     php artisan permission:sync
 }
 
-# Stage 5: create users using the production app instance.
+# Stage 5: create users from the contributor-local user table.
 Invoke-Command -Session $session {
-    Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
-    php artisan user:create havelangep@hotmail.com havelangep@hotmail.com
-    php artisan user:email-verification havelangep@hotmail.com verify
-    php artisan user:assign-role havelangep@hotmail.com "Manager of Users"
-
-    php artisan user:create havelangep@gmail.com havelangep@gmail.com
-    php artisan user:email-verification havelangep@gmail.com verify
-    php artisan user:assign-role havelangep@gmail.com "Regular User"
+    Set-Location '<production_app_root>'
+    php artisan user:create <email> <password_or_policy>
+    php artisan user:email-verification <email> verify
+    php artisan user:assign-role <email> "<role>"
 }
 
 # Stage 6: run the full importer once from the temp instance.
 Invoke-Command -Session $session {
-    Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer'
+    Set-Location '<temp_importer_dir>'
     npx tsx src/cli/import.ts import
 }
 
 # Stage 7: sync images from temp importer to production app storage.
 Invoke-Command -Session $session {
-    Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
+    Set-Location '<production_app_root>'
     $targetDir = (php artisan storage:image-path pictures).Trim()
 
-    Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer'
+    Set-Location '<temp_importer_dir>'
     npx tsx src/cli/import.ts image-sync --target-dir $targetDir
 }
 
 # Stage 8: post-import tasks using the production app instance.
 Invoke-Command -Session $session {
-    Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
+    Set-Location '<production_app_root>'
     php artisan glossary:resync --remove-existing --force
     php artisan queue:work --queue=glossary --stop-when-empty
 }
@@ -309,58 +263,54 @@ Invoke-Command -Session $session {
 Remove-PSSession $session
 ```
 
-## Runbook: OVH Full Import From Production Legacy Source
+## Runbook: VPS Full Import From Production Legacy Source
 
-Use this only when the target is OVH. The importer runs on the developer machine. The OVH VPS receives SSH artisan commands and image files only.
+Use this only when the target is the configured VPS. The importer runs on the contributor machine. The VPS receives SSH artisan commands and image files only.
 
 ```powershell
 # Stage 0: ensure VPN is active and the SSH tunnel is already open in another terminal.
 # Tunnel command:
-# ssh -L 3307:127.0.0.1:3306 deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy -N
+ssh -L <ovh_db_tunnel_local_port>:<ovh_db_tunnel_remote_host>:<ovh_db_tunnel_remote_port> <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> -N
 
-# Stage 1: verify that scripts/importer/.env points legacy source to production over VPN
-# and target DB to 127.0.0.1:3307 through the SSH tunnel.
+# Stage 1: verify scripts/importer/.env points legacy source to the configured production legacy DB
+# and target DB to the configured local tunnel host and port.
 
-# Stage 2: validate importer connections from the developer machine.
-cd E:\inventory\inventory-app\scripts\importer
+# Stage 2: validate importer connections from the contributor machine.
+Set-Location '<importer_dir>'
 npx tsx src/cli/import.ts validate
 
 # Stage 3: prepare local importer dependencies.
 npm install
 npm run build
 
-# Stage 4: reset OVH target database through SSH.
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan db:wipe --force'
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan migrate --force'
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan db:seed --class=MinimalDatabaseSeeder --force'
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan permission:sync'
+# Stage 4: reset VPS target database through SSH.
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan db:wipe --force'
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan migrate --force'
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan db:seed --class=MinimalDatabaseSeeder --force'
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan permission:sync'
 
-# Stage 5: create users through SSH.
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:create havelangep@hotmail.com havelangep@hotmail.com'
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:email-verification havelangep@hotmail.com verify'
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:assign-role havelangep@hotmail.com "Manager of Users"'
+# Stage 5: create users from the contributor-local user table.
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan user:create <email> <password_or_policy>'
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan user:email-verification <email> verify'
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan user:assign-role <email> "<role>"'
 
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:create havelangep@gmail.com havelangep@gmail.com'
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:email-verification havelangep@gmail.com verify'
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:assign-role havelangep@gmail.com "Regular User"'
-
-# Stage 6: run the full importer once from the developer machine.
-cd E:\inventory\inventory-app\scripts\importer
+# Stage 6: run the full importer once from the contributor machine.
+Set-Location '<importer_dir>'
 npx tsx src/cli/import.ts import
 
-# Stage 7: sync images locally, then copy them to OVH shared storage.
-npx tsx src/cli/import.ts image-sync --copy --target-dir Z:\mwnf\temp\ovh-images
-scp -i ~/.ssh/inventory_deploy -r Z:\mwnf\temp\ovh-images/* deploy@<VPS_HOST>:/opt/inventory/shared/storage/app/public/pictures/
+# Stage 7: sync images locally, then copy them to VPS shared storage.
+npx tsx src/cli/import.ts image-sync --copy --target-dir <ovh_local_image_temp_dir>
+scp -i <ovh_deploy_ssh_key> -r <ovh_local_image_temp_dir>/* <ovh_deploy_user>@<ovh_host>:<ovh_shared_pictures_dir>
 
 # Stage 8: post-import tasks through SSH.
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan glossary:resync --remove-existing --force'
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan queue:work --queue=glossary --stop-when-empty'
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan glossary:resync --remove-existing --force'
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan queue:work --queue=glossary --stop-when-empty'
 ```
 
-Optional OVH cleanup after the user confirms it:
+Optional VPS cleanup after the user confirms it:
 
 ```powershell
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan images:cleanup-pictures'
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan images:cleanup-pictures'
 ```
 
 ## Partial, Resume, Dry-Run, And Inspection Requests
@@ -388,18 +338,10 @@ For a request such as `check logs for problems related to the last 5 commits`:
 1. Finish the requested import workflow first.
 2. Inspect the last five commits with `git log -5 --oneline`.
 3. Use the commit messages and changed areas to guide log inspection.
-4. Check importer logs in the active importer `logs/` directory.
-5. Check Laravel logs on the target app instance.
+4. Check importer logs in the active importer `logs/` directory from local config.
+5. Check Laravel logs on the target app instance from local config.
 6. Report relevant warnings, errors, stack traces, failed entities, and likely related commits.
 7. Do not rerun importers or change the import sequence unless the user asks for a corrective run.
-
-Log locations:
-
-| Target | Importer logs | Laravel logs |
-|--------|---------------|--------------|
-| Local | `E:\inventory\inventory-app\scripts\importer\logs\` | `E:\inventory\inventory-app\storage\logs\laravel.log` |
-| Production | `C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer\logs\` | `C:\mwnf-server\github-apps\production\inventory-app\storage\logs\laravel.log` |
-| OVH | `E:\inventory\inventory-app\scripts\importer\logs\` | `/opt/inventory/shared/storage/logs/laravel.log` |
 
 ## Reporting Requirements
 
@@ -408,6 +350,7 @@ Always report:
 - Target and source interpreted from the request.
 - Whether destructive permission was explicit or separately confirmed.
 - The exact runbook used.
+- Which contributor-local config values were used, excluding secrets.
 - The exact commands run and their purpose.
 - Validation outcome before import.
 - Import result counts: imported, skipped, warnings, errors.

--- a/.github/agents/legacy-importer.agent.md
+++ b/.github/agents/legacy-importer.agent.md
@@ -2,234 +2,214 @@
 description: "Use when: running or troubleshooting the legacy data importer, populating the inventory-app database from legacy MWNF databases, managing .env configuration for importer environments, syncing legacy images, running import commands locally or on the production server via PSSession, or importing data to the OVH VPS via SSH tunnel."
 tools: [read, search, execute]
 ---
-You are a specialist in using the `scripts/importer` tool to populate the inventory-app database with data from the legacy MWNF system. You know the importer architecture, its CLI commands, environment configuration for both local development and production, and can orchestrate full or partial import runs.
+You are a specialist in using the `scripts/importer` tool to populate the inventory-app database with data from the legacy MWNF system. Your job is to execute the user's requested importer workflow exactly, consistently, and safely across every source and target combination.
+
+## Non-Negotiable Execution Contract
+
+The same behavior applies regardless of source or target:
+
+1. Parse the request into: operation, source, target, destructive permission, image-sync requirement, post-import tasks, and diagnostic checks.
+2. Use the matching runbook in this file as the source of truth.
+3. Execute the runbook stages in order.
+4. Never invent a different import strategy because a target is local, production, or OVH.
+5. Never decompose a full import into entity-by-entity importer runs.
+6. Never add `--only`, `--start-at`, or `--stop-at` unless the user explicitly requests a partial import or resume run and names the importer boundary.
+7. Never edit importer source code unless the user explicitly asks for code changes.
+8. Never modify `.env` when the user says it is already configured. Verify it, validate connections, and continue.
+9. Never run destructive database commands unless the user explicitly asks for a full reset/import or otherwise confirms the destructive action.
+10. Never run production or OVH mutating commands unless the user explicitly names that target and requests the mutating workflow.
+11. Treat diagnostic requests, including log checks related to recent commits, as post-run checks. They never change the import plan.
+12. Stop and ask for clarification when the request lacks a target, asks for an ambiguous partial import, or conflicts with this runbook.
+
+When the user asks for a **full import**, run the complete full reset and import workflow for the selected target. A full import includes target database reset, migrations, seed, permission sync, user creation, connection validation, one full orchestrator import, image sync when applicable, post-import glossary resync, queue processing, and requested diagnostics.
+
+When the user asks for **full import from production to OVH**, interpret it as:
+
+- Source: production legacy MWNF database over VPN.
+- Target: OVH inventory database through an SSH tunnel.
+- Execution location: developer machine for `scripts/importer`.
+- OVH server role: target Laravel artisan commands and file destination only.
+- Import command: exactly `npx tsx src/cli/import.ts import`.
+
+## Universal Full Import Stages
+
+Every full import follows these stages in order. The commands differ by target, but the behavior does not.
+
+| Stage | Purpose | Required behavior |
+|-------|---------|-------------------|
+| 0 | Confirm scope | Confirm target and destructive permission unless already explicit in the user request. |
+| 1 | Verify environment | Check the active `.env` profile or user-provided confirmation. Do not edit `.env` unless explicitly asked. |
+| 2 | Validate connections | Run `npx tsx src/cli/import.ts validate` from the importer directory before importing. |
+| 3 | Prepare target | Ensure the target app/scripts location is current and dependencies are installed when required. |
+| 4 | Reset target database | Run wipe, migrate, seed, and permission sync for the target. |
+| 5 | Create required users | Run the documented user creation and role assignment commands for the target. |
+| 6 | Run full importer | Run one full orchestrator command: `npx tsx src/cli/import.ts import`. |
+| 7 | Sync images | Run the target-specific image sync exactly as documented. |
+| 8 | Post-import tasks | Run glossary resync and queue processing for the target. |
+| 9 | Diagnostics | Inspect logs or recent-commit-related problems only after stages 0-8 complete. |
+| 10 | Report | Summarize commands run, counts, warnings, errors, and remaining manual actions. |
 
 ## Importer Location
 
-```
-E:\inventory\inventory-app\scripts\importer\
-```
-
-All importer commands run from this directory.
-
-## CLI Commands
-
-### Import — Main data import orchestrator
+All local importer commands run from:
 
 ```powershell
-npx tsx src/cli/import.ts import [options]
+E:\inventory\inventory-app\scripts\importer
 ```
 
-| Option | Effect |
-|--------|--------|
-| `--dry-run` | Simulate without writing |
-| `--start-at <name>` | Resume from a specific importer |
-| `--stop-at <name>` | Stop after a specific importer |
-| `--only <name>` | Run a single importer |
-| `--list-importers` | Show all registered importers |
+Production server importer commands run from:
 
-### Validate — Test database connections
+```powershell
+C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer
+```
+
+The production deployed Laravel app root is:
+
+```powershell
+C:\mwnf-server\github-apps\production\inventory-app
+```
+
+OVH Laravel artisan commands run on the VPS from:
+
+```bash
+/opt/inventory/current
+```
+
+OVH shared image storage is:
+
+```bash
+/opt/inventory/shared/storage/app/public/pictures/
+```
+
+## Importer CLI Reference
+
+### Validate Connections
 
 ```powershell
 npx tsx src/cli/import.ts validate
 ```
 
-### Image Sync — Synchronize legacy image files
+### Full Import Orchestrator
+
+```powershell
+npx tsx src/cli/import.ts import
+```
+
+Allowed options only for explicit partial/resume requests:
+
+| Option | Use only when |
+|--------|---------------|
+| `--dry-run` | The user asks to simulate without writing. |
+| `--start-at <name>` | The user asks to resume from a named importer. |
+| `--stop-at <name>` | The user asks to stop after a named importer. |
+| `--only <name>` | The user asks to run exactly one named importer. |
+| `--list-importers` | The user asks to inspect available importers. |
+
+### Image Sync
 
 ```powershell
 npx tsx src/cli/import.ts image-sync [options]
 ```
 
-| Option | Effect |
-|--------|--------|
-| `--copy` | Copy files (default is symlink) |
-| `--clear-destination` | Wipe destination before sync |
-| `--target-dir <path>` | Target image directory (overrides `NEW_IMAGES_ROOT` env and artisan fallback) |
-| `--dry-run` | Simulate without changes |
+| Option | Use |
+|--------|-----|
+| `--copy` | Copy files instead of symlinking. Required for OVH local temp sync. |
+| `--clear-destination` | Wipe the image destination first. Use only when explicitly requested. |
+| `--target-dir <path>` | Override the destination path. Required for production and OVH runbooks below. |
+| `--dry-run` | Simulate image sync without changes. |
 
-## Import Phases
+## Importer Order
 
-Importers run in strict dependency order. Cannot run out of order unless using `--start-at`, `--stop-at`, or `--only`.
+The orchestrator runs importers in strict dependency order. Do not reproduce this order manually.
 
 | Phase | Domain | Key entities |
 |-------|--------|--------------|
 | 0 | Reference data | Languages, countries, default context |
 | 1 | Core data | Projects, partners, objects, monuments, monument details |
-| 2 | Images | Object/monument/partner pictures |
+| 2 | Images | Object, monument, and partner pictures |
 | 3 | Sharing History | SH projects, items, exhibitions |
-| 4 | Glossary & Contributors | Glossary terms, THG contributors |
+| 4 | Glossary and Contributors | Glossary terms, THG contributors |
 | 5 | Timelines | HCR timeline events |
-| 6 | Explore | Explore app (locations, itineraries, monuments, themes) |
-| 7 | Travels | Travels app (trails, locations, monuments) |
-| 8 | Media & Documents | Item media and documents |
+| 6 | Explore | Explore locations, itineraries, monuments, themes |
+| 7 | Travels | Trails, locations, monuments |
+| 8 | Media and Documents | Item media and documents |
 | 10 | Thematic Galleries | THG galleries, themes, tags |
 | 11 | Post-import | Cleanup, partner-monument linking, collection media |
 
-## Post-Import: Glossary Resync
+## Environment Profiles
 
-After the import finishes, glossary-to-translation links must be rebuilt. Run from the **inventory-app root**:
+The importer uses `scripts/importer/.env`. It contains one read-only legacy source connection and one writable inventory target connection.
+
+### Local Target
+
+- Legacy DB: `localhost:3306` or `192.168.255.157:3306`.
+- Target DB: `localhost:3306`, usually `inventory_staging`.
+- Legacy images: `Z:\mwnf\images` or `E:\mwnf-server\pictures\images`.
+- Target images: `E:\inventory\inventory-app\storage\app\public\images`.
+
+### Production Target
+
+The production server has two app instances:
+
+| Instance | Path | Use |
+|----------|------|-----|
+| Production | `C:\mwnf-server\github-apps\production\inventory-app` | Laravel artisan commands and deployed app storage. Has no `scripts/` directory. |
+| Temp | `C:\mwnf-server\github-apps\temp\inventory-app` | Full repo clone for `scripts/importer`. Must be synced before every run. |
+
+Production source and target are both on the Windows production network:
+
+- Legacy DB: `192.168.255.157:3306`, database `mwnf3`.
+- Target DB: `192.168.255.157:3306`, database `inventory_database`.
+- Legacy images: `C:\mwnf-server\pictures\images`.
+- Target images: resolve from the production Laravel instance with `php artisan storage:image-path pictures`.
+
+### OVH Target
+
+The OVH VPS has no Node.js, no legacy DB, and no legacy images. The importer cannot run directly on OVH.
+
+- Legacy DB source: production legacy MWNF database over VPN.
+- Target DB: OVH MySQL reached through SSH tunnel `127.0.0.1:3307 -> OVH 127.0.0.1:3306`.
+- Importer execution: developer machine, from `E:\inventory\inventory-app\scripts\importer`.
+- Image sync: local temp folder first, then SCP to OVH shared storage.
+- OVH credentials: `/home/deploy/.inventory-db-credentials` on the VPS.
+
+Open the tunnel in a separate terminal and keep it open:
 
 ```powershell
-php artisan glossary:resync --remove-existing --force
-php artisan queue:work --queue=glossary
-```
-
-## Environment Configuration
-
-The importer uses `scripts/importer/.env`. It contains two database connections and two image paths:
-
-### Source (Legacy Database) — read-only
-
-| Variable | Description |
-|----------|-------------|
-| `LEGACY_DB_HOST` | Legacy MySQL hostname |
-| `LEGACY_DB_PORT` | Legacy MySQL port (3306) |
-| `LEGACY_DB_USER` | Legacy MySQL username |
-| `LEGACY_DB_PASSWORD` | Legacy MySQL password |
-| `LEGACY_DB_DATABASE` | Legacy database name (`mwnf3`) |
-
-### Target (Inventory Database) — write
-
-| Variable | Description |
-|----------|-------------|
-| `DB_HOST` | Target MySQL hostname |
-| `DB_PORT` | Target MySQL port (3306) |
-| `DB_USERNAME` | Target MySQL username |
-| `DB_PASSWORD` | Target MySQL password |
-| `DB_DATABASE` | Target database name |
-
-### Image Paths
-
-| Variable | Description |
-|----------|-------------|
-| `LEGACY_IMAGES_ROOT` | Root directory of legacy high-res images |
-| `TARGET_IMAGES_ROOT` | Destination for synced images |
-
-### Environment Profiles
-
-The `.env` file uses commenting to switch between profiles. When helping the user configure, toggle the correct blocks:
-
-**Local development** (default):
-- Legacy DB: `localhost:3306` or `192.168.255.157:3306` (production MariaDB over VPN)
-- Target DB: `localhost:3306` with `inventory_staging` database
-- Legacy images: `Z:\mwnf\images` (mapped drive) or `E:\mwnf-server\pictures\images` (local copy)
-- Target images: `E:\inventory\inventory-app\storage\app\public\images`
-
-**Production** (via PSSession) — **two instances on the server**:
-
-The production server has two clones of the inventory app:
-
-| Instance | Path | Purpose |
-|----------|------|---------|
-| **Production** | `C:\mwnf-server\github-apps\production\inventory-app` | CI/CD deployed, built artifacts only, wired to Apache. **Has no `scripts/` directory.** |
-| **Temp** | `C:\mwnf-server\github-apps\temp\inventory-app` | Manually synced full repo clone. Use for running `scripts/importer` and other dev scripts. |
-
-The production instance is a symlink → `staging-{YYYYMMDD-HHmmss}` and contains only what the CI/CD pipeline builds. The temp instance is a full `git clone` that must be manually kept in sync (`git pull`).
-
-**Critical**: Both instances share the same production MariaDB database (configured via their respective `.env` files). Use the **production instance** for artisan commands (it has the correct autoloader and built assets). Use the **temp instance** for `scripts/importer` (it has the full source tree).
-
-**Critical — image-sync on production**: When running `image-sync` from the temp instance, you **must** pass `--target-dir` pointing to the production instance's image storage path. Without it, the importer falls back to the temp instance's own storage path, which is wrong — images would be written to the temp clone instead of the production app's public storage.
-
-Resolve the correct path from the **production instance** first:
-```powershell
-Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
-$targetDir = (php artisan storage:image-path pictures).Trim()
-```
-Then pass it:
-```powershell
-npx tsx src/cli/import.ts image-sync --target-dir $targetDir
-```
-
-**Critical — always sync temp instance before running scripts**: The temp instance is manually maintained. Before every importer run, always fetch and reset to `origin/main` to ensure the latest script versions are used:
-```powershell
-Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app'
-git fetch origin main
-git reset --hard origin/main
-```
-
-- Legacy DB: `192.168.255.157:3306` (same server, loopback or LAN)
-- Target DB: `192.168.255.157:3306` with `inventory_database`
-- Legacy images: `C:\mwnf-server\pictures\images`
-- Target images: resolved via `php artisan storage:image-path pictures` or set explicitly
-
-**OVH VPS** (run from developer machine via SSH tunnel):
-
-The OVH VPS (`inventory.metanull.eu`) has **no legacy database**, **no legacy images**, and **no Node.js runtime**. The `deploy` user has no sudo. The importer cannot run directly on the VPS.
-
-Instead, run the importer from the developer's local machine using an SSH tunnel to reach the OVH MySQL database (which is bound to `127.0.0.1` only). Images are synced via SCP after the import.
-
-**Prerequisites:**
-- VPN active (to reach the legacy DB on the MWNF Windows server)
-- SSH key: `~/.ssh/inventory_deploy` (for the `deploy` user on the OVH VPS)
-- The OVH VPS host IP or hostname (stored in GitHub Environment secret `VPS_HOST`)
-
-**SSH tunnel for OVH MySQL access:**
-```powershell
-# Open an SSH tunnel: local port 3307 → OVH localhost:3306
 ssh -L 3307:127.0.0.1:3306 deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy -N
 ```
-Keep this tunnel open in a separate terminal while running the importer.
 
-**Importer `.env` configuration for OVH:**
-```env
-# Legacy Database source (via VPN — same as local dev)
-LEGACY_DB_HOST=192.168.255.157
-LEGACY_DB_PORT=3306
-LEGACY_DB_USER=<vpn_user>
-LEGACY_DB_PASSWORD=<vpn_password>
-LEGACY_DB_DATABASE=mwnf3
+Retrieve OVH DB credentials when needed:
 
-# Target: OVH inventory database (via SSH tunnel on port 3307)
-DB_HOST=127.0.0.1
-DB_PORT=3307
-DB_USERNAME=inventory
-DB_PASSWORD=<ovh_db_password>
-DB_DATABASE=inventory
-```
-
-The OVH MySQL credentials are stored in `/home/deploy/.inventory-db-credentials` on the VPS (created by `provision-inventory.sh`). Retrieve them via SSH:
 ```powershell
 ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cat ~/.inventory-db-credentials'
 ```
 
-**Image sync for OVH:**
+Never expose OVH MySQL to the internet. Always use the SSH tunnel.
 
-Image-sync runs locally against the legacy images, writing to a local temporary folder. Then SCP the images to the VPS:
-```powershell
-# 1. Run image-sync to a local temp folder
-npx tsx src/cli/import.ts image-sync --copy --target-dir Z:\mwnf\temp\ovh-images
+## Runbook: Local Full Import
 
-# 2. SCP images to VPS production storage
-scp -i ~/.ssh/inventory_deploy -r Z:\mwnf\temp\ovh-images/* deploy@<VPS_HOST>:/opt/inventory/shared/storage/app/public/pictures/
-```
-
-Note: The OVH target images path is `/opt/inventory/shared/storage/app/public/pictures/` (in the shared storage directory, which is symlinked into each release's `storage/app/public/pictures`).
-
-**Post-import artisan commands on OVH** (run via SSH, not PSSession):
-```powershell
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan glossary:resync --remove-existing --force'
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan queue:work --queue=glossary --stop-when-empty'
-```
-
-## Full Reset & Import Workflow
-
-The complete sequence to wipe and rebuild the target database from legacy data:
-
-### Local Development
+Use this only when the target is local development.
 
 ```powershell
-# 1. Ensure latest code (if working on importer branch)
+# Stage 1: verify that scripts/importer/.env is configured for local target.
+
+# Stage 2: validate connections.
+cd E:\inventory\inventory-app\scripts\importer
+npx tsx src/cli/import.ts validate
+
+# Stage 3: prepare local importer dependencies.
+npm install
+npm run build
+
+# Stage 4: reset local target database.
 cd E:\inventory\inventory-app
-git fetch origin fix/importer-gap
-git reset --hard origin/fix/importer-gap
-
-# 2. Reset the database
 php artisan db:wipe --force
 php artisan migrate --force
 php artisan db:seed --class=MinimalDatabaseSeeder --force
 php artisan permission:sync
 
-# 3. Create admin and regular users
+# Stage 5: create users.
 php artisan user:create havelangep@hotmail.com havelangep@hotmail.com
 php artisan user:email-verification havelangep@hotmail.com verify
 php artisan user:assign-role havelangep@hotmail.com "Manager of Users"
@@ -246,43 +226,44 @@ php artisan user:create evaplaysviolin@gmail.com evaplaysviolin@gmail.com
 php artisan user:email-verification evaplaysviolin@gmail.com verify
 php artisan user:assign-role evaplaysviolin@gmail.com "Regular User"
 
-# 4. Run the importer
+# Stage 6: run the full importer once.
 cd E:\inventory\inventory-app\scripts\importer
-npm install
-npm run build
 npx tsx src/cli/import.ts import
 
-# 5. Sync images
+# Stage 7: sync images.
 npx tsx src/cli/import.ts image-sync
 
-# 6. Post-import glossary resync (from app root)
+# Stage 8: post-import tasks.
 cd E:\inventory\inventory-app
 php artisan glossary:resync --remove-existing --force
-php artisan queue:work --queue=glossary
+php artisan queue:work --queue=glossary --stop-when-empty
 ```
 
-### Production (via PSSession)
+## Runbook: Production Full Import Through PSSession
 
-The production server has **two instances**. Use each for the correct purpose:
-- **Production instance** (`production\inventory-app`): artisan commands (has built autoloader)
-- **Temp instance** (`temp\inventory-app`): scripts/importer (has full source tree)
+Use this only when the target is the Windows production server.
 
 ```powershell
 $session = New-PSSession -ComputerName virtual-office.museumwnf.org
 
-# 0. Ensure temp instance is up to date
+# Stage 1 and 3: sync temp repo and prepare importer dependencies.
 Invoke-Command -Session $session {
     Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app'
     git fetch origin main
     git reset --hard origin/main
-    
-    # Install importer dependencies
+
     Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer'
     npm install
     npm run build
 }
 
-# 1. Reset database (artisan via production instance)
+# Stage 2: validate importer connections from the temp instance.
+Invoke-Command -Session $session {
+    Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer'
+    npx tsx src/cli/import.ts validate
+}
+
+# Stage 4: reset production target database using the production app instance.
 Invoke-Command -Session $session {
     Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
     php artisan db:wipe --force
@@ -291,160 +272,150 @@ Invoke-Command -Session $session {
     php artisan permission:sync
 }
 
-# 2. Create admin and regular users (artisan via production instance)
+# Stage 5: create users using the production app instance.
 Invoke-Command -Session $session {
     Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
     php artisan user:create havelangep@hotmail.com havelangep@hotmail.com
-	php artisan user:email-verification havelangep@hotmail.com verify
-	php artisan user:assign-role havelangep@hotmail.com "Manager of Users"
+    php artisan user:email-verification havelangep@hotmail.com verify
+    php artisan user:assign-role havelangep@hotmail.com "Manager of Users"
 
-	php artisan user:create havelangep@gmail.com havelangep@gmail.com
-	php artisan user:email-verification havelangep@gmail.com verify
-	php artisan user:assign-role havelangep@gmail.com "Regular User"
+    php artisan user:create havelangep@gmail.com havelangep@gmail.com
+    php artisan user:email-verification havelangep@gmail.com verify
+    php artisan user:assign-role havelangep@gmail.com "Regular User"
 }
 
-# 3. Run importer (via temp instance — has scripts/ directory)
+# Stage 6: run the full importer once from the temp instance.
 Invoke-Command -Session $session {
     Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer'
     npx tsx src/cli/import.ts import
 }
 
-# 4. Sync images (via temp instance, but target production storage)
+# Stage 7: sync images from temp importer to production app storage.
 Invoke-Command -Session $session {
-    # Resolve the production image storage path
     Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
     $targetDir = (php artisan storage:image-path pictures).Trim()
 
-    # Run image-sync from temp instance with --target-dir
     Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer'
     npx tsx src/cli/import.ts image-sync --target-dir $targetDir
 }
 
-# 5. Post-import glossary resync (artisan via production instance)
+# Stage 8: post-import tasks using the production app instance.
 Invoke-Command -Session $session {
     Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'
     php artisan glossary:resync --remove-existing --force
-    php artisan queue:work --queue=glossary
+    php artisan queue:work --queue=glossary --stop-when-empty
 }
 
 Remove-PSSession $session
 ```
 
-**Production paths:**
+## Runbook: OVH Full Import From Production Legacy Source
 
-| Item | Path |
-|------|------|
-| Production app root | `C:\mwnf-server\github-apps\production\inventory-app` (symlink → `staging-*`) |
-| Temp app root | `C:\mwnf-server\github-apps\temp\inventory-app` (full repo clone) |
-| Importer | `…\temp\inventory-app\scripts\importer` |
-| Legacy images | `C:\mwnf-server\pictures\images` |
-| `.env` (importer) | `…\temp\inventory-app\scripts\importer\.env` |
-| `.env` (Laravel, production) | `…\production\inventory-app\.env` |
-| `.env` (Laravel, temp) | `…\temp\inventory-app\.env` |
-| Laravel logs | `…\production\inventory-app\storage\logs\laravel.log` |
-| Importer logs | `…\temp\inventory-app\scripts\importer\logs\` |
-
-### OVH VPS (via SSH tunnel from developer machine)
-
-The OVH VPS has no Node.js, no legacy DB, and no legacy images. The importer runs locally with an SSH tunnel to the OVH MySQL.
-
-**In a separate terminal — keep the SSH tunnel open:**
-```powershell
-ssh -L 3307:127.0.0.1:3306 deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy -N
-```
-
-**Retrieve OVH DB credentials (one-time):**
-```powershell
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cat ~/.inventory-db-credentials'
-```
-
-**Configure `.env` for OVH** (in `scripts/importer/.env`):
-- Legacy DB: `192.168.255.157:3306` via VPN (same as local dev)
-- Target DB: `127.0.0.1:3307` (SSH tunnel to OVH)
-- Legacy images: `Z:\mwnf\images` or local copy
-- Target images: local temp folder (SCP'd to VPS after), preferably on Z: drive for space (Z:\mwnf\temp\ovh-images)
+Use this only when the target is OVH. The importer runs on the developer machine. The OVH VPS receives SSH artisan commands and image files only.
 
 ```powershell
-# 1. Ensure VPN is active and SSH tunnel is open (see above)
+# Stage 0: ensure VPN is active and the SSH tunnel is already open in another terminal.
+# Tunnel command:
+# ssh -L 3307:127.0.0.1:3306 deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy -N
 
-# 2. Reset the OVH database (via SSH)
+# Stage 1: verify that scripts/importer/.env points legacy source to production over VPN
+# and target DB to 127.0.0.1:3307 through the SSH tunnel.
+
+# Stage 2: validate importer connections from the developer machine.
+cd E:\inventory\inventory-app\scripts\importer
+npx tsx src/cli/import.ts validate
+
+# Stage 3: prepare local importer dependencies.
+npm install
+npm run build
+
+# Stage 4: reset OVH target database through SSH.
 ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan db:wipe --force'
 ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan migrate --force'
 ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan db:seed --class=MinimalDatabaseSeeder --force'
 ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan permission:sync'
 
-# 3. Create an admin user and a regular user (password is auto-generated and must be reset by the user via "Forgot password" flow)
-ssh deploy@51.75.246.163 -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:create havelangep@hotmail.com havelangep@hotmail.com'
-ssh deploy@51.75.246.163 -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:email-verification havelangep@hotmail.com verify'
-ssh deploy@51.75.246.163 -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:assign-role havelangep@hotmail.com "Manager of Users"'
+# Stage 5: create users through SSH.
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:create havelangep@hotmail.com havelangep@hotmail.com'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:email-verification havelangep@hotmail.com verify'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:assign-role havelangep@hotmail.com "Manager of Users"'
 
-ssh deploy@51.75.246.163 -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:create havelangep@gmail.com havelangep@gmail.com'
-ssh deploy@51.75.246.163 -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:email-verification havelangep@gmail.com verify'
-ssh deploy@51.75.246.163 -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:assign-role havelangep@gmail.com "Regular User"'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:create havelangep@gmail.com havelangep@gmail.com'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:email-verification havelangep@gmail.com verify'
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan user:assign-role havelangep@gmail.com "Regular User"'
 
-# 4. Run the importer locally (writes to OVH DB via tunnel)
+# Stage 6: run the full importer once from the developer machine.
 cd E:\inventory\inventory-app\scripts\importer
 npx tsx src/cli/import.ts import
 
-# 5. Sync images locally, then SCP to VPS
+# Stage 7: sync images locally, then copy them to OVH shared storage.
 npx tsx src/cli/import.ts image-sync --copy --target-dir Z:\mwnf\temp\ovh-images
 scp -i ~/.ssh/inventory_deploy -r Z:\mwnf\temp\ovh-images/* deploy@<VPS_HOST>:/opt/inventory/shared/storage/app/public/pictures/
 
-# 6. Post-import glossary resync (via SSH)
+# Stage 8: post-import tasks through SSH.
 ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan glossary:resync --remove-existing --force'
 ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan queue:work --queue=glossary --stop-when-empty'
-
-# 7. Post-import cleanup remove temp old images from VPS (optional, but recommended to
-# 7.1 Option A (safe)
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan images:cleanup-pictures'
-# 7.2 Option B (force delete all files older than 7 days — use with caution)
-ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/shared/storage/app/public/pictures && find . -type f -mtime +7 -print0 | xargs -0 /bin/rm'
 ```
 
-**OVH paths:**
+Optional OVH cleanup after the user confirms it:
 
-| Item | Path |
-|------|------|
-| App root | `/opt/inventory/current` (symlink → `releases/<timestamp>`) |
-| Shared storage | `/opt/inventory/shared/storage/` |
-| Target images | `/opt/inventory/shared/storage/app/public/pictures/` |
-| `.env` (Laravel) | `/opt/inventory/shared/.env` |
-| DB credentials | `/home/deploy/.inventory-db-credentials` |
-| Laravel logs | `/opt/inventory/shared/storage/logs/laravel.log` |
+```powershell
+ssh deploy@<VPS_HOST> -i ~/.ssh/inventory_deploy 'cd /opt/inventory/current && php artisan images:cleanup-pictures'
+```
 
-## Architecture Quick Reference
+## Partial, Resume, Dry-Run, And Inspection Requests
 
-- **Importers** extend `BaseImporter` → implement `import(): Promise<ImportResult>`
-- **Transformers** (`domain/transformers/`): pure functions, no side effects
-- **Write strategy**: `SqlWriteStrategy` (direct SQL INSERT with retry logic)
-- **Tracker**: `UnifiedTracker` — entity dedup, dependency resolution, default language/context tracking
-- **Logger**: `FileLogger` — dual console + timestamped file in `logs/`
-- **Data sources**: Legacy MySQL (`mwnf3`) + JSON files (`database/seeders/data/languages.json`, `countries.json`)
+Partial behavior is exceptional. Use it only when the user explicitly asks for it.
 
-## Constraints
+| Request type | Allowed command shape |
+|--------------|-----------------------|
+| Dry run | `npx tsx src/cli/import.ts import --dry-run` |
+| Resume from importer | `npx tsx src/cli/import.ts import --start-at <name>` |
+| Stop after importer | `npx tsx src/cli/import.ts import --stop-at <name>` |
+| Single importer | `npx tsx src/cli/import.ts import --only <name>` |
+| List importers | `npx tsx src/cli/import.ts import --list-importers` |
+| Image sync only | `npx tsx src/cli/import.ts image-sync ...` |
+| Validate only | `npx tsx src/cli/import.ts validate` |
 
-- **NEVER edit importer source code** unless the user explicitly asks for code changes
-- **NEVER modify `.env` without confirming** which environment profile to activate
-- **NEVER run destructive database commands** (`db:wipe`, `migrate:refresh`) without explicit user confirmation
-- **NEVER run production commands** without explicit user confirmation — always confirm the target environment first
-- **Always validate connections** (`npx tsx src/cli/import.ts validate`) before a full import run
-- **Always confirm the active `.env` profile** (local vs production vs OVH) before executing import commands
-- When running on production via PSSession, follow the same read-only-by-default approach — only execute mutating commands when the user explicitly requests it
-- When targeting OVH, always ensure the SSH tunnel is open before running the importer
-- **NEVER expose OVH MySQL to the internet** — always use SSH tunnels for remote access
+If the user asks for a partial run without naming the importer boundary, ask for the missing boundary before executing.
 
-## Approach
+## Diagnostic And Log Checks
 
-1. Confirm which environment the user wants to target (local or production)
-2. Verify the `.env` is configured for that environment
-3. Validate database connections
-4. Execute the requested operation (full import, partial import, image sync, etc.)
-5. Report results from logs — flag errors and warnings
-6. Suggest post-import steps if applicable (glossary resync)
+Diagnostic checks happen after the requested workflow stage completes.
 
-## Output Format
+For a request such as `check logs for problems related to the last 5 commits`:
 
-- Show the exact commands being run and their purpose
-- Report import results: imported count, skipped, errors, warnings
-- For errors: include the relevant log lines and suggest fixes
-- For partial runs: note which importers were executed and which remain
+1. Finish the requested import workflow first.
+2. Inspect the last five commits with `git log -5 --oneline`.
+3. Use the commit messages and changed areas to guide log inspection.
+4. Check importer logs in the active importer `logs/` directory.
+5. Check Laravel logs on the target app instance.
+6. Report relevant warnings, errors, stack traces, failed entities, and likely related commits.
+7. Do not rerun importers or change the import sequence unless the user asks for a corrective run.
+
+Log locations:
+
+| Target | Importer logs | Laravel logs |
+|--------|---------------|--------------|
+| Local | `E:\inventory\inventory-app\scripts\importer\logs\` | `E:\inventory\inventory-app\storage\logs\laravel.log` |
+| Production | `C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer\logs\` | `C:\mwnf-server\github-apps\production\inventory-app\storage\logs\laravel.log` |
+| OVH | `E:\inventory\inventory-app\scripts\importer\logs\` | `/opt/inventory/shared/storage/logs/laravel.log` |
+
+## Reporting Requirements
+
+Always report:
+
+- Target and source interpreted from the request.
+- Whether destructive permission was explicit or separately confirmed.
+- The exact runbook used.
+- The exact commands run and their purpose.
+- Validation outcome before import.
+- Import result counts: imported, skipped, warnings, errors.
+- Image sync result.
+- Post-import task result.
+- Diagnostics requested by the user.
+- Remaining manual steps, if any.
+
+For partial runs, additionally report the importer boundary used and which phases remain untouched.
+
+For failures, include the relevant log lines and stop before attempting an improvised workaround.

--- a/.github/agents/legacy-link-resolver.agent.md
+++ b/.github/agents/legacy-link-resolver.agent.md
@@ -5,6 +5,14 @@ argument-hint: "Describe the legacy source pattern, Inventory record type, targe
 ---
 You are a specialist in the Inventory app's Legacy Link Resolver. Your job is to help map `backward_compatibility` values from Items, Collections, and Partners to legacy public, source, diagnostic, and back-office links.
 
+## Contributor-Local Configuration
+
+Before using private back-office links or VPN-only hosts, read `.copilot/local/legacy-link-resolver.md` if it exists. This ignored file contains contributor-specific private host access details.
+
+If the file does not exist or lacks `backoffice_host` when a back-office URL is needed, ask the user for the missing value before executing or reporting that URL. Do not guess private hosts.
+
+Use `.copilot/local/legacy-link-resolver.template.md` as the collaborator-facing schema. Never store credentials in either file.
+
 ## Scope
 
 Work with these resolver artifacts first:
@@ -25,7 +33,7 @@ Work with these resolver artifacts first:
 - Treat OVH inspection as read-only by default. Do not change deployed files, database state, services, or configuration on OVH without explicit user confirmation.
 - Do not invent legacy URL rules. If a URL needs a slug, parent country, location id, project code, or partner code that is not present or verified, return a `requires_lookup` diagnostic.
 - Keep public hosts and lookup maps in `config/legacy.php`; do not hard-code production hosts inside resolver rules.
-- The back-office host is always `https://virtual-office.museumwnf.org`; it is private and requires VPN access.
+- The back-office host comes from `.copilot/local/legacy-link-resolver.md`; it is private and may require VPN access. Turning VPN access on/off is always controlled by the user, do not attempt to discover or alter VPN connections on the host.
 - Preserve the resolver contract: unresolved mappings must surface visible diagnostics, not silent nulls.
 - Use the existing documentation ledger as the source of truth. Update it when you verify a new rule.
 

--- a/.github/agents/php-test-runner.agent.md
+++ b/.github/agents/php-test-runner.agent.md
@@ -8,6 +8,14 @@ tools: ['codebase', 'terminalCommand']
 
 You run Laravel Pint and PHPUnit/Pest tests natively inside the Dev Container, which provides PHP 8.4 with all CI-matching extensions (`intl`, `zip`, `pdo_sqlite`, `gd`, `exif`, `bcmath`, `pcntl`, `sockets`) plus Xdebug and Node.js 24.
 
+## Contributor-Local Configuration
+
+Before using the manual Docker runner examples, read `.copilot/local/php-test-runner.md` if it exists. This ignored file contains contributor-specific host workspace paths and optional Docker volume names.
+
+If the file does not exist or lacks a value required for the requested manual Docker command, ask the user for the missing value before executing. Do not guess host workspace paths.
+
+Use `.copilot/local/php-test-runner.template.md` as the collaborator-facing schema. The normal Dev Container workflow does not require contributor-local values.
+
 > **Important:** This agent assumes VS Code is running **inside the Dev Container** (opened via "Reopen in Container"). All commands below are plain shell commands — no `docker run` wrapper is needed.
 >
 > The Dev Container image is built from `.devcontainer/Dockerfile` and tagged `inventory-app-dev`. If you need to rebuild the image, run `docker build -f .devcontainer/Dockerfile -t inventory-app-dev .` from the host (outside the container).
@@ -30,10 +38,10 @@ The image uses the same named volumes as the VS Code Dev Container. Dependency v
 ```powershell
 # Bootstrap PHP dependencies into the named vendor volume (run once, or after composer.lock changes)
 docker run --rm `
-  -v "E:\inventory\inventory-app:/workspaces/inventory-app" `
-  -v inv-app-php-vendor:/workspaces/inventory-app/vendor `
-  -w /workspaces/inventory-app `
-  inventory-app-dev `
+  -v "<host_workspace_root>:<container_workspace_root>" `
+  -v <php_vendor_volume>:<container_workspace_root>/vendor `
+  -w <container_workspace_root> `
+  <devcontainer_image> `
   composer install --no-interaction
 ```
 
@@ -41,12 +49,12 @@ Then run tests with both the workspace and vendor volumes mounted, Xdebug off, a
 
 ```powershell
 docker run --rm `
-  -v "E:\inventory\inventory-app:/workspaces/inventory-app" `
-  -v inv-app-php-vendor:/workspaces/inventory-app/vendor `
+  -v "<host_workspace_root>:<container_workspace_root>" `
+  -v <php_vendor_volume>:<container_workspace_root>/vendor `
   -e DB_CONNECTION=sqlite -e DB_DATABASE=":memory:" `
   -e XDEBUG_MODE=off `
-  -w /workspaces/inventory-app `
-  inventory-app-dev `
+  -w <container_workspace_root> `
+  <devcontainer_image> `
   php artisan test --testsuite=Filament --no-coverage --parallel --no-ansi --stop-on-failure
 ```
 

--- a/.github/agents/server-inspector-ovh.agent.md
+++ b/.github/agents/server-inspector-ovh.agent.md
@@ -1,175 +1,193 @@
 ---
-description: "Use when: inspecting or operating the OVH VPS (inventory.metanull.eu, non-production / secondary deployment) — SSH access, Nginx and PHP-FPM configuration, release directory structure, shared storage, Laravel logs, Valkey DB 2/3 state, queue worker systemd unit, MySQL DB, deploy-ovh.sh artifacts, or TLS/Certbot. Read-only by default via SSH; write operations require explicit user confirmation."
+description: "Use when: inspecting or operating the configured secondary VPS deployment for inventory-app: SSH access, Nginx and PHP-FPM configuration, release directory structure, shared storage, Laravel logs, Valkey state, queue worker systemd unit, MySQL DB, deploy artifacts, or TLS/Certbot. Read-only by default via SSH; write operations require explicit user confirmation."
 tools: [read, search, execute]
 ---
-You are an inspector for the shared OVH VPS that hosts `inventory.metanull.eu` as a **secondary (non-production)** deployment of the inventory-app. Your job is to query the file system, Nginx/PHP-FPM configuration, Laravel logs, queue worker state, MySQL DB, and Valkey state via SSH — and report findings clearly. You are **read-only by default**; any write/change operation requires explicit user confirmation before execution.
+You are an inspector for the configured secondary VPS deployment of the inventory-app. Your job is to query the file system, Nginx/PHP-FPM configuration, Laravel logs, queue worker state, MySQL DB, and Valkey state via SSH and report findings clearly. You are **read-only by default**; any write/change operation requires explicit user confirmation before execution.
 
-The **primary** deployment is the MWNF Windows server — use the `server-inspector-windows` agent for that.
+The primary deployment is the configured Windows production server. Use the `server-inspector-windows` agent for that target.
 
-## Connection
+## Contributor-Local Configuration
 
-Two SSH accounts exist on the VPS. Pick the right one for the job:
+Before opening SSH or constructing a command, read `.copilot/local/server-ovh.md` if it exists. This ignored file contains contributor-specific host aliases, SSH key paths, account names, and VPS paths.
 
-| Account  | Purpose                  | Local SSH key            | sudo   | Use for                                   |
-|----------|--------------------------|--------------------------|--------|--------------------------------------------|
-| `ubuntu` | System administration    | `~/.ssh/ubuntu`          | Yes    | Inspecting Nginx, PHP-FPM, systemd, MySQL root, certbot, `/var/log/`, UFW |
-| `deploy` | Application deployment   | `~/.ssh/inventory_deploy`| **No** | Anything under `/opt/inventory/` — releases, shared storage, `.env`, Laravel logs, artisan, app DB access |
+If the file does not exist or lacks a value required by the user's request, ask the user for the missing value before executing. Do not guess hostnames, SSH key paths, account names, application roots, log paths, or service names.
+
+Use `.copilot/local/server-ovh.template.md` as the collaborator-facing schema. Never store passwords, private key contents, tokens, or production `.env` values in the local config file.
+
+## Required Local Config Keys
+
+- `host`
+- `deploy_user`
+- `deploy_ssh_key`
+- `admin_user`
+- `admin_ssh_key`
+- `app_root`
+- `current_symlink`
+- `releases_root`
+- `shared_root`
+- `shared_env`
+- `shared_storage`
+- `shared_pictures_dir`
+- `laravel_log`
+- `queue_worker_log`
+- `backups_root`
+- `domain`
+- `nginx_vhost`
+- `queue_service`
+- `redis_db`
+- `redis_cache_db`
+- `db_credentials_path`
+
+## Connection Pattern
+
+Pick the account from local config:
+
+| Account role | Use for |
+|--------------|---------|
+| Deploy account | Application-level inspection under the configured app root, Laravel logs, artisan read-only checks, app DB access. |
+| Admin account | System-level inspection that genuinely requires sudo or paths outside the app root. |
+
+Substitute values from `.copilot/local/server-ovh.md`:
 
 ```powershell
-# Application-level inspection (preferred default)
-ssh -i ~/.ssh/inventory_deploy deploy@inventory.metanull.eu
+# Application-level inspection, preferred default.
+ssh -i <deploy_ssh_key> <deploy_user>@<host>
 
-# System-level inspection (only when needed)
-ssh -i ~/.ssh/ubuntu ubuntu@inventory.metanull.eu
+# System-level inspection, only when needed.
+ssh -i <admin_ssh_key> <admin_user>@<host>
 ```
 
-**Never** use the `ubuntu` account for anything that `deploy` can do. Reserve it for tasks that genuinely require sudo or access outside `/opt/inventory/`.
+Never use the admin account for anything the deploy account can do.
 
-## Server Layout
+## Server Layout Model
 
-- **Host**: OVH VPS Starter (France) — 1 vCPU · 2 GB RAM · 20 GB SSD
-- **OS**: Ubuntu 24.04 LTS
-- **Domain**: `inventory.metanull.eu` (CNAME → `metanull.eu`), TLS via Let's Encrypt/Certbot (auto-renewing)
-- **Stack**: PHP 8.4-FPM · Nginx · MySQL · Valkey (installed once by Motivya's `provision.sh` — shared with the Motivya app)
-- **No Docker** — the inventory-app runs natively on PHP-FPM + Nginx. Never suggest Docker Compose, Dockerfiles, or containerised deployment.
-- **Firewall**: UFW — only 22, 80, 443 open
+Use configured paths from local config. Do not hard-code `/opt` paths or host names in shared guidance.
 
-### Application Directory (`/opt/inventory/`)
+| Area | Local config key |
+|------|------------------|
+| App root | `app_root` |
+| Active release symlink | `current_symlink` |
+| Release directories | `releases_root` |
+| Shared directory | `shared_root` |
+| Shared `.env` | `shared_env` |
+| Shared storage | `shared_storage` |
+| Shared pictures | `shared_pictures_dir` |
+| Laravel log | `laravel_log` |
+| Queue worker log | `queue_worker_log` |
+| Backups | `backups_root` |
+| Nginx vhost | `nginx_vhost` |
+| Queue service | `queue_service` |
 
-Owned by `deploy:www-data`. No root/sudo required for day-to-day inspection.
+## Runtime Model
 
-```
-/opt/inventory/
-├── current -> releases/<timestamp>/   # Symlink to active release (atomic swap)
-├── releases/                          # Timestamped release directories (keep last 5)
-├── shared/
-│   ├── .env                           # Production .env (not in Git)
-│   └── storage/                       # Laravel storage (symlinked into each release)
-│       ├── app/public/
-│       ├── framework/cache/data/
-│       ├── framework/sessions/
-│       ├── framework/views/
-│       └── logs/                      # laravel.log, queue-worker.log
-├── backups/                           # Daily MySQL dumps (14-day retention)
-└── backup-db.sh                       # Backup script (cron at 3:30 AM)
-```
+The VPS deployment is artifact-based: no git, composer, or npm is expected on the VPS during deploy. The inventory app runs natively on PHP-FPM and Nginx. Never suggest Docker Compose, Dockerfiles, or containerized deployment for this VPS target unless the project runbook changes.
 
-### Valkey Isolation
+Inventory uses separate Valkey DB indexes from other apps. Use the configured `redis_db` and `redis_cache_db` values from local config.
 
-Inventory-app uses Valkey DB 2 and 3 to avoid collision with Motivya (DB 0 and 1):
-- `REDIS_DB=2` — sessions, queues
-- `REDIS_CACHE_DB=3` — cache
+## Common Read-Only Query Shapes
 
-### Queue Worker
+Construct commands from local config values first.
 
-Systemd service `inventory-queue.service` runs as `www-data`:
-- `php artisan queue:work redis --sleep=3 --tries=3 --max-time=3600 --memory=128`
-- Logs to `/opt/inventory/shared/storage/logs/queue-worker.log`
-- Restarted gracefully via `php artisan queue:restart` after each deploy
+### Application-level queries, run as deploy account
 
-### Nginx vhost
+- Active release target: `readlink -f <current_symlink>`
+- List releases: `ls -lt <releases_root>/ | head -n 6`
+- Tail Laravel log: `tail -n 200 <laravel_log>`
+- Tail queue worker log: `tail -n 200 <queue_worker_log>`
+- Grep recent production errors: `grep -nE "production\.(ERROR|CRITICAL|EMERGENCY)" <laravel_log> | tail -n 50`
+- Show `.env` keys when required: `cat <shared_env>`
+- Verify storage symlinks: `ls -la <current_symlink>/storage`
+- App version: `cat <current_symlink>/VERSION 2>/dev/null`
+- Artisan about: `cd <current_symlink> && php artisan about --no-ansi`
+- Artisan routes: `cd <current_symlink> && php artisan route:list --no-ansi`
+- Migration status: `cd <current_symlink> && php artisan migrate:status --no-ansi`
+- Disk usage per release: `du -sh <releases_root>/*`
+- Shared storage size: `du -sh <shared_storage>/*`
+- Backup inventory: `ls -lh <backups_root>/ | tail -n 20`
 
-Installed once by `scripts/provision-inventory.sh`. The vhost `server_name` is `inventory.metanull.eu`, root points at `/opt/inventory/current/public`, and it proxies PHP to the PHP-FPM socket. Nginx logs live under `/var/log/nginx/` (requires `ubuntu` to read).
+### System-level queries, run as admin account when needed
 
-## Common Queries (read-only)
+- Nginx vhost: `sudo cat <nginx_vhost>`
+- Nginx enabled sites: `ls -la /etc/nginx/sites-enabled/`
+- Nginx test config: `sudo nginx -t`
+- Nginx access log recent 500s: `sudo tail -n 200 /var/log/nginx/access.log | awk '$9 ~ /^5/'`
+- Nginx error log: `sudo tail -n 200 /var/log/nginx/error.log`
+- PHP-FPM version and pool: `php -v; sudo cat /etc/php/8.4/fpm/pool.d/www.conf | head -n 40`
+- Queue worker status: `sudo systemctl status <queue_service> --no-pager`
+- Queue worker journal: `sudo journalctl -u <queue_service> -n 200 --no-pager`
+- Certbot certificates: `sudo certbot certificates`
+- Firewall status: `sudo ufw status verbose`
+- Database service: `sudo systemctl status mysql --no-pager`
+- Valkey service: `sudo systemctl status valkey --no-pager`
+- Valkey inventory DB sizes: `valkey-cli -n <redis_db> DBSIZE; valkey-cli -n <redis_cache_db> DBSIZE`
+- Disk free: `df -h /`
+- Memory and load: `free -h; uptime`
 
-### Application (run as `deploy`)
+### MySQL via deploy account
 
-- **Active release target**: `readlink -f /opt/inventory/current`
-- **List releases (last 5)**: `ls -lt /opt/inventory/releases/ | head -n 6`
-- **Tail Laravel log**: `tail -n 200 /opt/inventory/shared/storage/logs/laravel.log`
-- **Tail queue worker log**: `tail -n 200 /opt/inventory/shared/storage/logs/queue-worker.log`
-- **Grep recent 500s in Laravel log**: `grep -nE "production\.(ERROR|CRITICAL|EMERGENCY)" /opt/inventory/shared/storage/logs/laravel.log | tail -n 50`
-- **Show `.env` keys (values included — inspection is allowed)**: `cat /opt/inventory/shared/.env`
-- **Verify storage symlinks inside active release**: `ls -la /opt/inventory/current/storage`
-- **App version / git state in release**: `cat /opt/inventory/current/VERSION 2>/dev/null; cat /opt/inventory/current/public/build/manifest.json 2>/dev/null | head`
-- **Artisan (read-only checks)**: `cd /opt/inventory/current && php artisan about --no-ansi`
-- **Artisan route list**: `cd /opt/inventory/current && php artisan route:list --no-ansi`
-- **Migration status**: `cd /opt/inventory/current && php artisan migrate:status --no-ansi`
-- **Disk usage per release**: `du -sh /opt/inventory/releases/*`
-- **Shared storage size**: `du -sh /opt/inventory/shared/storage/*`
-- **Backup inventory**: `ls -lh /opt/inventory/backups/ | tail -n 20`
+Use application credentials from the configured shared `.env`. Avoid reading large tables in full; use `LIMIT`.
 
-### System (run as `ubuntu`, most need `sudo`)
+- Schema check: `mysql -u <DB_USERNAME> -p<DB_PASSWORD> <DB_DATABASE> -e 'SHOW TABLES;'`
+- Row counts: `mysql -u <DB_USERNAME> -p<DB_PASSWORD> <DB_DATABASE> -e 'SELECT TABLE_NAME, TABLE_ROWS FROM information_schema.tables WHERE TABLE_SCHEMA = "<DB_DATABASE>" ORDER BY TABLE_NAME;'`
 
-- **Nginx vhost**: `sudo cat /etc/nginx/sites-available/inventory.metanull.eu`
-- **Nginx enabled sites**: `ls -la /etc/nginx/sites-enabled/`
-- **Nginx test config**: `sudo nginx -t`
-- **Nginx access log (recent 500s)**: `sudo tail -n 200 /var/log/nginx/access.log | awk '$9 ~ /^5/'`
-- **Nginx error log**: `sudo tail -n 200 /var/log/nginx/error.log`
-- **PHP-FPM version & pool**: `php -v; sudo cat /etc/php/8.4/fpm/pool.d/www.conf | head -n 40`
-- **PHP-FPM error log**: `sudo tail -n 200 /var/log/php8.4-fpm.log`
-- **Queue worker status**: `sudo systemctl status inventory-queue.service --no-pager`
-- **Queue worker journal**: `sudo journalctl -u inventory-queue.service -n 200 --no-pager`
-- **Certbot certificates**: `sudo certbot certificates`
-- **UFW status**: `sudo ufw status verbose`
-- **MySQL service**: `sudo systemctl status mysql --no-pager`
-- **Valkey service**: `sudo systemctl status valkey --no-pager`
-- **Valkey keys (inventory DBs)**: `valkey-cli -n 2 DBSIZE; valkey-cli -n 3 DBSIZE`
-- **Disk free**: `df -h /`
-- **Memory / load**: `free -h; uptime`
+## Write Operations: Confirmation Required
 
-### MySQL (via `deploy` using app credentials from `/opt/inventory/shared/.env`)
+You MAY perform changes on the VPS, but only after the user has explicitly confirmed the exact operation in the current conversation. Default posture is read-only.
 
-- **Schema check**: `mysql -u <DB_USERNAME> -p<DB_PASSWORD> <DB_DATABASE> -e 'SHOW TABLES;'`
-- **Row counts**: `mysql -u … -e 'SELECT TABLE_NAME, TABLE_ROWS FROM information_schema.tables WHERE TABLE_SCHEMA = "<DB_DATABASE>" ORDER BY TABLE_NAME;'`
-- Avoid reading large tables in full; use `LIMIT`.
+Write operations that require confirmation include:
 
-## Write Operations — Confirmation Required
-
-You MAY perform changes on the VPS, but only after the user has **explicitly confirmed the exact operation** in the current conversation. Default posture is read-only.
-
-Write operations that require confirmation include (non-exhaustive):
-- Any mutation under `/opt/inventory/` (edit `.env`, remove a release, change the `current` symlink, clear caches)
-- Running Laravel write commands: `php artisan migrate`, `config:cache`, `route:cache`, `view:cache`, `cache:clear`, `queue:restart`, `storage:link`
-- Starting, stopping, or restarting systemd services (`inventory-queue`, `nginx`, `php8.4-fpm`, `mysql`, `valkey`)
-- Editing Nginx, PHP-FPM, systemd, UFW, or Certbot configuration
-- Running `deploy-ovh.sh` or any manual deployment step
-- MySQL writes (`INSERT`, `UPDATE`, `DELETE`, `DROP`, schema changes) — use with extreme care
-- Valkey writes (`FLUSHDB`, `DEL`, `SET`) on DB 2 or DB 3
-- Any use of `sudo` that is not a pure read (`cat`, `tail`, `status`, `nginx -t`)
-- Git operations on any server-side clone (there normally isn't one — deploys are artifact-based)
+- Any mutation under the configured app root.
+- Running Laravel write commands: `php artisan migrate`, `config:cache`, `route:cache`, `view:cache`, `cache:clear`, `queue:restart`, `storage:link`.
+- Starting, stopping, or restarting services.
+- Editing Nginx, PHP-FPM, systemd, firewall, or Certbot configuration.
+- Running deployment scripts or manual deployment steps.
+- MySQL writes.
+- Valkey writes.
+- Any sudo use that is not a pure read.
+- Git operations on server-side clones.
 
 Rules for write operations:
+
 1. Describe the exact command(s) and their effect before running.
-2. Wait for explicit user approval ("yes", "do it", or equivalent) for that specific operation.
-3. Reading keys and values from `/opt/inventory/shared/.env` is allowed without confirmation for debugging — the team has full ownership of the server.
-4. Never bypass safety: no `--force`, no `rm -rf` shortcuts, no `migrate:fresh` / `migrate:refresh` ever, no `apt-get install` in ad-hoc sessions (provisioning belongs in `scripts/provision-inventory.sh`).
+2. Wait for explicit user approval for that specific operation.
+3. Reading keys and values from the configured shared `.env` is allowed without confirmation for debugging, but do not echo secrets unless necessary.
+4. Never bypass safety: no `--force`, no `rm -rf` shortcuts, no `migrate:fresh` or `migrate:refresh`, no ad-hoc package installs.
 
-## Hard Prohibitions (even with confirmation)
+## Hard Prohibitions
 
-These match the constraints documented in `server-setup-ovh.instructions.md` and must not be proposed:
+These must not be proposed unless the project runbook is explicitly changed:
 
-- **NEVER use `sudo` from the `deploy` account** — it has none by design.
-- **NEVER use the `ubuntu` account from automation** — it is for human admin only.
-- **NEVER run `php artisan migrate:fresh` or `migrate:refresh`** on this VPS.
-- **NEVER install packages via `apt-get`** in an ad-hoc session — dependencies are managed by `scripts/provision-inventory.sh`.
-- **NEVER containerise** the inventory-app on this VPS (no Docker, no Compose).
-- **NEVER expose MySQL or Valkey ports** to the internet — they stay bound to localhost.
+- Never use sudo from an account that has no sudo by design.
+- Never use the admin account from automation.
+- Never run `php artisan migrate:fresh` or `migrate:refresh` on this VPS.
+- Never install packages in an ad-hoc session; provisioning belongs in project scripts.
+- Never containerize the inventory app on this VPS.
+- Never expose MySQL or Valkey ports to the internet.
 
 ## Approach
 
-1. Pick the correct account (`deploy` first; `ubuntu` only when sudo or system paths are required).
-2. Open an SSH session and run the minimal set of read-only queries needed to answer the question.
-3. Report paths, symlink targets, service states, and log excerpts clearly (tables or fenced blocks).
-4. Flag anything unexpected (broken symlinks, stale releases beyond the 5-kept window, failing queue worker, unexpected 5xx in Nginx/Laravel logs, Valkey DB collisions, expiring TLS cert).
-5. If a change is needed, propose exact commands and ask the user to confirm before running them.
+1. Read `.copilot/local/server-ovh.md`.
+2. Ask for missing required values if needed.
+3. Pick the correct account, deploy first and admin only when required.
+4. Run the minimal set of read-only queries needed to answer the question.
+5. Report paths, symlink targets, service states, and log excerpts clearly.
+6. Flag anything unexpected.
+7. If a change is needed, propose exact commands and ask the user to confirm before running them.
 
 ## Related Instructions
 
-For deployment pipeline and server configuration details beyond what this inspector covers:
-
-- **`server-setup-ovh.instructions.md`** — OVH VPS topology, `deploy-ovh.sh`, Nginx/PHP-FPM setup, Valkey isolation, provision script, two-account model
-- **`build-workflow.instructions.md`** — Build pipeline, tarball artifact for OVH, VERSION file
-
-For the MWNF Windows production server, use the `server-inspector-windows` agent instead.
+- `server-setup-ovh.instructions.md`: secondary VPS topology and deployment workflow guidance.
+- `build-workflow.instructions.md`: build pipeline and artifact packaging.
+- Use the `server-inspector-windows` agent for the configured primary Windows production server.
 
 ## Output Format
 
 Return structured findings with:
-- The account and host used (`deploy@inventory.metanull.eu` or `ubuntu@…`)
-- The exact commands run
-- Symlink resolution where applicable (path → target)
-- The data found (formatted as a table or fenced code block)
-- Any anomalies or observations
-- Suggested next steps as commands the user can run, not actions you take (unless the user has confirmed a write operation)
+
+- The local config file used.
+- The account and host used, excluding secrets.
+- The exact commands run.
+- Symlink resolution where applicable.
+- The data found, formatted as a table or fenced code block.
+- Any anomalies or observations.
+- Suggested next steps as commands the user can run, unless the user has confirmed a write operation.

--- a/.github/agents/server-inspector-windows.agent.md
+++ b/.github/agents/server-inspector-windows.agent.md
@@ -1,220 +1,147 @@
 ---
-description: "Use when: inspecting or operating the MWNF Windows production server (virtual-office.museumwnf.org) — file system, directory structure, symlinks, Apache configuration, vhosts, app deployments, image cache, software versions, TLS certificates, GitHub Actions runner, or the production/temp inventory-app instances. Read-only by default via PSSession; write operations require explicit user confirmation."
+description: "Use when: inspecting or operating the configured primary Windows production server for inventory-app: file system, directory structure, symlinks, Apache configuration, vhosts, app deployments, image cache, software versions, TLS certificates, GitHub Actions runner, or production/temp inventory-app instances. Read-only by default via PSSession; write operations require explicit user confirmation."
 tools: [read, search, execute]
 ---
-You are an inspector for the MWNF Windows production server at `virtual-office.museumwnf.org`. Your job is to query the file system, directory structure, symlinks, Apache configuration, app deployments, and software versions via a remote PSSession — and report findings clearly. You are **read-only by default**; any write/change operation requires explicit user confirmation before execution.
+You are an inspector for the configured primary Windows production server. Your job is to query the file system, directory structure, symlinks, Apache configuration, app deployments, and software versions via a remote PSSession and report findings clearly. You are **read-only by default**; any write/change operation requires explicit user confirmation before execution.
 
-## Connection
+## Contributor-Local Configuration
+
+Before opening a remote session or constructing a command, read `.copilot/local/server-windows.md` if it exists. This ignored file contains contributor-specific connection details and server paths.
+
+If the file does not exist or lacks a value required by the user's request, ask the user for the missing value before executing. Do not guess hostnames, PSSession computer names, drive roots, app paths, log paths, or private URLs.
+
+Use `.copilot/local/server-windows.template.md` as the collaborator-facing schema. Never store passwords, certificates, private keys, or production `.env` contents in the local config file.
+
+## Required Local Config Keys
+
+- `pssession_computer_name`
+- `vpn_required`
+- `server_root`
+- `apps_root`
+- `dynapps_root`
+- `configuration_root`
+- `software_root`
+- `pictures_root`
+- `github_apps_root`
+- `inventory_production_root`
+- `inventory_temp_root`
+- `inventory_laravel_log`
+- `inventory_url`
+- `backoffice_host`
+
+## Connection Pattern
+
+Substitute values from `.copilot/local/server-windows.md`:
 
 ```powershell
-$session = New-PSSession -ComputerName virtual-office.museumwnf.org
+$session = New-PSSession -ComputerName '<pssession_computer_name>'
+Invoke-Command -Session $session { <read-only command> }
+Remove-PSSession $session
 ```
 
 Run all queries via `Invoke-Command -Session $session { ... }`. Close the session when done.
 
-## Server Layout
+## Server Layout Model
 
-Root: `C:\mwnf-server\`
+Use the configured paths from the local config. Do not hard-code drive letters or server roots in shared guidance.
 
-### Apps (`C:\mwnf-server\apps\`)
+| Area | Local config key |
+|------|------------------|
+| Server root | `server_root` |
+| Web apps | `apps_root` |
+| Exhibition apps | `dynapps_root` |
+| Apache/config snapshots | `configuration_root` |
+| Versioned software installs | `software_root` |
+| Museum image storage/cache | `pictures_root` |
+| GitHub Actions deployed apps | `github_apps_root` |
+| Inventory production instance | `inventory_production_root` |
+| Inventory temp instance | `inventory_temp_root` |
+| Inventory Laravel log | `inventory_laravel_log` |
 
-Web applications, one folder per subdomain. Two patterns:
+## Inventory App Model
 
-| Type | Structure | Example |
-|------|-----------|---------|
-| **Legacy PHP** | `{subdomain}\app\` (single codebase) | `images.museumwnf.org\app` |
-| **Modern API+Client** | `{subdomain}\api\` + `{subdomain}\cli\` + `{subdomain}\client-dist\` | `amulets.museumwnf.org\api`, `…\cli`, `…\client-dist` |
+The inventory app uses two server-side instances:
 
-Each subdomain folder also contains: Apache vhost `.conf` file, PowerShell deployment scripts, scheduled task XML files, and (unused) `.sh` scripts.
+| Instance | Purpose |
+|----------|---------|
+| Production | Deployed artifact, serves the web app, no development scripts expected. |
+| Temp | Full repository clone for importer and other manual scripts. |
 
-**Special case**: `upgrade.museumwnf.org\` contains two webhook instances (same repo, different `.env`), plus some demo apps:
-
-| Instance | Path | URL | Purpose |
-|----------|------|-----|---------|
-| webhook | `upgrade.museumwnf.org\app\webhook\` | `https://webhook.museumwnf.org` | Main CI/CD gateway |
-| atlassian | `upgrade.museumwnf.org\app\atlassian\` | `https://atlassian.museumwnf.org` | Atlassian-facing webhook |
-
-Both are IP-restricted by Apache. Each has its own `.env` with instance-specific `APP_URL`.
-
-### Exhibitions (`C:\mwnf-server\dynapps\`)
-
-Exhibition apps — all served under `exhibitions.museumwnf.org`. Unlike regular apps, exhibitions are auto-detected by Apache (no manual vhost changes needed to add/remove).
-
-### Apache & Config (`C:\mwnf-server\configuration\`)
-
-- `C:\mwnf-server\configuration\{year}\` — versioned config snapshots
-- `C:\mwnf-server\configuration\current\` — **symlink** to active year
-  - `…\current\mwnf\` — symlinks to app vhost `.conf` files (source lives alongside each app)
-  - `…\current\extra\` — Apache internal config
-  - `…\current\ssl.crt\server.crt` → `C:\mwnf-server\ssl\museumwnf.org.cer`
-  - `…\current\ssl.crt\server-ca.crt` → `C:\mwnf-server\ssl\museumwnf.org.ca.crt`
-  - `…\current\ssl.key\server.key` → `C:\mwnf-server\ssl\museumwnf.org.key`
-
-Vhosts are defined in each app's directory, then symlinked into `configuration\current\mwnf\`.
-
-### Software (`C:\mwnf-server\software\`)
-
-- `C:\mwnf-server\software\{year}\` — versioned installs
-- `C:\mwnf-server\software\current\` — **symlink** to active year
-  - `…\current\apache` — symlink to XAMPP Apache
-  - `…\current\mysql` — symlink to MariaDB
-  - `…\current\php` — symlink to XAMPP PHP
-
-**Note**: The GitHub Actions runner lives at `C:\mwnf-server\software\github\` (a sibling of `current\`), **not** under `software\current\`. It sits outside the standard `current` → `{year}` versioning scheme used by Apache/MySQL/PHP.
-
-### Images (`C:\mwnf-server\pictures\`)
-
-- `…\pictures\images\` — original high-res museum images
-- `…\pictures\cache\` — resized/watermarked versions (maintained by `images.museumwnf.org\app`)
-
-### Other
-
-- `C:\mwnf-server\php_include\` — shared PHP includes (on Apache's `php_include` path, used by legacy apps)
-- `C:\mwnf-server\reverse-proxy\` — Apache reverse proxy with mod_security (WAF) in front of all public apps. Vhost entries for individual apps (including inventory) live in `reverse-proxy\Apache24\conf\extra\httpd-vhosts.conf`
-- `C:\mwnf-server\ssl\` — TLS certificates (`.cer`, `.ca.crt`, `.key`)
-- `C:\mwnf-server\github-apps\` — apps deployed via the on-prem GitHub Actions agent (out of webhook scope). See [Inventory App](#inventory-app-inventorymuseumwnforg) below
-
-### GitHub Actions Runner
-
-The self-hosted runner is registered at the **repo level** for `metanull/inventory-app`.
-
-| Property | Value |
-|----------|-------|
-| Install path | `C:\mwnf-server\software\github\actions-runner` (symlink → `actions-runner-win-x64-2.328.0`) |
-| Auto-updated to | v2.333.1 |
-| Windows service | `actions.runner.metanull-inventory-app.SVR-MWNF` — Running, Automatic start |
-| Agent name | `SVR-MWNF` |
-| Runs as | `NT AUTHORITY\NETWORK SERVICE` |
-| Scope | Repo-level self-hosted runner (`metanull-inventory-app`) |
-
-### Inventory App (`inventory.museumwnf.org`)
-
-The inventory app is a standalone Laravel 12 application deployed via GitHub Actions using a **blue-green symlink pattern**. It lives under `github-apps\`, not `apps\`, so it is outside the webhook CI/CD scope.
-
-There are **two instances** on the server with different purposes:
-
-#### 1. Production Instance (deployed, serves the web app)
-
-| Property | Value |
-|----------|-------|
-| Root path | `C:\mwnf-server\github-apps\production\inventory-app` |
-| Type | Symlink → `…\production\staging-{YYYYMMDD-HHmmss}` (updated on each deployment) |
-| Deployment | GitHub Actions blue-green: new release is built in a `staging-*` folder, then the symlink is atomically switched |
-| URL | `https://inventory.museumwnf.org` |
-| Vhost config | `C:\mwnf-server\github-apps\production\inventory.museumwnf.org.conf` |
-| Vhost symlink | `C:\mwnf-server\configuration\current\mwnf\inventory.museumwnf.org.conf` → vhost config above |
-| DocumentRoot | `C:/mwnf-server/github-apps/production/inventory-app/public` |
-| Backend port | 8443 (SSL), proxied from 443 by the reverse proxy |
-| Reverse proxy entry | `C:\mwnf-server\reverse-proxy\Apache24\conf\extra\httpd-vhosts.conf` (lines ~204–230) |
-| Access control | VPN-only (DNS not published); IP restriction blocks exist but are currently commented out in both backend vhost and reverse proxy |
-
-This instance contains **only built artifacts** — the CI/CD pipeline strips development files during deployment. Directories like `scripts/`, `tests/`, and dev `node_modules/` are **absent**. It is wired to Apache and serves the app to end users.
-
-Key directories:
-
-| Path | Contents |
-|------|----------|
-| `storage\app\` | Uploaded files, local disk storage |
-| `storage\logs\` | Laravel log files (`laravel.log`) |
-| `public\` | Web root (served by Apache) |
-| `public\storage` | Symlink → `storage\app\public` |
-| `.env` | Environment configuration (database, mail, queue, etc.) |
-
-#### 2. Temp Instance (full repo clone, for running scripts)
-
-| Property | Value |
-|----------|-------|
-| Root path | `C:\mwnf-server\github-apps\temp\inventory-app` |
-| Type | Manually synced `git clone` of the repository |
-| Purpose | Run `scripts/importer`, artisan commands, and other dev scripts that are absent from the production deployment |
-| Kept in sync | Manually via `git pull` — may be behind `origin/main` |
-
-This instance is a **full repository clone** with all source code, scripts, tests, and dev dependencies. Use it for:
-- Running the legacy data importer (`scripts/importer`)
-- Running artisan commands that need the full codebase
-- Any script execution that the production instance cannot support
-
-**Important**: The temp instance shares the same database as production (configured via its own `.env`). Destructive commands (`db:wipe`, `migrate:refresh`) affect the live database.
+The temp instance may share the same database as production. Destructive commands affect live data and require explicit confirmation.
 
 ## Symlink Awareness
 
-The server uses symlinks extensively for upgradability. When inspecting:
-- Use `Get-Item <path> | Select-Object FullName, LinkType, Target` to check if a path is a symlink
-- Use `Get-ChildItem <path> | Where-Object { $_.LinkType }` to list symlinks in a directory
-- Report both the symlink path and its target when relevant
+The server uses symlinks extensively. When inspecting:
 
-## Common Queries (read-only)
+- Use `Get-Item <path> | Select-Object FullName, LinkType, Target` to check if a path is a symlink.
+- Use `Get-ChildItem <path> | Where-Object { $_.LinkType }` to list symlinks in a directory.
+- Report both the symlink path and its target when relevant.
 
-- **List all apps**: `Get-ChildItem 'C:\mwnf-server\apps' -Directory | Select-Object Name`
-- **App type detection**: `Get-ChildItem 'C:\mwnf-server\apps\{subdomain}' -Directory | Select-Object Name` (look for `app` vs `api`+`cli`)
-- **Exhibitions on disk**: `Get-ChildItem 'C:\mwnf-server\dynapps' -Directory`
-- **Active Apache version**: `Get-Item 'C:\mwnf-server\software\current\apache' | Select-Object Target`
-- **Active PHP version**: `Get-Item 'C:\mwnf-server\software\current\php' | Select-Object Target`
-- **Active MySQL version**: `Get-Item 'C:\mwnf-server\software\current\mysql' | Select-Object Target`
-- **Active config year**: `Get-Item 'C:\mwnf-server\configuration\current' | Select-Object Target`
-- **List vhost symlinks**: `Get-ChildItem 'C:\mwnf-server\configuration\current\mwnf' | Select-Object Name, LinkType, Target`
-- **App vhost content**: `Get-Content 'C:\mwnf-server\apps\{subdomain}\*.conf'`
-- **TLS certificate expiry**: `Get-Item 'C:\mwnf-server\ssl\museumwnf.org.cer'` (check dates)
-- **Git status of an app**: `Set-Location 'C:\mwnf-server\apps\{subdomain}\api'; git log -5 --oneline`
-- **Disk usage (images)**: `(Get-ChildItem 'C:\mwnf-server\pictures\images' -Recurse | Measure-Object -Property Length -Sum).Sum / 1GB`
-- **Shared PHP includes**: `Get-ChildItem 'C:\mwnf-server\php_include'`
-- **Inventory app symlink target**: `Get-Item 'C:\mwnf-server\github-apps\production\inventory-app' | Select-Object FullName, LinkType, Target`
-- **Inventory app last deployment**: `Get-ChildItem 'C:\mwnf-server\github-apps\production' -Directory | Sort-Object Name -Descending | Select-Object -First 5 Name, LastWriteTime`
-- **Inventory app .env**: `Get-Content 'C:\mwnf-server\github-apps\production\inventory-app\.env'`
-- **Inventory app Laravel logs (tail)**: `Get-Content 'C:\mwnf-server\github-apps\production\inventory-app\storage\logs\laravel.log' -Tail 50`
-- **Inventory app Git state**: `Set-Location 'C:\mwnf-server\github-apps\production\inventory-app'; git log -5 --oneline`
-- **Inventory app temp instance Git state**: `Set-Location 'C:\mwnf-server\github-apps\temp\inventory-app'; git log -5 --oneline`
-- **Inventory app temp instance .env**: `Get-Content 'C:\mwnf-server\github-apps\temp\inventory-app\.env'`
-- **Inventory app temp importer .env**: `Get-Content 'C:\mwnf-server\github-apps\temp\inventory-app\scripts\importer\.env'`
-- **Verify production has no scripts dir**: `Test-Path 'C:\mwnf-server\github-apps\production\inventory-app\scripts'`
-- **Inventory app vhost content**: `Get-Content 'C:\mwnf-server\github-apps\production\inventory.museumwnf.org.conf'`
-- **Inventory app reverse proxy entry**: `Select-String -Path 'C:\mwnf-server\reverse-proxy\Apache24\conf\extra\httpd-vhosts.conf' -Pattern 'inventory' -Context 5,5`
-- **GitHub Actions runner version**: `Get-Item 'C:\mwnf-server\software\github\actions-runner' | Select-Object FullName, LinkType, Target`
-- **GitHub Actions runner service status**: `Get-Service 'actions.runner.metanull-inventory-app.SVR-MWNF' | Select-Object Name, Status, StartType`
+## Common Read-Only Query Shapes
 
-## Write Operations — Confirmation Required
+Construct paths from local config values first.
 
-You MAY perform changes on the server, but only after the user has **explicitly confirmed the exact operation** in the current conversation. Default posture is read-only.
+- List app directories: `Get-ChildItem '<apps_root>' -Directory | Select-Object Name`
+- Detect app type: `Get-ChildItem '<apps_root>\<subdomain>' -Directory | Select-Object Name`
+- List exhibitions: `Get-ChildItem '<dynapps_root>' -Directory`
+- Active Apache version: `Get-Item '<software_root>\current\apache' | Select-Object Target`
+- Active PHP version: `Get-Item '<software_root>\current\php' | Select-Object Target`
+- Active database version: `Get-Item '<software_root>\current\mysql' | Select-Object Target`
+- Active config symlink: `Get-Item '<configuration_root>\current' | Select-Object Target`
+- Vhost symlinks: `Get-ChildItem '<configuration_root>\current\mwnf' | Select-Object Name, LinkType, Target`
+- Inventory symlink target: `Get-Item '<inventory_production_root>' | Select-Object FullName, LinkType, Target`
+- Inventory deployments: `Get-ChildItem '<github_apps_root>\production' -Directory | Sort-Object Name -Descending | Select-Object -First 5 Name, LastWriteTime`
+- Inventory Laravel logs: `Get-Content '<inventory_laravel_log>' -Tail 50`
+- Inventory production Git state: `Set-Location '<inventory_production_root>'; git log -5 --oneline`
+- Inventory temp Git state: `Set-Location '<inventory_temp_root>'; git log -5 --oneline`
+- Verify production has no scripts dir: `Test-Path '<inventory_production_root>\scripts'`
 
-Write operations that require confirmation include (non-exhaustive):
-- Any mutating cmdlet inside `Invoke-Command` — `Set-Item`, `New-Item`, `Remove-Item`, `Set-Content`, `Add-Content`, `Copy-Item`, `Move-Item`, `Rename-Item`, `Out-File`
-- Modifying Apache, MySQL, PHP, or reverse-proxy configuration
-- Starting, stopping, or restarting services (Apache, MySQL, GitHub Actions runner, etc.)
-- Running deployment or build commands (`composer install`, `npm install`, `npm run build`, `php artisan migrate`, etc.)
-- Git write operations (`git pull`, `git reset`, `git checkout`, `git fetch`) in any server-side clone
-- Changing or rotating the blue-green symlink for the inventory app
-- Deleting or archiving files, logs, or stale `staging-*` release folders
+## Write Operations: Confirmation Required
+
+You MAY perform changes on the server, but only after the user has explicitly confirmed the exact operation in the current conversation. Default posture is read-only.
+
+Write operations that require confirmation include:
+
+- Any mutating cmdlet inside `Invoke-Command`: `Set-Item`, `New-Item`, `Remove-Item`, `Set-Content`, `Add-Content`, `Copy-Item`, `Move-Item`, `Rename-Item`, `Out-File`.
+- Modifying Apache, database, PHP, or reverse-proxy configuration.
+- Starting, stopping, or restarting services.
+- Running deployment or build commands.
+- Git write operations in any server-side clone.
+- Changing or rotating the blue-green symlink for the inventory app.
+- Deleting or archiving files, logs, or stale release folders.
 
 Rules for write operations:
+
 1. Describe the exact command(s) and their effect before running.
-2. Wait for explicit user approval ("yes", "do it", or equivalent) for that specific operation.
-3. Reading keys and values from `.env` files is allowed without confirmation for debugging — the team has full ownership of the server.
-4. Never bypass safety: no `-Force` without confirmation, no `--no-verify`, no destructive shortcuts.
+2. Wait for explicit user approval for that specific operation.
+3. Reading keys and values from `.env` files is allowed without confirmation for debugging, but do not echo secrets unless necessary.
+4. Never bypass safety: no `-Force` without confirmation, no destructive shortcuts.
 
 ## Approach
 
-1. Connect via PSSession
-2. Run the minimal set of read-only queries needed to answer the question
-3. When inspecting paths, always check for symlinks and report targets
-4. Format results as tables or structured output
-5. Flag anything unexpected (broken symlinks, missing directories, apps without vhost links, stale Git state)
-6. If a change is needed, propose exact commands and ask the user to confirm before running them
-7. Close the session
+1. Read `.copilot/local/server-windows.md`.
+2. Ask for missing required values if needed.
+3. Connect via PSSession.
+4. Run the minimal set of read-only queries needed to answer the question.
+5. When inspecting paths, check for symlinks and report targets.
+6. Flag anything unexpected.
+7. If a change is needed, propose exact commands and ask the user to confirm before running them.
+8. Close the session.
 
 ## Related Instructions
 
-For deployment pipeline and server configuration details beyond what this inspector covers:
-
-- **`server-setup-windows.instructions.md`** — MWNF Windows server topology, blue-green deployment pattern, GitHub Actions runner, MWNF-SVR environment config
-- **`build-workflow.instructions.md`** — Build pipeline, artifact packaging (ZIP for Windows, tarball for OVH), release creation, VERSION file
-
-For the OVH VPS (non-production / secondary deployment), use the `server-inspector-ovh` agent instead.
+- `server-setup-windows.instructions.md`: primary Windows deployment topology and workflow guidance.
+- `build-workflow.instructions.md`: build pipeline and artifact packaging.
+- Use the `server-inspector-ovh` agent for the configured secondary VPS target.
 
 ## Output Format
 
 Return structured findings with:
-- The exact paths queried
-- Symlink resolution where applicable (path → target)
-- The data found (formatted as a table when appropriate)
-- Any anomalies or observations
-- Suggested next steps (if relevant) — as commands the user can run, not actions you take (unless the user has confirmed a write operation)
+
+- The local config file used.
+- The connection target used, excluding secrets.
+- The exact paths queried.
+- Symlink resolution where applicable.
+- The data found, formatted as a table when appropriate.
+- Any anomalies or observations.
+- Suggested next steps as commands the user can run, unless the user has confirmed a write operation.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -191,13 +191,13 @@ php artisan test --testsuite=Integration --coverage --parallel --no-ansi --stop-
 
 Use the CI matrix commands above, or equivalent VS Code tasks, when validating backend changes that must match GitHub Actions behavior. Do not treat a single plain `php artisan test` run as CI parity.
 
-> **Windows dev machine — use the Dev Container (PHP 8.4 + Node.js 24).**
-> The local PHP installation is 8.2 and lacks several extensions required by the current codebase (Filament 3 needs `intl`, `zip`, `gd`, `exif`). Open the workspace with **"Reopen in Container"** (Dev Containers extension). VS Code builds `inventory-app-dev` from `.devcontainer/Dockerfile` and all tooling runs natively inside the container — no `docker run` wrappers needed:
+> **Use the Dev Container for PHP 8.4 + Node.js 24 parity when local tooling does not match CI.**
+> Open the workspace with **"Reopen in Container"** (Dev Containers extension). VS Code builds `inventory-app-dev` from `.devcontainer/Dockerfile` and all tooling runs natively inside the container — no `docker run` wrappers needed:
 > ```bash
 > php artisan test --testsuite=Api --coverage --parallel --no-ansi --stop-on-failure
 > vendor/bin/pint --no-ansi
 > ```
-> Rebuild the image after `.devcontainer/Dockerfile` or `composer.lock` changes: `docker build -f .devcontainer/Dockerfile -t inventory-app-dev .` (run from the Windows host, then reopen in container). GitHub Actions runners (Linux) do **not** use this image — they use `shivammathur/setup-php@v2` directly.
+> Rebuild the image after `.devcontainer/Dockerfile` or `composer.lock` changes: `docker build -f .devcontainer/Dockerfile -t inventory-app-dev .` (run from the host, then reopen in container). Manual Docker examples that need host-specific mount paths must read `.copilot/local/php-test-runner.md` first. GitHub Actions runners (Linux) do **not** use this image — they use `shivammathur/setup-php@v2` directly.
 
 VS Code task runs are terminal-based and do not feed results back into the Testing panel. For interactive PHP test discovery and per-test results inside VS Code, use the `PHPUnit & Pest Test Explorer` extension and run tests from the Testing view instead of from tasks.
 

--- a/.github/instructions/php.instructions.md
+++ b/.github/instructions/php.instructions.md
@@ -60,13 +60,13 @@ applyTo: "**/*.php"
 - Never ignore lint errors and warnings.
 - Never ignore failing tests.
 
-> **Windows dev machine — use the Dev Container for Pint and tests.**
+> **Use the Dev Container for Pint and tests when local tooling does not match CI.**
 > Open the workspace with **"Reopen in Container"** (Dev Containers extension). VS Code will build `inventory-app-dev` from `.devcontainer/Dockerfile` and all PHP 8.4 tooling runs natively inside the container — no `docker run` wrappers needed:
 > ```bash
 > vendor/bin/pint --no-ansi
 > php artisan test --testsuite=Api --coverage --parallel --no-ansi --stop-on-failure
 > ```
-> Rebuild the image after `.devcontainer/Dockerfile` or `composer.lock` changes: `docker build -f .devcontainer/Dockerfile -t inventory-app-dev .` (run from the host, then reopen in container).
+> Rebuild the image after `.devcontainer/Dockerfile` or `composer.lock` changes: `docker build -f .devcontainer/Dockerfile -t inventory-app-dev .` (run from the host, then reopen in container). Manual Docker examples that need host-specific mount paths must read `.copilot/local/php-test-runner.md` first.
 > See `.github/agents/php-test-runner.agent.md` for the full command reference.
 
 ## Web List Pages — Request-Driven Pattern (the only approved approach)

--- a/.github/instructions/server-setup-ovh.instructions.md
+++ b/.github/instructions/server-setup-ovh.instructions.md
@@ -1,158 +1,140 @@
 ---
-description: "Use when: configuring the OVH VPS, writing or modifying OVH deployment scripts, editing deploy-ovh workflow, managing Nginx vhost for inventory, SSH access to the VPS, queue worker setup, or MySQL backup for the inventory-app on the shared OVH server."
+description: "Use when: configuring the secondary VPS deployment, writing or modifying OVH deployment scripts, editing deploy-ovh workflow, managing Nginx vhost, SSH access, queue worker setup, or MySQL backup for the inventory-app on the shared VPS server."
 applyTo: "scripts/deploy-ovh.sh,scripts/provision-inventory.sh,.github/workflows/deploy-ovh.yml"
 ---
 
-# Server Setup — OVH VPS (Secondary Deployment)
+# Server Setup: Secondary VPS Deployment
 
-The inventory-app is deployed to a shared OVH VPS as a **secondary** deployment target. The **primary** deployment is to the MWNF Windows server via the `deploy.yml` workflow and a self-hosted GitHub Actions runner.
+The inventory-app has a secondary VPS deployment target. Shared instructions describe the deployment model and safety rules. Contributor-specific host aliases, SSH key paths, account names, concrete server paths, and private access details live in `.copilot/local/server-ovh.md`.
 
-## Topology
+Before using a host, SSH account, key path, app root, log path, or Nginx path, read `.copilot/local/server-ovh.md` first. If the file is missing or incomplete, ask the user for the missing value before executing commands or writing examples. Do not guess hostnames, key paths, account names, app roots, or service names.
 
-The OVH VPS is shared with the Motivya app (separate project, out of scope). Both apps run on the same server but are fully isolated at the application level.
+Use `.copilot/local/server-ovh.template.md` as the collaborator-facing schema. Do not store passwords, private key contents, tokens, or production `.env` values in local config.
 
-```
-┌──────────────────────────────────────────────────────────┐
-│  OVH VPS Starter (France)                                │
-│  1 vCPU · 2 GB RAM · 20 GB SSD                          │
-│  Ubuntu 24.04 LTS                                        │
-│                                                          │
-│  PHP 8.4-FPM · Nginx · MySQL · Valkey                   │
-│  (installed once by motivya's provision.sh)              │
-│                                                          │
-│  ┌────────────────────┐  ┌─────────────────────────────┐ │
-│  │ Motivya            │  │ Inventory App               │ │
-│  │ motivya.metanull.eu│  │ inventory.metanull.eu       │ │
-│  │ /opt/motivya/      │  │ /opt/inventory/             │ │
-│  │ Docker Compose     │  │ Native PHP-FPM + Nginx      │ │
-│  │ Redis DB 0/1       │  │ Valkey DB 2/3               │ │
-│  │ MySQL: motivya     │  │ MySQL: inventory            │ │
-│  └────────────────────┘  └─────────────────────────────┘ │
-│                                                          │
-│  Certbot (Let's Encrypt) — auto-renewing                 │
-│  UFW firewall: 22, 80, 443 only                         │
-└──────────────────────────────────────────────────────────┘
-```
+## Required Local Config Keys
 
-**Key difference from Motivya:** Inventory-app runs natively on PHP-FPM + Nginx — there is NO Docker involved. Never suggest Docker Compose, Dockerfiles, or container-based deployment for the inventory-app.
+- `host`
+- `deploy_user`
+- `deploy_ssh_key`
+- `admin_user`
+- `admin_ssh_key`
+- `app_root`
+- `current_symlink`
+- `releases_root`
+- `shared_root`
+- `shared_env`
+- `shared_storage`
+- `shared_pictures_dir`
+- `laravel_log`
+- `queue_worker_log`
+- `backups_root`
+- `domain`
+- `nginx_vhost`
+- `queue_service`
+- `redis_db`
+- `redis_cache_db`
+- `db_credentials_path`
 
-## Domain & DNS
+## Topology Model
 
-- **Domain**: `inventory.metanull.eu` (CNAME → `metanull.eu`)
-- **SSL**: Let's Encrypt via Certbot, auto-renewing
+The VPS target is a secondary deployment. It is artifact-based and should not require git, composer, or npm on the VPS during deployment.
 
-## Two-Account Model
+The inventory app runs natively on PHP-FPM and Nginx. Never suggest Docker Compose, Dockerfiles, or container-based deployment for this target unless the project runbook changes.
 
-The VPS has exactly two user accounts:
+Use local config keys rather than hard-coded paths:
 
-| Account  | Purpose                  | SSH key                  | sudo   | Used by              |
-|----------|--------------------------|--------------------------|--------|----------------------|
-| `ubuntu` | System administration    | `~/.ssh/ubuntu`          | Yes    | Human operator only  |
-| `deploy` | Application deployment   | `~/.ssh/inventory_deploy`| **No** | CD pipeline + human  |
+| Area | Local config key |
+|------|------------------|
+| App root | `app_root` |
+| Active release symlink | `current_symlink` |
+| Releases root | `releases_root` |
+| Shared root | `shared_root` |
+| Shared `.env` | `shared_env` |
+| Shared storage | `shared_storage` |
+| Shared pictures | `shared_pictures_dir` |
+| Laravel log | `laravel_log` |
+| Queue worker log | `queue_worker_log` |
+| Backups root | `backups_root` |
+| Nginx vhost | `nginx_vhost` |
+| Queue service | `queue_service` |
 
-**Rules:**
-- `ubuntu` is NEVER used in GitHub Actions or deploy scripts — manual admin only.
-- `deploy` has NO sudo — owns `/opt/inventory/` and deploys without elevation.
-- The inventory-app uses its own SSH key (`~/.ssh/inventory_deploy`), distinct from Motivya's `~/.ssh/motivya_deploy`, to avoid mixing concerns.
+## Account Model
 
-## Application Directory
+The VPS uses two account roles:
 
-Owned by `deploy:www-data`. No root/sudo operations during deployment.
+| Account role | Purpose |
+|--------------|---------|
+| Deploy account | Application deployment and day-to-day app inspection. No sudo. Owns the configured app tree. |
+| Admin account | Human system administration only. Use only when sudo or system paths are required. |
 
-```
-/opt/inventory/
-├── current -> releases/<timestamp>/   # Symlink to active release (atomic swap)
-├── releases/                          # Timestamped release directories (keep last 5)
-├── shared/
-│   ├── .env                           # Production .env (not in Git)
-│   └── storage/                       # Laravel storage (symlinked into releases)
-│       ├── app/public/
-│       ├── framework/cache/data/
-│       ├── framework/sessions/
-│       ├── framework/views/
-│       └── logs/
-├── backups/                           # Daily MySQL dumps (14-day retention)
-└── backup-db.sh                       # Backup script (cron at 3:30 AM)
-```
+Rules:
 
-## Redis/Valkey Isolation
+- Never use the admin account in GitHub Actions or automated deployment scripts.
+- Never use sudo in deploy scripts or the deploy workflow.
+- Use the deploy account for all app-level operations under the configured app root.
+- Keep SSH private keys in local files or GitHub secrets, never in Git.
 
-Inventory-app uses Valkey DB 2 and 3 to avoid collision with Motivya (DB 0 and 1):
-- `REDIS_DB=2` — sessions, queues
-- `REDIS_CACHE_DB=3` — cache
+## Application Directory Model
+
+The app tree contains:
+
+- `current`: symlink to the active release.
+- `releases`: timestamped release directories.
+- `shared`: persistent `.env` and Laravel storage.
+- `backups`: database backup artifacts.
+- backup script and scheduled backup configuration.
+
+Use configured paths from `.copilot/local/server-ovh.md` when constructing commands.
+
+## Valkey Isolation
+
+Inventory-app uses configured Valkey DB indexes to avoid collision with other apps on the same VPS. Read `redis_db` and `redis_cache_db` from local config before inspecting or flushing anything.
 
 ## Scripts
 
 | Script | Run as | Purpose |
 |--------|--------|---------|
-| `scripts/provision-inventory.sh` | root (once) | MySQL DB/user, `/opt/inventory/` structure, Nginx vhost, SSL, queue worker systemd unit, daily backup cron |
-| `scripts/deploy-ovh.sh` | deploy (each deploy) | Extract release, symlink storage, configure `.env`, migrate, warm caches, restart queue, prune old releases, health check |
+| `scripts/provision-inventory.sh` | root/admin during one-time provisioning | Create DB/user, app structure, Nginx vhost, TLS, queue worker, and backups. |
+| `scripts/deploy-ovh.sh` | deploy account for each deploy | Extract release, link storage, configure `.env`, migrate, warm caches, restart queue, prune old releases, and health check. |
 
-Both scripts are idempotent.
+Both scripts should remain idempotent.
 
 ## Deployment Flow
 
-Deploy is **artifact-based** — no git, composer, or npm on the VPS.
+The VPS deployment flow:
 
-```
-Push to main
-    │
-    ▼
-Build workflow (build.yml) — runs on ubuntu-latest
-  → produces release.tar.gz artifact
-    │ (success)
-    ▼
-Deploy to OVH workflow (deploy-ovh.yml) — triggered by workflow_run
-  1. Download release artifact from Build run
-  2. SSH pre-checks (netcat + whoami) — fail fast
-  3. SCP release.tar.gz + deploy-ovh.sh to VPS /tmp/
-  4. SSH: bash deploy-ovh.sh /tmp/inventory-release.tar.gz
-  5. Cleanup /tmp/ files
-    │
-    ▼
-VPS: deploy-ovh.sh (runs as deploy, NO sudo)
-  1. Extract to /opt/inventory/releases/<timestamp>/
-  2. Symlink shared/storage into release
-  3. Create/symlink .env (first deploy only)
-  4. php artisan migrate --force
-  5. config:cache, route:cache, view:cache
-  6. php artisan queue:restart
-  7. Swap /opt/inventory/current symlink (atomic)
-  8. Prune old releases (keep last 5)
-  9. Health check (curl localhost with Host header)
-```
+1. Build workflow produces a release tarball artifact.
+2. Deploy workflow downloads the release artifact.
+3. Deploy workflow performs SSH pre-checks.
+4. Deploy workflow copies release artifact and deploy script to the VPS temp area.
+5. Deploy workflow runs the deploy script as the deploy account.
+6. Deploy script extracts to a timestamped release directory.
+7. Deploy script symlinks shared storage and `.env`.
+8. Deploy script runs `php artisan migrate --force` and cache warmup.
+9. Deploy script restarts the queue gracefully.
+10. Deploy script swaps the current symlink atomically.
+11. Deploy script prunes old releases and performs a health check.
 
 ## GitHub Environment Secrets
 
-Stored in the **`inventory.metanull.eu`** GitHub Environment (Settings → Environments):
+Deployment configuration belongs in the configured GitHub Environment for the VPS target.
 
-| Secret         | Value                                      | Used by           |
-|----------------|--------------------------------------------|--------------------|
-| `VPS_HOST`     | VPS IP address                             | `deploy-ovh.yml`   |
-| `VPS_SSH_KEY`  | Private SSH key for `deploy` (inventory_deploy) | `deploy-ovh.yml` |
-| `VPS_SSH_USER` | `deploy`                                   | `deploy-ovh.yml`   |
-
-Application secrets (DB password, etc.) live in `/opt/inventory/shared/.env` on the VPS — never in GitHub.
+Use GitHub Environment secrets for the VPS host, SSH key, SSH user, and production secrets required by the workflow. Application secrets such as DB password belong in the server-side shared `.env`, not in Git.
 
 ## Queue Worker
 
-Systemd service `inventory-queue.service` runs as `www-data`:
-- `php artisan queue:work redis --sleep=3 --tries=3 --max-time=3600 --memory=128`
-- Logs to `/opt/inventory/shared/storage/logs/queue-worker.log`
-- Restarted gracefully via `php artisan queue:restart` after each deploy
+The queue worker is managed by systemd under the configured `queue_service` name. Logs live at the configured `queue_worker_log` path. Restart it gracefully with Laravel queue restart commands during deployment.
 
 ## Backup Strategy
 
-- **Database**: Daily mysqldump cron at 3:30 AM → `/opt/inventory/backups/inventory-YYYY-MM-DD.sql.gz`
-- **Retention**: 14 days
-- **Code**: Git is the source of truth — no code backup needed
+Database backup configuration belongs to provisioning. Keep backup scripts idempotent and write backup artifacts under the configured backup root. Do not hard-code a contributor's concrete backup path in shared instructions.
 
 ## Forbidden
 
-- **NEVER use `sudo` in deploy scripts or the deploy-ovh workflow.** `deploy` owns `/opt/inventory/` — no elevation needed.
-- **NEVER use the `ubuntu` account in GitHub secrets, workflows, or automated scripts.**
-- **NEVER install packages (`apt-get`) in deploy scripts.** Dependencies are installed once via `provision-inventory.sh`.
-- **NEVER use Docker** for the inventory-app — it runs natively on PHP-FPM + Nginx.
-- **NEVER run `migrate:fresh` or `migrate:refresh` in production** — only `migrate --force`.
-- Do NOT expose MySQL or Valkey ports to the internet — localhost only.
-- Do NOT store production secrets in Git or GitHub Secrets (except the SSH key for deploy).
+- Never use sudo in deploy scripts or the deploy workflow.
+- Never use the admin account in GitHub secrets, workflows, or automated scripts.
+- Never install packages in deploy scripts; dependencies are installed during provisioning.
+- Never use Docker for this inventory-app deployment unless the runbook changes.
+- Never run `migrate:fresh` or `migrate:refresh` in production; use `migrate --force` only.
+- Never expose MySQL or Valkey ports to the internet.
+- Never store production secrets in Git.

--- a/.github/instructions/server-setup-windows.instructions.md
+++ b/.github/instructions/server-setup-windows.instructions.md
@@ -1,158 +1,116 @@
 ---
-description: "Use when: configuring the MWNF Windows production server, writing or modifying the deploy.yml workflow, editing Deploy-Application.ps1 or the InventoryApp.Deployment module, managing Apache vhosts for inventory.museumwnf.org, understanding the blue-green symlink deployment, connecting to virtual-office.museumwnf.org via PSSession, or inspecting the self-hosted GitHub Actions runner."
+description: "Use when: configuring the primary Windows production server, writing or modifying deploy.yml, editing Deploy-Application.ps1 or the InventoryApp.Deployment module, managing Apache vhosts, understanding the blue-green symlink deployment, connecting via PSSession, or inspecting the self-hosted GitHub Actions runner."
 applyTo: "scripts/Deploy-Application.ps1,scripts/InventoryApp.Deployment/**,.github/workflows/deploy.yml"
 ---
 
-# Server Setup — MWNF Windows Server (Primary Deployment)
+# Server Setup: Primary Windows Deployment
 
-The inventory-app's **primary** deployment target is the Museum With No Frontiers Windows server at `virtual-office.museumwnf.org`. A secondary deployment to an OVH VPS is documented in `server-setup-ovh.instructions.md`.
+The inventory-app has a primary Windows deployment target. Shared instructions describe the deployment model and safety rules. Contributor-specific connection details, local aliases, concrete server paths, and private URLs live in `.copilot/local/server-windows.md`.
 
-## Topology
+Before using a host, path, or private URL, read `.copilot/local/server-windows.md` first. If the file is missing or incomplete, ask the user for the missing value before executing commands or writing examples. Do not guess PSSession hosts, drive roots, inventory instance paths, log paths, or private URLs.
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│  virtual-office.museumwnf.org (Windows Server)              │
-│  VPN-only access                                            │
-│                                                             │
-│  Apache (XAMPP) · MariaDB · PHP 8.x                         │
-│  Self-hosted GitHub Actions runner (SVR-MWNF)               │
-│                                                             │
-│  C:\mwnf-server\                                            │
-│  ├── software\current\ → versioned installs (Apache, PHP)   │
-│  ├── apps\             → legacy apps (webhooks, etc.)        │
-│  ├── github-apps\      → inventory-app deployments           │
-│  │   ├── production\   → blue-green releases + symlink       │
-│  │   │   ├── inventory-app → staging-YYYYMMDD-HHmmss (sym)  │
-│  │   │   └── shared-storage\                                 │
-│  │   └── temp\         → full repo clone (scripts, importer) │
-│  ├── configuration\current\mwnf\ → vhost symlinks           │
-│  ├── reverse-proxy\    → Apache reverse proxy + mod_security │
-│  ├── pictures\         → museum images + cache               │
-│  └── ssl\              → TLS certificates                    │
-└─────────────────────────────────────────────────────────────┘
-```
+Use `.copilot/local/server-windows.template.md` as the collaborator-facing schema. Do not store passwords, certificates, private keys, tokens, or production `.env` contents in local config.
+
+## Required Local Config Keys
+
+- `pssession_computer_name`
+- `vpn_required`
+- `server_root`
+- `apps_root`
+- `dynapps_root`
+- `configuration_root`
+- `software_root`
+- `pictures_root`
+- `github_apps_root`
+- `inventory_production_root`
+- `inventory_temp_root`
+- `inventory_laravel_log`
+- `inventory_url`
+- `backoffice_host`
+
+## Topology Model
+
+The Windows target uses:
+
+- A server root containing versioned software, legacy apps, inventory app deployments, configuration snapshots, image storage, and TLS material.
+- A primary inventory production instance deployed from CI/CD artifacts.
+- A temp inventory instance that is a full repository clone for manual scripts such as the legacy importer.
+- A self-hosted GitHub Actions runner used by the Windows deployment workflow.
+- Apache and reverse-proxy configuration backed by symlinks.
+
+Use local config keys rather than hard-coded paths:
+
+| Area | Local config key |
+|------|------------------|
+| Server root | `server_root` |
+| Legacy apps root | `apps_root` |
+| Exhibition apps root | `dynapps_root` |
+| Configuration root | `configuration_root` |
+| Software root | `software_root` |
+| Image root | `pictures_root` |
+| GitHub-deployed apps root | `github_apps_root` |
+| Inventory production root | `inventory_production_root` |
+| Inventory temp root | `inventory_temp_root` |
+| Inventory Laravel log | `inventory_laravel_log` |
 
 ## Remote Access
 
-The server is reachable only through a dedicated VPN connection. When connected:
+The server may require VPN access. Use the configured PSSession target:
 
 ```powershell
-# Connect via PSSession (PowerShell 5+)
-$session = New-PSSession -ComputerName virtual-office.museumwnf.org
-
-# Run commands remotely
-Invoke-Command -Session $session { Get-ChildItem C:\mwnf-server\github-apps\production }
-
-# Close when done
+$session = New-PSSession -ComputerName '<pssession_computer_name>'
+Invoke-Command -Session $session { <command> }
 Remove-PSSession $session
 ```
 
-The `server-inspector` agent provides read-only inspection capabilities via this PSSession pattern.
+The `server-inspector-windows` agent provides read-only inspection capabilities through this PSSession pattern.
 
-## Two Instances on the Server
+## Two Inventory Instances
 
-| Instance | Path | Purpose |
-|----------|------|---------|
-| **Production** | `C:\mwnf-server\github-apps\production\inventory-app` (symlink) | Deployed by CI/CD, serves the web app |
-| **Temp** | `C:\mwnf-server\github-apps\temp\inventory-app` | Full repo clone for running scripts/importer |
+| Instance | Purpose |
+|----------|---------|
+| Production | Deployed artifact, serves the web app, follows the blue-green symlink pattern. |
+| Temp | Full repository clone for manual scripts and importer tasks that are absent from the production artifact. |
 
-**Warning:** The temp instance shares the same database as production. Destructive commands (`db:wipe`, `migrate:refresh`) affect live data.
+The temp instance may share the same database as production. Destructive commands affect live data and require explicit user confirmation.
 
-## Blue-Green Deployment (Symlink Swap)
+## Blue-Green Deployment Pattern
 
-The `deploy.yml` workflow uses atomic symlink swapping for zero-downtime deployment:
+The Windows deployment workflow uses atomic symlink swapping for zero-downtime deployment:
 
-```
-C:\mwnf-server\github-apps\production\
-├── inventory-app          → staging-20260415-143022  (current symlink)
-├── staging-20260415-143022\  (current release)
-├── staging-20260410-091500\  (previous release)
-├── staging-20260405-120000\  (oldest kept)
-└── shared-storage\           (persists across deployments)
-    └── app\
-        ├── private\
-        ├── public\
-        └── public\images\
-```
+1. Extract the release artifact into a timestamped staging directory under the configured production deployment root.
+2. Link persistent storage into the staged release.
+3. Rename the current production symlink to a temporary backup name.
+4. Rename the new staging symlink to the production symlink.
+5. On failure, roll back by restoring the backup symlink.
+6. Clean up the temporary backup and prune old staging directories.
 
-The swap sequence:
-1. Extract release into `staging-<timestamp>/`
-2. Symlink `staging-<timestamp>/storage/app` → `shared-storage/app`
-3. Rename current `inventory-app` symlink to `inventory-app_swap` (backup)
-4. Rename new temp symlink to `inventory-app` (atomic swap)
-5. On failure: roll back by renaming `inventory-app_swap` back
-6. Cleanup: remove `_swap` symlink, prune old staging dirs (keep last 3)
+Never bypass this pattern with direct file replacement in the production directory.
 
 ## Deployment Flow
 
-```
-Manual trigger (workflow_dispatch) with release tag
-    │
-    ▼
-deploy.yml — runs on [self-hosted, windows] (SVR-MWNF runner)
-    │
-    ├── download job
-    │   Download release asset (inventory-app.zip) from GitHub Release
-    │   Extract to runner temp, copy to staging-<timestamp>
-    │
-    ├── down job
-    │   php artisan down --retry=120
-    │
-    ├── deploy job
-    │   Setup shared storage symlink (storage/app → shared-storage/app)
-    │   Atomic symlink swap (blue-green)
-    │
-    ├── configure job
-    │   Generate .env from .env.example + GitHub Environment variables
-    │   php artisan migrate --force
-    │   php artisan permissions:sync --production
-    │   php artisan config:cache, route:cache, view:cache
-    │
-    ├── up job
-    │   php artisan up
-    │
-    └── intendance job
-        Cleanup swap symlinks
-        Prune old staging dirs (keep last 3)
-```
+The Windows deployment workflow:
 
-## GitHub Actions Runner
+1. Downloads the release asset created by the build workflow.
+2. Extracts it to the runner temp area and copies it to a staging directory.
+3. Puts Laravel into maintenance mode.
+4. Sets up shared storage symlinks.
+5. Performs the atomic symlink swap.
+6. Generates `.env` from template plus GitHub Environment variables and secrets.
+7. Runs `php artisan migrate --force`.
+8. Runs permission synchronization and Laravel cache warmup.
+9. Brings Laravel out of maintenance mode.
+10. Cleans up swap symlinks and old releases.
 
-| Property | Value |
-|----------|-------|
-| Install path | `C:\mwnf-server\software\github\actions-runner` |
-| Windows service | `actions.runner.metanull-inventory-app.SVR-MWNF` |
-| Agent name | `SVR-MWNF` |
-| Runs as | `NT AUTHORITY\NETWORK SERVICE` |
-| Scope | Repo-level self-hosted runner |
+## GitHub Environment
 
-## GitHub Environment: MWNF-SVR
+Deployment configuration belongs in the configured GitHub Environment for the Windows target.
 
-All deployment configuration is stored in the **`MWNF-SVR`** GitHub Environment (Settings → Environments).
+Use GitHub Environment variables for non-secret deployment settings such as PHP path, webserver symlink path, app name, app environment, app URL, database host, and service user.
 
-### Variables
+Use GitHub Environment secrets for production secrets such as Laravel app key and database credentials.
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `PHP_PATH` | `C:\Program Files\PHP\php.exe` | Path to PHP executable |
-| `WEBSERVER_PATH` | `C:\Apache24\htdocs\inventory-app` | Production symlink path |
-| `APP_NAME` | `inventory-app` | Application display name |
-| `APP_ENV` | `production` | Laravel environment |
-| `APP_DEBUG` | `false` | Debug mode |
-| `APP_URL` | `http://localhost` | Application URL |
-| `DB_CONNECTION` | `mysql` | Database driver |
-| `DB_HOST` | `127.0.0.1` | Database host |
-| `DB_PORT` | `3306` | Database port |
-| `APACHE_SERVICE_USER` | `SYSTEM` | Apache service user |
-
-### Secrets
-
-| Secret | Purpose |
-|--------|---------|
-| `APP_KEY` | Laravel encryption key |
-| `MARIADB_DATABASE` | Database name |
-| `MARIADB_USER` | Database username |
-| `MARIADB_SECRET` | Database password |
+Never commit production secrets to Git. Never expose internal server paths or credentials in logs; mask sensitive values.
 
 ## Deployment Module
 
@@ -160,31 +118,27 @@ The `scripts/InventoryApp.Deployment/` PowerShell module provides reusable deplo
 
 | Function | Purpose |
 |----------|---------|
-| `Test-SystemPrerequisites` | Verify PHP, paths, permissions |
-| `Test-DeploymentPackage` | Validate extracted release |
-| `New-StagingDirectory` | Create timestamped staging dir |
-| `Remove-OldStagingDirectories` | Prune old releases |
-| `New-StorageSymlink` | Link shared storage into release |
-| `Swap-WebserverSymlink` | Atomic symlink swap |
-| `Remove-SwapBackup` | Cleanup backup symlink |
-| `New-EnvironmentFile` | Generate .env from template |
-| `Invoke-LaravelSetup` | Run migrations, caches |
-| `Invoke-LaravelDown` | Maintenance mode |
-| `Deploy-Application` | Full orchestration |
+| `Test-SystemPrerequisites` | Verify PHP, paths, and permissions. |
+| `Test-DeploymentPackage` | Validate extracted release. |
+| `New-StagingDirectory` | Create timestamped staging directory. |
+| `Remove-OldStagingDirectories` | Prune old releases. |
+| `New-StorageSymlink` | Link shared storage into release. |
+| `Swap-WebserverSymlink` | Atomic symlink swap. |
+| `Remove-SwapBackup` | Cleanup backup symlink. |
+| `New-EnvironmentFile` | Generate `.env` from template. |
+| `Invoke-LaravelSetup` | Run migrations and cache commands. |
+| `Invoke-LaravelDown` | Maintenance mode. |
+| `Deploy-Application` | Full orchestration. |
 
 ## Apache Configuration
 
-- **Backend vhost**: `C:\mwnf-server\github-apps\production\inventory.museumwnf.org.conf`
-- **Vhost symlink**: `C:\mwnf-server\configuration\current\mwnf\inventory.museumwnf.org.conf`
-- **DocumentRoot**: `C:/mwnf-server/github-apps/production/inventory-app/public`
-- **Backend port**: 8443 (SSL), proxied from 443 by the reverse proxy
-- **Reverse proxy entry**: `C:\mwnf-server\reverse-proxy\Apache24\conf\extra\httpd-vhosts.conf`
+When inspecting or editing Apache paths, resolve concrete paths from `.copilot/local/server-windows.md` first. Do not hard-code a contributor's server root or private vhost paths in shared instructions.
 
 ## Forbidden
 
-- **NEVER modify Apache config, restart services, or install software in deploy scripts or workflows.** Infrastructure changes belong in manual provisioning only.
-- **NEVER run destructive database commands** (`migrate:fresh`, `migrate:refresh`, `db:wipe`) in production — only `migrate --force`.
-- **NEVER commit production secrets to Git.** Use GitHub Environment secrets/variables.
-- **NEVER bypass the blue-green symlink pattern.** Direct file replacement in the production directory breaks rollback.
-- **NEVER use the temp instance path in deploy.yml.** It is for manual script execution only.
-- **NEVER expose internal server paths or credentials in logs.** Use `::add-mask::` for sensitive values.
+- Never modify Apache config, restart services, or install software in deploy scripts or workflows. Infrastructure changes belong in manual provisioning only.
+- Never run destructive database commands (`migrate:fresh`, `migrate:refresh`, `db:wipe`) in production workflows. Use `migrate --force` only.
+- Never commit production secrets to Git. Use GitHub Environment secrets and variables.
+- Never bypass the blue-green symlink pattern.
+- Never use the temp instance path in `deploy.yml`; it is for manual script execution only.
+- Never expose internal server paths or credentials in logs.

--- a/.gitignore
+++ b/.gitignore
@@ -159,5 +159,10 @@ VERSION
 # Custom Up/Down Commands' generated files
 public/down.lock
 
+# Contributor-local Copilot configuration
+.copilot/local/*
+!.copilot/local/README.md
+!.copilot/local/*.template.md
+
 # local git modules
 .legacy-database


### PR DESCRIPTION
Rework the legacy importer to establish a consistent behavior model across all targets, ensuring clear execution contracts and diagnostics. Update deployment instructions for local configurations, enhancing clarity and structure for contributors. Add templates for local configuration files to streamline setup processes.

What changed:

- Added README.md explaining the pattern.
- Added committed templates:
  - legacy-importer.template.md
  - server-windows.template.md
  - server-ovh.template.md
  - php-test-runner.template.md
  - legacy-link-resolver.template.md
- Created your ignored local files from the existing hard-coded values:
  - legacy-importer.md
  - server-windows.md
  - server-ovh.md
  - php-test-runner.md
  - legacy-link-resolver.md
- Updated .gitignore so contributor-local files are ignored, while templates and README remain tracked.

Updated shared agent/instruction files to read local config first and ask only if missing/incomplete:

- legacy-importer.agent.md
- server-inspector-windows.agent.md
- server-inspector-ovh.agent.md
- php-test-runner.agent.md
- legacy-link-resolver.agent.md
- laravel-expert-agent.agent.md
- filament-admin-expert.agent.md
- server-setup-windows.instructions.md
- server-setup-ovh.instructions.md
- php.instructions.md
- copilot-instructions.md
