### PR TITLE
Fix (queue): Let worker daemon process the glossary queue

### DIFF
--- a/scripts/provision-inventory.sh
+++ b/scripts/provision-inventory.sh
@@ -233,7 +233,7 @@ After=network.target mysql.service valkey-server.service
 User=www-data
 Group=www-data
 WorkingDirectory=${APP_DIR}/current
-ExecStart=/usr/bin/php artisan queue:work redis --sleep=3 --tries=3 --max-time=3600 --memory=128
+ExecStart=/usr/bin/php artisan queue:work redis --queue=glossary,default --sleep=3 --tries=3 --max-time=3600 --memory=128
 Restart=always
 RestartSec=5
 StandardOutput=append:${APP_DIR}/shared/storage/logs/queue-worker.log


### PR DESCRIPTION
## Summary:

| What | Status | |---|---| | **Live server** `/etc/systemd/system/inventory-queue.service` | ✅ Fixed — service restarted, now processes `glossary,default` | | provision-inventory.sh | ✅ Fixed — re-provisioning won't regress the fix | | legacy-importer.agent.md | ✅ No change needed — the `queue:work --queue=glossary --stop-when-empty` step in all three runbooks is correct: it acts as a blocking wait during import to ensure the queue is fully drained before the workflow completes |