### PR TITLE
Fix: Bug in #1299 - Test had a syntx error

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -131,11 +131,12 @@ Runs build and test jobs conditionally based on which paths changed in the pull 
 | `app/**`, `routes/**`, `config/**`, `database/**`, `tests/**`, `bootstrap/**`, `composer.json`, `composer.lock`, `phpunit.xml`, `artisan` | `backend-lint`, `backend-tests` |
 | `resources/css/**`, `resources/js/**`, `resources/views/**`, `vite.config.js`, `tailwind.config.js`, `postcss.config.js`, `package.json`, `package-lock.json`, `tsconfig.json`, `eslint.config.js` | `backend-rendered-frontend-validation` |
 | `spa/**` | `spa-frontend-validation` |
+| `scripts/importer/**` | `importer-validation` |
 
 **Jobs**
 
 1. **detect-changes** - Classifies changed files using `git diff` against the PR base SHA
-   - Emits outputs: `backend`, `root-frontend`, `spa` (true/false)
+   - Emits outputs: `backend`, `root-frontend`, `spa`, `importer` (true/false)
    - All outputs are `true` when triggered by `workflow_dispatch`
 
 2. **backend-lint** *(when `backend=true`)* - Laravel backend linting
@@ -153,7 +154,12 @@ Runs build and test jobs conditionally based on which paths changed in the pull 
    - Installs Node.js lts/Krypton and root npm dependencies
    - Runs `npm run build`
 
-5. **spa-frontend-validation** *(when `spa=true`)* - SPA (Vue 3) validation
+5. **importer-validation** *(when `importer=true`)* - Importer TypeScript build and tests
+   - Installs Node.js lts/Krypton and importer npm dependencies
+   - Runs `npm run build` (TypeScript compilation)
+   - Runs `npm test` (Vitest unit tests)
+
+6. **spa-frontend-validation** *(when `spa=true`)* - SPA (Vue 3) validation
    - Installs Node.js lts/Krypton and SPA npm dependencies
    - Runs lint, build, and `npm run test:all`
 

--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -24,6 +24,7 @@ jobs:
       backend: ${{ steps.detect.outputs.backend }}
       root-frontend: ${{ steps.detect.outputs.root-frontend }}
       spa: ${{ steps.detect.outputs.spa }}
+      importer: ${{ steps.detect.outputs.importer }}
 
     steps:
       - uses: actions/checkout@v6
@@ -37,6 +38,7 @@ jobs:
             echo "backend=true" >> $GITHUB_OUTPUT
             echo "root-frontend=true" >> $GITHUB_OUTPUT
             echo "spa=true" >> $GITHUB_OUTPUT
+            echo "importer=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -62,6 +64,12 @@ jobs:
             echo "spa=true" >> $GITHUB_OUTPUT
           else
             echo "spa=false" >> $GITHUB_OUTPUT
+          fi
+
+          if echo "$CHANGED" | grep -qE '^scripts/importer/'; then
+            echo "importer=true" >> $GITHUB_OUTPUT
+          else
+            echo "importer=false" >> $GITHUB_OUTPUT
           fi
 
   backend-lint:
@@ -191,6 +199,39 @@ jobs:
       - name: "Check > npm > Build Backend Assets"
         run: |
           npm run build
+
+  importer-validation:
+    name: Importer Validation (TypeScript)
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.importer == 'true'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Setup > Image > Install Node.js"
+        uses: actions/setup-node@v6
+        with:
+          node-version: "lts/Krypton"
+
+      - name: "Setup > node > Enable Corepack"
+        run: |
+          corepack enable
+
+      - name: "Setup > npm > Install Dependencies (Importer)"
+        working-directory: scripts/importer
+        run: |
+          npm ci --no-audit --no-fund
+
+      - name: "Check > npm > Build (Importer)"
+        working-directory: scripts/importer
+        run: |
+          npm run build
+
+      - name: "Check > npm > Run Tests (Importer)"
+        working-directory: scripts/importer
+        run: |
+          npm test
 
   spa-frontend-validation:
     name: Frontend Validation - SPA (Vue 3)

--- a/scripts/importer/tests/unit/monument-picture-importer.test.ts
+++ b/scripts/importer/tests/unit/monument-picture-importer.test.ts
@@ -242,8 +242,8 @@ describe('MonumentPictureImporter', () => {
     await importer.import();
 
     const monumentQuery = queryMock.mock.calls.find(
-      ([sql]: [string]) =>
-        typeof sql === 'string' && sql.includes('FROM mwnf3.monuments') && !sql.includes('pictures')
+      (args) =>
+        typeof args[0] === 'string' && args[0].includes('FROM mwnf3.monuments') && !args[0].includes('pictures')
     );
     expect(monumentQuery).toBeDefined();
     const [sql] = monumentQuery as [string];


### PR DESCRIPTION
Here's a summary of what was found and fixed:

---

## Root cause

**Broken file**: monument-picture-importer.test.ts (line 245)

PR #1300 added a regression test for the `getParentItemName()` fix using this destructuring syntax in a `.find()` callback:

```typescript
// Before (broken) — TypeScript error:
([sql]: [string]) => typeof sql === 'string' && ...
```

TypeScript rejects this because `mock.calls` is typed as `any[][]`, and `any[]` cannot be narrowed to the tuple `[string]` (requires exactly 1 element). The fix:

```typescript
// After (fixed):
(args) => typeof args[0] === 'string' && args[0].includes('FROM mwnf3.monuments') && !args[0].includes('pictures')
```

The importer now builds cleanly and all 338 tests pass.

---

## Why CI didn't catch it

Two gaps in the workflow structure:

1. **Mandatory Checks** (continuous-integration.yml): The `audit-npm-importer` job only runs `npm audit --audit-level moderate` — **no `npm run build` and no `npm test`**. TypeScript errors in importer code are invisible to this job.

2. **Build and Test** (ci-build-test.yml, non-required check): The `detect-changes` job had **no path group for `scripts/importer/**`**, so no validation job was ever triggered for importer changes — even as a non-blocking check.

---

## CI fix applied

Added to ci-build-test.yml:
- `importer=true` output in `detect-changes` when `scripts/importer/**` files change
- New `importer-validation` job that runs `npm run build` + `npm test` when `importer=true`

Updated README.md to document the new path group and job.

> Note: ci-build-test.yml is a non-required check. If you want importer build failures to **block** PR merges, the `audit-npm-importer` job in continuous-integration.yml would also need `npm run build` and `npm test` added, or the `ci-success` required check extended to cover it.