### PR TITLE
Fix auth snapshots to use filesystem paths

### DIFF
--- a/.github/agents/legacy-importer.agent.md
+++ b/.github/agents/legacy-importer.agent.md
@@ -174,12 +174,13 @@ npm run build
 
 # Stage 4: reset local target database.
 Set-Location '<local_laravel_root>'
-php artisan auth:snapshot auth-snapshots/pre-import.json.enc --force
+$authSnapshotPath = Join-Path ([System.IO.Path]::GetTempPath()) 'inventory-auth-snapshots/pre-import.json.enc'
+php artisan auth:snapshot $authSnapshotPath --force
 php artisan db:wipe --force
 php artisan migrate --force
 php artisan db:seed --class=MinimalDatabaseSeeder --force
 php artisan permissions:sync
-php artisan auth:restore auth-snapshots/pre-import.json.enc --force
+php artisan auth:restore $authSnapshotPath --force
 
 # Stage 5: create users from the contributor-local user table only if no auth snapshot exists.
 php artisan user:create <email> <password_or_policy>
@@ -226,12 +227,13 @@ Invoke-Command -Session $session {
 # Stage 4: reset production target database using the production app instance.
 Invoke-Command -Session $session {
     Set-Location '<production_app_root>'
-    php artisan auth:snapshot auth-snapshots/pre-import.json.enc --force
+    $authSnapshotPath = Join-Path ([System.IO.Path]::GetTempPath()) 'inventory-auth-snapshots/pre-import.json.enc'
+    php artisan auth:snapshot $authSnapshotPath --force
     php artisan db:wipe --force
     php artisan migrate --force
     php artisan db:seed --class=MinimalDatabaseSeeder --force
     php artisan permissions:sync --production
-    php artisan auth:restore auth-snapshots/pre-import.json.enc --force
+    php artisan auth:restore $authSnapshotPath --force
 }
 
 # Stage 5: create users from the contributor-local user table only if no auth snapshot exists.
@@ -288,12 +290,12 @@ npm install
 npm run build
 
 # Stage 4: reset VPS target database through SSH.
-ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan auth:snapshot auth-snapshots/pre-import.json.enc --force'
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan auth:snapshot /tmp/inventory-auth-snapshots/pre-import.json.enc --force'
 ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan db:wipe --force'
 ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan migrate --force'
 ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan db:seed --class=MinimalDatabaseSeeder --force'
 ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan permissions:sync --production'
-ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan auth:restore auth-snapshots/pre-import.json.enc --force'
+ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan auth:restore /tmp/inventory-auth-snapshots/pre-import.json.enc --force'
 
 # Stage 5: create users from the contributor-local user table only if no auth snapshot exists.
 ssh <ovh_deploy_user>@<ovh_host> -i <ovh_deploy_ssh_key> 'cd <ovh_app_root> && php artisan user:create <email> <password_or_policy>'

--- a/app/Console/Commands/CreateAuthSnapshot.php
+++ b/app/Console/Commands/CreateAuthSnapshot.php
@@ -3,11 +3,12 @@
 namespace App\Console\Commands;
 
 use App\Models\User;
+use App\Support\AuthSnapshots\AuthSnapshotFile;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Facades\Storage;
 use JsonException;
 use Spatie\Permission\PermissionRegistrar;
 
@@ -19,7 +20,7 @@ class CreateAuthSnapshot extends Command
      * @var string
      */
     protected $signature = 'auth:snapshot
-                            {path? : Local disk path for the encrypted snapshot}
+                            {path? : Filesystem path for the encrypted snapshot. Defaults to the system temp directory}
                             {--force : Overwrite an existing snapshot file}';
 
     /**
@@ -36,8 +37,8 @@ class CreateAuthSnapshot extends Command
     {
         $path = $this->snapshotPath();
 
-        if (Storage::disk('local')->exists($path) && ! $this->option('force')) {
-            $this->error("Snapshot already exists at local disk path [{$path}]. Use --force to overwrite it.");
+        if (File::exists($path) && ! $this->option('force')) {
+            $this->error("Snapshot already exists at [{$path}]. Use --force to overwrite it.");
 
             return Command::FAILURE;
         }
@@ -50,14 +51,12 @@ class CreateAuthSnapshot extends Command
             return Command::FAILURE;
         }
 
-        if (! Storage::disk('local')->put($path, Crypt::encryptString($payload))) {
-            $this->error("Unable to write auth snapshot to local disk path [{$path}].");
-
+        if (! $this->writeSnapshot($path, Crypt::encryptString($payload))) {
             return Command::FAILURE;
         }
 
         $this->info('Auth snapshot created successfully.');
-        $this->line("Local disk path: {$path}");
+        $this->line("Snapshot path: {$path}");
         $this->line('The snapshot is encrypted with the current Laravel APP_KEY. The APP_KEY is not stored in the snapshot.');
 
         return Command::SUCCESS;
@@ -67,11 +66,36 @@ class CreateAuthSnapshot extends Command
     {
         $path = $this->argument('path');
 
-        if (is_string($path) && $path !== '') {
-            return $path;
+        return AuthSnapshotFile::resolvePath(is_string($path) ? $path : null);
+    }
+
+    protected function writeSnapshot(string $path, string $contents): bool
+    {
+        try {
+            $directory = dirname($path);
+
+            File::ensureDirectoryExists($directory, 0700, true);
+
+            if (! File::isDirectory($directory) || ! File::isWritable($directory)) {
+                $this->error("Auth snapshot directory is not writable: {$directory}");
+
+                return false;
+            }
+
+            if (File::put($path, $contents, true) === false) {
+                $this->error("Unable to write auth snapshot to [{$path}].");
+
+                return false;
+            }
+
+            File::chmod($path, 0600);
+        } catch (\Throwable $exception) {
+            $this->error('Unable to write auth snapshot: '.$exception->getMessage());
+
+            return false;
         }
 
-        return 'auth-snapshots/auth-snapshot-'.now()->format('Ymd-His').'.json.enc';
+        return true;
     }
 
     /**

--- a/app/Console/Commands/RestoreAuthSnapshot.php
+++ b/app/Console/Commands/RestoreAuthSnapshot.php
@@ -3,13 +3,14 @@
 namespace App\Console\Commands;
 
 use App\Models\User;
+use App\Support\AuthSnapshots\AuthSnapshotFile;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Facades\Storage;
 use JsonException;
 use Spatie\Permission\PermissionRegistrar;
 
@@ -21,7 +22,7 @@ class RestoreAuthSnapshot extends Command
      * @var string
      */
     protected $signature = 'auth:restore
-                            {path : Local disk path to the encrypted snapshot}
+                            {path : Filesystem path to the encrypted snapshot}
                             {--force : Replace existing user accounts and user-owned auth records}';
 
     /**
@@ -36,10 +37,11 @@ class RestoreAuthSnapshot extends Command
      */
     public function handle(): int
     {
-        $path = $this->argument('path');
+        $argumentPath = $this->argument('path');
+        $path = AuthSnapshotFile::resolvePath(is_string($argumentPath) ? $argumentPath : null);
 
-        if (! is_string($path) || $path === '' || ! Storage::disk('local')->exists($path)) {
-            $this->error("Auth snapshot was not found on the local disk at [{$path}].");
+        if (! File::isFile($path)) {
+            $this->error("Auth snapshot was not found at [{$path}].");
 
             return Command::FAILURE;
         }
@@ -101,10 +103,10 @@ class RestoreAuthSnapshot extends Command
     protected function readSnapshot(string $path): ?array
     {
         try {
-            $contents = Storage::disk('local')->get($path);
+            $contents = File::get($path);
 
             if (! is_string($contents)) {
-                $this->error("Unable to read auth snapshot from local disk path [{$path}].");
+                $this->error("Unable to read auth snapshot from [{$path}].");
 
                 return null;
             }
@@ -116,6 +118,8 @@ class RestoreAuthSnapshot extends Command
             $this->error('Unable to decrypt auth snapshot. Verify that this app uses the same APP_KEY that created the snapshot.');
         } catch (JsonException $exception) {
             $this->error('Unable to decode auth snapshot: '.$exception->getMessage());
+        } catch (\Throwable $exception) {
+            $this->error('Unable to read auth snapshot: '.$exception->getMessage());
         }
 
         return null;

--- a/app/Support/AuthSnapshots/AuthSnapshotFile.php
+++ b/app/Support/AuthSnapshots/AuthSnapshotFile.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Support\AuthSnapshots;
+
+final class AuthSnapshotFile
+{
+    public static function resolvePath(?string $path): string
+    {
+        $candidate = is_string($path) && $path !== ''
+            ? $path
+            : self::defaultPath();
+
+        if (self::isAbsolutePath($candidate)) {
+            return self::normalizePath($candidate);
+        }
+
+        return self::normalizePath(getcwd().DIRECTORY_SEPARATOR.$candidate);
+    }
+
+    public static function defaultPath(): string
+    {
+        return self::joinPath(
+            sys_get_temp_dir(),
+            'inventory-auth-snapshots',
+            'auth-snapshot-'.now()->format('Ymd-His').'.json.enc',
+        );
+    }
+
+    private static function isAbsolutePath(string $path): bool
+    {
+        return str_starts_with($path, '/')
+            || str_starts_with($path, '\\')
+            || preg_match('/^[A-Za-z]:[\\/]/', $path) === 1;
+    }
+
+    private static function joinPath(string $firstPart, string ...$parts): string
+    {
+        $path = rtrim($firstPart, '/\\');
+
+        foreach ($parts as $part) {
+            $path .= DIRECTORY_SEPARATOR.trim($part, '/\\');
+        }
+
+        return $path;
+    }
+
+    private static function normalizePath(string $path): string
+    {
+        return str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
+    }
+}

--- a/tests/Console/AuthSnapshotCommandTest.php
+++ b/tests/Console/AuthSnapshotCommandTest.php
@@ -6,7 +6,7 @@ use App\Enums\Permission as PermissionEnum;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\File;
 use Laravel\Sanctum\PersonalAccessToken;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
@@ -17,16 +17,28 @@ class AuthSnapshotCommandTest extends TestCase
 {
     use RefreshDatabase;
 
+    private string $snapshotDirectory;
+
     protected function setUp(): void
     {
         parent::setUp();
         app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        $this->snapshotDirectory = sys_get_temp_dir().DIRECTORY_SEPARATOR.'auth_snapshot_test_'.uniqid('', true);
+        File::ensureDirectoryExists($this->snapshotDirectory);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->snapshotDirectory) && File::isDirectory($this->snapshotDirectory)) {
+            File::deleteDirectory($this->snapshotDirectory);
+        }
+
+        parent::tearDown();
     }
 
     public function test_snapshot_is_encrypted_and_does_not_contain_app_key_or_plaintext_user_data(): void
     {
-        Storage::fake('local');
-
         User::factory()->create([
             'email' => 'secure-user@example.com',
             'two_factor_secret' => encrypt('JBSWY3DPEHPK3PXP'),
@@ -34,13 +46,15 @@ class AuthSnapshotCommandTest extends TestCase
             'two_factor_confirmed_at' => now(),
         ]);
 
+        $path = $this->snapshotPath('test.json.enc');
+
         $this->artisan('auth:snapshot', [
-            'path' => 'auth-snapshots/test.json.enc',
+            'path' => $path,
         ])->assertExitCode(0);
 
-        Storage::disk('local')->assertExists('auth-snapshots/test.json.enc');
+        $this->assertTrue(File::exists($path));
 
-        $contents = Storage::disk('local')->get('auth-snapshots/test.json.enc');
+        $contents = File::get($path);
 
         $this->assertStringNotContainsString(config('app.key'), $contents);
         $this->assertStringNotContainsString('secure-user@example.com', $contents);
@@ -50,8 +64,6 @@ class AuthSnapshotCommandTest extends TestCase
 
     public function test_restore_recreates_users_mfa_roles_direct_permissions_and_tokens(): void
     {
-        Storage::fake('local');
-
         $role = Role::firstOrCreate(['name' => 'Snapshot Role', 'guard_name' => 'web']);
         $permission = Permission::firstOrCreate(['name' => PermissionEnum::ACCESS_ADMIN_PANEL->value, 'guard_name' => 'web']);
         $user = User::factory()->create([
@@ -64,9 +76,10 @@ class AuthSnapshotCommandTest extends TestCase
         $user->assignRole($role);
         $user->givePermissionTo($permission);
         $token = $user->createToken('Snapshot token', ['view-data'])->accessToken;
+        $path = $this->snapshotPath('test.json.enc');
 
         $this->artisan('auth:snapshot', [
-            'path' => 'auth-snapshots/test.json.enc',
+            'path' => $path,
         ])->assertExitCode(0);
 
         DB::table('model_has_roles')->where('model_type', User::class)->delete();
@@ -77,7 +90,7 @@ class AuthSnapshotCommandTest extends TestCase
         $this->assertDatabaseMissing('users', ['email' => 'restore-user@example.com']);
 
         $this->artisan('auth:restore', [
-            'path' => 'auth-snapshots/test.json.enc',
+            'path' => $path,
         ])->assertExitCode(0);
 
         $restoredUser = User::where('email', 'restore-user@example.com')->firstOrFail();
@@ -97,16 +110,15 @@ class AuthSnapshotCommandTest extends TestCase
 
     public function test_restore_requires_force_when_users_already_exist(): void
     {
-        Storage::fake('local');
-
         User::factory()->create(['email' => 'snapshot-user@example.com']);
+        $path = $this->snapshotPath('test.json.enc');
 
         $this->artisan('auth:snapshot', [
-            'path' => 'auth-snapshots/test.json.enc',
+            'path' => $path,
         ])->assertExitCode(0);
 
         $this->artisan('auth:restore', [
-            'path' => 'auth-snapshots/test.json.enc',
+            'path' => $path,
         ])
             ->expectsOutput('Users already exist. Re-run with --force to replace existing user accounts and user-owned auth records.')
             ->assertExitCode(1);
@@ -114,18 +126,17 @@ class AuthSnapshotCommandTest extends TestCase
 
     public function test_restore_with_force_replaces_existing_user_accounts(): void
     {
-        Storage::fake('local');
-
         User::factory()->create(['email' => 'snapshot-user@example.com']);
+        $path = $this->snapshotPath('test.json.enc');
 
         $this->artisan('auth:snapshot', [
-            'path' => 'auth-snapshots/test.json.enc',
+            'path' => $path,
         ])->assertExitCode(0);
 
         User::factory()->create(['email' => 'seeded-user@example.com']);
 
         $this->artisan('auth:restore', [
-            'path' => 'auth-snapshots/test.json.enc',
+            'path' => $path,
             '--force' => true,
         ])->assertExitCode(0);
 
@@ -135,13 +146,51 @@ class AuthSnapshotCommandTest extends TestCase
 
     public function test_restore_fails_when_snapshot_cannot_be_decrypted(): void
     {
-        Storage::fake('local');
-        Storage::disk('local')->put('auth-snapshots/invalid.json.enc', 'not-encrypted');
+        $path = $this->snapshotPath('invalid.json.enc');
+
+        File::put($path, 'not-encrypted');
 
         $this->artisan('auth:restore', [
-            'path' => 'auth-snapshots/invalid.json.enc',
+            'path' => $path,
         ])
             ->expectsOutput('Unable to decrypt auth snapshot. Verify that this app uses the same APP_KEY that created the snapshot.')
             ->assertExitCode(1);
+    }
+
+    public function test_snapshot_creates_parent_directory_for_absolute_path(): void
+    {
+        User::factory()->create(['email' => 'nested-snapshot@example.com']);
+
+        $path = $this->snapshotDirectory.DIRECTORY_SEPARATOR.'nested'.DIRECTORY_SEPARATOR.'pre-import.json.enc';
+
+        $this->artisan('auth:snapshot', [
+            'path' => $path,
+        ])->assertExitCode(0);
+
+        $this->assertTrue(File::exists($path));
+    }
+
+    public function test_snapshot_resolves_relative_path_from_current_working_directory(): void
+    {
+        User::factory()->create(['email' => 'relative-snapshot@example.com']);
+
+        $originalDirectory = getcwd();
+
+        try {
+            chdir($this->snapshotDirectory);
+
+            $this->artisan('auth:snapshot', [
+                'path' => 'relative/pre-import.json.enc',
+            ])->assertExitCode(0);
+        } finally {
+            chdir($originalDirectory);
+        }
+
+        $this->assertTrue(File::exists($this->snapshotPath('relative'.DIRECTORY_SEPARATOR.'pre-import.json.enc')));
+    }
+
+    private function snapshotPath(string $filename): string
+    {
+        return $this->snapshotDirectory.DIRECTORY_SEPARATOR.$filename;
     }
 }


### PR DESCRIPTION
## Summary
- Change `auth:snapshot` and `auth:restore` to resolve real filesystem paths instead of Laravel `local` disk paths.
- Default snapshots to the OS temp directory under `inventory-auth-snapshots` and create parent directories with restrictive permissions.
- Update Console tests to use real temp files and cover absolute paths, parent directory creation, and relative path resolution.
- Update the legacy importer runbook so full import snapshots use caller-writable temp locations, including `/tmp/inventory-auth-snapshots/pre-import.json.enc` on OVH.

## Verification
- `docker run --rm -v "${PWD}:/workspaces/inventory-app" -v inv-app-php-vendor:/workspaces/inventory-app/vendor -v inv-app-node-modules:/workspaces/inventory-app/node_modules -v inv-app-spa-node-modules:/workspaces/inventory-app/spa/node_modules -v inv-app-importer-node-modules:/workspaces/inventory-app/scripts/importer/node_modules -w /workspaces/inventory-app -e XDEBUG_MODE=off inventory-app-dev php artisan test --testsuite=Console --no-coverage --parallel --no-ansi --stop-on-failure`
- `docker run --rm -v "${PWD}:/workspaces/inventory-app" -v inv-app-php-vendor:/workspaces/inventory-app/vendor -v inv-app-node-modules:/workspaces/inventory-app/node_modules -v inv-app-spa-node-modules:/workspaces/inventory-app/spa/node_modules -v inv-app-importer-node-modules:/workspaces/inventory-app/scripts/importer/node_modules -w /workspaces/inventory-app -e XDEBUG_MODE=off inventory-app-dev vendor/bin/pint --no-ansi`