### PR TITLE
Implement auth snapshot and restore for database resets

### DIFF
--- a/.github/agents/legacy-importer.agent.md
+++ b/.github/agents/legacy-importer.agent.md
@@ -174,12 +174,14 @@ npm run build
 
 # Stage 4: reset local target database.
 Set-Location '<local_laravel_root>'
+php artisan auth:snapshot auth-snapshots/pre-import.json.enc --force
 php artisan db:wipe --force
 php artisan migrate --force
 php artisan db:seed --class=MinimalDatabaseSeeder --force
-php artisan permission:sync
+php artisan permissions:sync
+php artisan auth:restore auth-snapshots/pre-import.json.enc --force
 
-# Stage 5: create users from the contributor-local user table.
+# Stage 5: create users from the contributor-local user table only if no auth snapshot exists.
 php artisan user:create <email> <password_or_policy>
 php artisan user:email-verification <email> verify
 php artisan user:assign-role <email> "<role>"
@@ -224,13 +226,15 @@ Invoke-Command -Session $session {
 # Stage 4: reset production target database using the production app instance.
 Invoke-Command -Session $session {
     Set-Location '<production_app_root>'
+    php artisan auth:snapshot auth-snapshots/pre-import.json.enc --force
     php artisan db:wipe --force
     php artisan migrate --force
     php artisan db:seed --class=MinimalDatabaseSeeder --force
-    php artisan permission:sync
+    php artisan permissions:sync --production
+    php artisan auth:restore auth-snapshots/pre-import.json.enc --force
 }
 
-# Stage 5: create users from the contributor-local user table.
+# Stage 5: create users from the contributor-local user table only if no auth snapshot exists.
 Invoke-Command -Session $session {
     Set-Location '<production_app_root>'
     php artisan user:create <email> <password_or_policy>
@@ -284,12 +288,14 @@ npm install
 npm run build
 
 # Stage 4: reset VPS target database through SSH.
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan auth:snapshot auth-snapshots/pre-import.json.enc --force'
 ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan db:wipe --force'
 ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan migrate --force'
 ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan db:seed --class=MinimalDatabaseSeeder --force'
-ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan permission:sync'
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan permissions:sync --production'
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan auth:restore auth-snapshots/pre-import.json.enc --force'
 
-# Stage 5: create users from the contributor-local user table.
+# Stage 5: create users from the contributor-local user table only if no auth snapshot exists.
 ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan user:create <email> <password_or_policy>'
 ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan user:email-verification <email> verify'
 ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan user:assign-role <email> "<role>"'

--- a/app/Console/Commands/CreateAuthSnapshot.php
+++ b/app/Console/Commands/CreateAuthSnapshot.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use JsonException;
+use Spatie\Permission\PermissionRegistrar;
+
+class CreateAuthSnapshot extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'auth:snapshot
+                            {path? : Local disk path for the encrypted snapshot}
+                            {--force : Overwrite an existing snapshot file}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create an encrypted snapshot of user accounts, MFA setup, role assignments, direct permissions, and API tokens.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $path = $this->snapshotPath();
+
+        if (Storage::disk('local')->exists($path) && ! $this->option('force')) {
+            $this->error("Snapshot already exists at local disk path [{$path}]. Use --force to overwrite it.");
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $payload = json_encode($this->snapshotPayload(), JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            $this->error('Unable to encode auth snapshot: '.$exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        if (! Storage::disk('local')->put($path, Crypt::encryptString($payload))) {
+            $this->error("Unable to write auth snapshot to local disk path [{$path}].");
+
+            return Command::FAILURE;
+        }
+
+        $this->info('Auth snapshot created successfully.');
+        $this->line("Local disk path: {$path}");
+        $this->line('The snapshot is encrypted with the current Laravel APP_KEY. The APP_KEY is not stored in the snapshot.');
+
+        return Command::SUCCESS;
+    }
+
+    protected function snapshotPath(): string
+    {
+        $path = $this->argument('path');
+
+        if (is_string($path) && $path !== '') {
+            return $path;
+        }
+
+        return 'auth-snapshots/auth-snapshot-'.now()->format('Ymd-His').'.json.enc';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function snapshotPayload(): array
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        return [
+            'version' => 1,
+            'created_at' => now()->toISOString(),
+            'tables' => [
+                'users' => $this->rows('users'),
+                'role_assignments' => $this->roleAssignments(),
+                'permission_assignments' => $this->permissionAssignments(),
+                'personal_access_tokens' => $this->personalAccessTokens(),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function rows(string $table): array
+    {
+        if (! Schema::hasTable($table)) {
+            return [];
+        }
+
+        return DB::table($table)
+            ->orderBy('id')
+            ->get()
+            ->map(fn (object $row): array => (array) $row)
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function roleAssignments(): array
+    {
+        $tables = config('permission.table_names');
+        $columns = config('permission.column_names');
+        $modelKey = $columns['model_morph_key'] ?? 'model_id';
+        $roleKey = $columns['role_pivot_key'] ?? 'role_id';
+
+        if (! Schema::hasTable($tables['model_has_roles']) || ! Schema::hasTable($tables['roles'])) {
+            return [];
+        }
+
+        return DB::table($tables['model_has_roles'].' as assignment')
+            ->join($tables['roles'].' as role', 'role.id', '=', 'assignment.'.$roleKey)
+            ->where('assignment.model_type', User::class)
+            ->orderBy('assignment.'.$modelKey)
+            ->orderBy('role.name')
+            ->get([
+                'role.name as name',
+                'role.guard_name as guard_name',
+                'assignment.model_type as model_type',
+                'assignment.'.$modelKey.' as model_id',
+            ])
+            ->map(fn (object $row): array => (array) $row)
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function permissionAssignments(): array
+    {
+        $tables = config('permission.table_names');
+        $columns = config('permission.column_names');
+        $modelKey = $columns['model_morph_key'] ?? 'model_id';
+        $permissionKey = $columns['permission_pivot_key'] ?? 'permission_id';
+
+        if (! Schema::hasTable($tables['model_has_permissions']) || ! Schema::hasTable($tables['permissions'])) {
+            return [];
+        }
+
+        return DB::table($tables['model_has_permissions'].' as assignment')
+            ->join($tables['permissions'].' as permission', 'permission.id', '=', 'assignment.'.$permissionKey)
+            ->where('assignment.model_type', User::class)
+            ->orderBy('assignment.'.$modelKey)
+            ->orderBy('permission.name')
+            ->get([
+                'permission.name as name',
+                'permission.guard_name as guard_name',
+                'assignment.model_type as model_type',
+                'assignment.'.$modelKey.' as model_id',
+            ])
+            ->map(fn (object $row): array => (array) $row)
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function personalAccessTokens(): array
+    {
+        if (! Schema::hasTable('personal_access_tokens')) {
+            return [];
+        }
+
+        return DB::table('personal_access_tokens')
+            ->where('tokenable_type', User::class)
+            ->orderBy('id')
+            ->get()
+            ->map(fn (object $row): array => (array) $row)
+            ->all();
+    }
+}

--- a/app/Console/Commands/RestoreAuthSnapshot.php
+++ b/app/Console/Commands/RestoreAuthSnapshot.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use JsonException;
+use Spatie\Permission\PermissionRegistrar;
+
+class RestoreAuthSnapshot extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'auth:restore
+                            {path : Local disk path to the encrypted snapshot}
+                            {--force : Replace existing user accounts and user-owned auth records}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Restore user accounts, MFA setup, role assignments, direct permissions, and API tokens from an encrypted auth snapshot.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $path = $this->argument('path');
+
+        if (! is_string($path) || $path === '' || ! Storage::disk('local')->exists($path)) {
+            $this->error("Auth snapshot was not found on the local disk at [{$path}].");
+
+            return Command::FAILURE;
+        }
+
+        if (User::query()->exists() && ! $this->option('force')) {
+            $this->error('Users already exist. Re-run with --force to replace existing user accounts and user-owned auth records.');
+
+            return Command::FAILURE;
+        }
+
+        $payload = $this->readSnapshot($path);
+
+        if ($payload === null) {
+            return Command::FAILURE;
+        }
+
+        if (($payload['version'] ?? null) !== 1) {
+            $this->error('Unsupported auth snapshot version.');
+
+            return Command::FAILURE;
+        }
+
+        $tables = $payload['tables'] ?? [];
+
+        try {
+            DB::transaction(function () use ($tables): void {
+                Schema::disableForeignKeyConstraints();
+
+                try {
+                    $this->clearUserAuthRecords();
+                    $this->restoreRows('users', Arr::get($tables, 'users', []));
+                    $this->restoreRoleAssignments(Arr::get($tables, 'role_assignments', []));
+                    $this->restorePermissionAssignments(Arr::get($tables, 'permission_assignments', []));
+                    $this->restoreRows('personal_access_tokens', Arr::get($tables, 'personal_access_tokens', []));
+                } finally {
+                    Schema::enableForeignKeyConstraints();
+                }
+            });
+        } catch (\Throwable $exception) {
+            $this->error('Unable to restore auth snapshot: '.$exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $this->info('Auth snapshot restored successfully.');
+        $this->line('Restored users: '.count(Arr::get($tables, 'users', [])));
+        $this->line('Restored role assignments: '.count(Arr::get($tables, 'role_assignments', [])));
+        $this->line('Restored direct permission assignments: '.count(Arr::get($tables, 'permission_assignments', [])));
+        $this->line('Restored personal access tokens: '.count(Arr::get($tables, 'personal_access_tokens', [])));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function readSnapshot(string $path): ?array
+    {
+        try {
+            $contents = Storage::disk('local')->get($path);
+
+            if (! is_string($contents)) {
+                $this->error("Unable to read auth snapshot from local disk path [{$path}].");
+
+                return null;
+            }
+
+            $decrypted = Crypt::decryptString($contents);
+
+            return json_decode($decrypted, true, 512, JSON_THROW_ON_ERROR);
+        } catch (DecryptException) {
+            $this->error('Unable to decrypt auth snapshot. Verify that this app uses the same APP_KEY that created the snapshot.');
+        } catch (JsonException $exception) {
+            $this->error('Unable to decode auth snapshot: '.$exception->getMessage());
+        }
+
+        return null;
+    }
+
+    protected function clearUserAuthRecords(): void
+    {
+        $tables = config('permission.table_names');
+
+        $this->deleteUserModelRows($tables['model_has_roles']);
+        $this->deleteUserModelRows($tables['model_has_permissions']);
+
+        if (Schema::hasTable('personal_access_tokens')) {
+            DB::table('personal_access_tokens')
+                ->where('tokenable_type', User::class)
+                ->delete();
+        }
+
+        User::query()->delete();
+    }
+
+    protected function deleteUserModelRows(string $table): void
+    {
+        if (! Schema::hasTable($table)) {
+            return;
+        }
+
+        DB::table($table)
+            ->where('model_type', User::class)
+            ->delete();
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $rows
+     */
+    protected function restoreRows(string $table, array $rows): void
+    {
+        if ($rows === [] || ! Schema::hasTable($table)) {
+            return;
+        }
+
+        $columns = Schema::getColumnListing($table);
+
+        foreach ($rows as $row) {
+            DB::table($table)->insert(Arr::only($row, $columns));
+        }
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $assignments
+     */
+    protected function restoreRoleAssignments(array $assignments): void
+    {
+        if ($assignments === []) {
+            return;
+        }
+
+        $tables = config('permission.table_names');
+        $columns = config('permission.column_names');
+        $modelKey = $columns['model_morph_key'] ?? 'model_id';
+        $roleKey = $columns['role_pivot_key'] ?? 'role_id';
+
+        foreach ($assignments as $assignment) {
+            $role = DB::table($tables['roles'])
+                ->where('name', $assignment['name'])
+                ->where('guard_name', $assignment['guard_name'])
+                ->first();
+
+            if ($role === null) {
+                throw new \RuntimeException("Role [{$assignment['name']}] does not exist. Run php artisan permissions:sync before restoring the snapshot.");
+            }
+
+            DB::table($tables['model_has_roles'])->insert([
+                $roleKey => $role->id,
+                'model_type' => $assignment['model_type'],
+                $modelKey => $assignment['model_id'],
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $assignments
+     */
+    protected function restorePermissionAssignments(array $assignments): void
+    {
+        if ($assignments === []) {
+            return;
+        }
+
+        $tables = config('permission.table_names');
+        $columns = config('permission.column_names');
+        $modelKey = $columns['model_morph_key'] ?? 'model_id';
+        $permissionKey = $columns['permission_pivot_key'] ?? 'permission_id';
+
+        foreach ($assignments as $assignment) {
+            $permission = DB::table($tables['permissions'])
+                ->where('name', $assignment['name'])
+                ->where('guard_name', $assignment['guard_name'])
+                ->first();
+
+            if ($permission === null) {
+                throw new \RuntimeException("Permission [{$assignment['name']}] does not exist. Run php artisan permissions:sync before restoring the snapshot.");
+            }
+
+            DB::table($tables['model_has_permissions'])->insert([
+                $permissionKey => $permission->id,
+                'model_type' => $assignment['model_type'],
+                $modelKey => $assignment['model_id'],
+            ]);
+        }
+    }
+}

--- a/docs/deployment/command-line-user-management.md
+++ b/docs/deployment/command-line-user-management.md
@@ -176,9 +176,18 @@ php artisan permission:cache-reset
 # Seed roles and permissions (idempotent - safe for production)
 php artisan db:seed --class=RolePermissionSeeder
 
+# Create an encrypted auth snapshot before a destructive reset
+php artisan auth:snapshot auth-snapshots/pre-reset.json.enc --force
+
 # Full database reset and seed (CAUTION: Deletes all data)
 php artisan migrate:fresh --seed
+
+# Restore the snapshot after migrations and permission sync
+php artisan permissions:sync --production
+php artisan auth:restore auth-snapshots/pre-reset.json.enc --force
 ```
+
+Auth snapshots preserve user accounts, MFA setup, role assignments, direct permissions, and API tokens. The snapshot is encrypted with Laravel's current `APP_KEY`, but the `APP_KEY` is not stored in the file. Restore the snapshot only into an application that uses the same `APP_KEY`.
 
 ## Common Use Cases
 

--- a/docs/deployment/development-setup.md
+++ b/docs/deployment/development-setup.md
@@ -322,8 +322,17 @@ npm run type-check
 ### 5.3 Database Management
 
 ```bash
-# Reset database
-php artisan migrate:fresh --seed
+# Snapshot auth before a destructive reset
+php artisan auth:snapshot auth-snapshots/pre-reset.json.enc --force
+
+# Reset database and run migrations
+php artisan db:wipe --force
+php artisan migrate --force
+php artisan db:seed --class=MinimalDatabaseSeeder --force
+php artisan permissions:sync
+
+# Restore users, MFA setup, role assignments, direct permissions, and API tokens
+php artisan auth:restore auth-snapshots/pre-reset.json.enc --force
 
 # Create new migration
 php artisan make:migration create_example_table

--- a/scripts/Reset-Database.ps1
+++ b/scripts/Reset-Database.ps1
@@ -1,26 +1,29 @@
 & {
+	function Invoke-Artisan {
+		param(
+			[Parameter(Mandatory = $true)]
+			[string[]]$Arguments
+		)
+
+		php artisan @Arguments
+		if ($LASTEXITCODE -ne 0) {
+			throw "Artisan command failed: php artisan $($Arguments -join ' ')"
+		}
+	}
+
 	Write-Warning "This will WIPE THE ENTIRE DATABASE!"
 	if ( 'I know what I do!' -eq (Read-Host -Prompt 'Type "I know what I do!" to continue...')) {
-		$Managers = @('havelangep@hotmail.com')
-		$Users = @('havelangep@hotmail.com', 'havelangep@gmail.com', 'evaplaysviolin@gmail.com', 'eva@museumwnf.net', 'management@museumwnf.net')
 		$Directory = Split-Path -Parent $PSScriptRoot
+		$SnapshotPath = 'auth-snapshots/reset-database-latest.json.enc'
 
 		if ((Resolve-Path $Directory -ErrorAction Continue)) {
 			Set-Location $Directory
-			php artisan db:wipe --force
-			php artisan migrate:refresh --force
-			php artisan db:seed --class=MinimalDatabaseSeeder --force
-			php artisan permission:sync
-
-			$Users |% {
-				php artisan user:create $_ $_
-				php artisan user:email-verification $_ verify
-				if ($Managers -contains $_) {
-					php artisan user:assign-role $_ 'Manager of Users'
-				} else {
-					php artisan user:assign-role $_ 'Regular User'
-				}
-			}
+			Invoke-Artisan @('auth:snapshot', $SnapshotPath, '--force')
+			Invoke-Artisan @('db:wipe', '--force')
+			Invoke-Artisan @('migrate', '--force')
+			Invoke-Artisan @('db:seed', '--class=MinimalDatabaseSeeder', '--force')
+			Invoke-Artisan @('permissions:sync')
+			Invoke-Artisan @('auth:restore', $SnapshotPath, '--force')
 		}
 	} else {
 		Write-Information 'Cancelled'

--- a/scripts/importer/README.md
+++ b/scripts/importer/README.md
@@ -194,10 +194,15 @@ Business logic is written once in transformers:
 
 The importer is designed to run as part of a complete database initialization:
 
-1. **Wipe database** - Create or Empty the database schema (e.g. `artisan db:wipe; artisan migrate`)
-2. **Run the importer** - Import legacy data from mwnf3 database
-3. **Glossary resync** - Re-link glossary spellings to imported translations (required post-import step)
-4. **Done** - Database is ready with both reference and legacy data
+1. **Create auth snapshot** - Preserve user accounts, MFA setup, role assignments, direct permissions, and API tokens (`php artisan auth:snapshot auth-snapshots/pre-import.json.enc --force`)
+2. **Wipe database** - Create or empty the database schema (e.g. `php artisan db:wipe --force; php artisan migrate --force`)
+3. **Seed and sync permissions** - Run `php artisan db:seed --class=MinimalDatabaseSeeder --force` and `php artisan permissions:sync`
+4. **Restore auth snapshot** - Restore users after migrations and permission sync (`php artisan auth:restore auth-snapshots/pre-import.json.enc --force`)
+5. **Run the importer** - Import legacy data from mwnf3 database
+6. **Glossary resync** - Re-link glossary spellings to imported translations (required post-import step)
+7. **Done** - Database is ready with both reference and legacy data
+
+Auth snapshots are encrypted with Laravel's current `APP_KEY`; the key is not written into the snapshot file. Restore the snapshot only into an application using the same `APP_KEY`, because Fortify MFA secrets are encrypted with that key.
 
 All operations are logged to timestamped files in the `logs/` directory for later review.
 

--- a/tests/Console/AuthSnapshotCommandTest.php
+++ b/tests/Console/AuthSnapshotCommandTest.php
@@ -52,8 +52,8 @@ class AuthSnapshotCommandTest extends TestCase
     {
         Storage::fake('local');
 
-        $role = Role::create(['name' => 'Snapshot Role', 'guard_name' => 'web']);
-        $permission = Permission::create(['name' => PermissionEnum::ACCESS_ADMIN_PANEL->value, 'guard_name' => 'web']);
+        $role = Role::firstOrCreate(['name' => 'Snapshot Role', 'guard_name' => 'web']);
+        $permission = Permission::firstOrCreate(['name' => PermissionEnum::ACCESS_ADMIN_PANEL->value, 'guard_name' => 'web']);
         $user = User::factory()->create([
             'email' => 'restore-user@example.com',
             'two_factor_secret' => encrypt('JBSWY3DPEHPK3PXP'),

--- a/tests/Console/AuthSnapshotCommandTest.php
+++ b/tests/Console/AuthSnapshotCommandTest.php
@@ -10,11 +10,18 @@ use Illuminate\Support\Facades\Storage;
 use Laravel\Sanctum\PersonalAccessToken;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
 use Tests\TestCase;
 
 class AuthSnapshotCommandTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+    }
 
     public function test_snapshot_is_encrypted_and_does_not_contain_app_key_or_plaintext_user_data(): void
     {

--- a/tests/Console/AuthSnapshotCommandTest.php
+++ b/tests/Console/AuthSnapshotCommandTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Console;
+
+use App\Enums\Permission as PermissionEnum;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\PersonalAccessToken;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class AuthSnapshotCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_snapshot_is_encrypted_and_does_not_contain_app_key_or_plaintext_user_data(): void
+    {
+        Storage::fake('local');
+
+        User::factory()->create([
+            'email' => 'secure-user@example.com',
+            'two_factor_secret' => encrypt('JBSWY3DPEHPK3PXP'),
+            'two_factor_recovery_codes' => encrypt(json_encode(['alpha-code'])),
+            'two_factor_confirmed_at' => now(),
+        ]);
+
+        $this->artisan('auth:snapshot', [
+            'path' => 'auth-snapshots/test.json.enc',
+        ])->assertExitCode(0);
+
+        Storage::disk('local')->assertExists('auth-snapshots/test.json.enc');
+
+        $contents = Storage::disk('local')->get('auth-snapshots/test.json.enc');
+
+        $this->assertStringNotContainsString(config('app.key'), $contents);
+        $this->assertStringNotContainsString('secure-user@example.com', $contents);
+        $this->assertStringNotContainsString('JBSWY3DPEHPK3PXP', $contents);
+        $this->assertNotSame('', $contents);
+    }
+
+    public function test_restore_recreates_users_mfa_roles_direct_permissions_and_tokens(): void
+    {
+        Storage::fake('local');
+
+        $role = Role::create(['name' => 'Snapshot Role', 'guard_name' => 'web']);
+        $permission = Permission::create(['name' => PermissionEnum::ACCESS_ADMIN_PANEL->value, 'guard_name' => 'web']);
+        $user = User::factory()->create([
+            'email' => 'restore-user@example.com',
+            'two_factor_secret' => encrypt('JBSWY3DPEHPK3PXP'),
+            'two_factor_recovery_codes' => encrypt(json_encode(['alpha-code', 'beta-code'])),
+            'two_factor_confirmed_at' => now(),
+        ]);
+
+        $user->assignRole($role);
+        $user->givePermissionTo($permission);
+        $token = $user->createToken('Snapshot token', ['view-data'])->accessToken;
+
+        $this->artisan('auth:snapshot', [
+            'path' => 'auth-snapshots/test.json.enc',
+        ])->assertExitCode(0);
+
+        DB::table('model_has_roles')->where('model_type', User::class)->delete();
+        DB::table('model_has_permissions')->where('model_type', User::class)->delete();
+        PersonalAccessToken::query()->delete();
+        User::query()->delete();
+
+        $this->assertDatabaseMissing('users', ['email' => 'restore-user@example.com']);
+
+        $this->artisan('auth:restore', [
+            'path' => 'auth-snapshots/test.json.enc',
+        ])->assertExitCode(0);
+
+        $restoredUser = User::where('email', 'restore-user@example.com')->firstOrFail();
+
+        $this->assertSame($user->id, $restoredUser->id);
+        $this->assertTrue($restoredUser->hasEnabledTwoFactorAuthentication());
+        $this->assertSame('JBSWY3DPEHPK3PXP', decrypt($restoredUser->two_factor_secret));
+        $this->assertTrue($restoredUser->hasRole('Snapshot Role'));
+        $this->assertTrue($restoredUser->hasDirectPermission(PermissionEnum::ACCESS_ADMIN_PANEL->value));
+        $this->assertDatabaseHas('personal_access_tokens', [
+            'id' => $token->id,
+            'tokenable_type' => User::class,
+            'tokenable_id' => $restoredUser->id,
+            'name' => 'Snapshot token',
+        ]);
+    }
+
+    public function test_restore_requires_force_when_users_already_exist(): void
+    {
+        Storage::fake('local');
+
+        User::factory()->create(['email' => 'snapshot-user@example.com']);
+
+        $this->artisan('auth:snapshot', [
+            'path' => 'auth-snapshots/test.json.enc',
+        ])->assertExitCode(0);
+
+        $this->artisan('auth:restore', [
+            'path' => 'auth-snapshots/test.json.enc',
+        ])
+            ->expectsOutput('Users already exist. Re-run with --force to replace existing user accounts and user-owned auth records.')
+            ->assertExitCode(1);
+    }
+
+    public function test_restore_with_force_replaces_existing_user_accounts(): void
+    {
+        Storage::fake('local');
+
+        User::factory()->create(['email' => 'snapshot-user@example.com']);
+
+        $this->artisan('auth:snapshot', [
+            'path' => 'auth-snapshots/test.json.enc',
+        ])->assertExitCode(0);
+
+        User::factory()->create(['email' => 'seeded-user@example.com']);
+
+        $this->artisan('auth:restore', [
+            'path' => 'auth-snapshots/test.json.enc',
+            '--force' => true,
+        ])->assertExitCode(0);
+
+        $this->assertDatabaseHas('users', ['email' => 'snapshot-user@example.com']);
+        $this->assertDatabaseMissing('users', ['email' => 'seeded-user@example.com']);
+    }
+
+    public function test_restore_fails_when_snapshot_cannot_be_decrypted(): void
+    {
+        Storage::fake('local');
+        Storage::disk('local')->put('auth-snapshots/invalid.json.enc', 'not-encrypted');
+
+        $this->artisan('auth:restore', [
+            'path' => 'auth-snapshots/invalid.json.enc',
+        ])
+            ->expectsOutput('Unable to decrypt auth snapshot. Verify that this app uses the same APP_KEY that created the snapshot.')
+            ->assertExitCode(1);
+    }
+}


### PR DESCRIPTION
Introduce commands to create and restore authentication snapshots, preserving user data during database resets. This enhancement ensures that user accounts, MFA setups, role assignments, direct permissions, and API tokens remain intact after destructive database operations.