### PR TITLE
Update OVH runtime deployment docs

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -24,6 +24,16 @@ This directory contains sample web server configuration files for deploying the 
 - PHP 8.2 or higher with PHP-FPM
 - SSL certificate (for production)
 
+### OVH Reference Host
+
+The current OVH host for `inventory.metanull.eu` runs this stack:
+
+- Ubuntu 25.10 (Questing Quokka)
+- Nginx 1.28.0
+- PHP 8.4.11 with PHP-FPM
+- MySQL 8.4.8
+- Valkey 8.1.6
+
 ## Installation Instructions
 
 ### Apache (Linux/Unix)
@@ -212,3 +222,4 @@ For Laravel-specific configuration questions, refer to the [Laravel Deployment D
 For web server specific issues, consult:
 - [Apache Documentation](https://httpd.apache.org/docs/)
 - [Nginx Documentation](https://nginx.org/en/docs/)
+

--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -13,6 +13,7 @@
 # Requirements:
 # - Nginx 1.18+
 # - PHP 8.2+ with PHP-FPM
+# - OVH currently uses PHP 8.4 with /var/run/php/php8.4-fpm.sock
 # - SSL certificate (for HTTPS)
 
 # HTTP to HTTPS redirect (recommended for production)
@@ -95,8 +96,9 @@ server {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         
-        # Update this to match your PHP-FPM configuration
-        fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
+        # Update this to match your PHP-FPM configuration.
+        # The OVH host currently uses PHP 8.4.
+        fastcgi_pass unix:/var/run/php/php8.4-fpm.sock;
         # Alternative: fastcgi_pass 127.0.0.1:9000;
         
         fastcgi_index index.php;
@@ -182,7 +184,7 @@ server {
 #     location ~ \.php$ {
 #         try_files $uri =404;
 #         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-#         fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
+#         fastcgi_pass unix:/var/run/php/php8.4-fpm.sock;
 #         fastcgi_index index.php;
 #         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
 #         include fastcgi_params;
@@ -210,3 +212,4 @@ server {
 #     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
 #     limit_req_zone $binary_remote_addr zone=login:10m rate=1r/s;
 # }
+

--- a/docs/deployment/server-configuration.md
+++ b/docs/deployment/server-configuration.md
@@ -187,7 +187,7 @@ LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
 
 # PHP-FPM configuration
 <FilesMatch \.php$>
-    SetHandler "proxy:unix:/var/run/php/php8.2-fpm.sock|fcgi://localhost"
+    SetHandler "proxy:unix:/var/run/php/php8.4-fpm.sock|fcgi://localhost"
 </FilesMatch>
 
 # Windows PHP-FPM
@@ -249,7 +249,7 @@ server {
     location ~ \.php$ {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php8.4-fpm.sock;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
@@ -402,11 +402,11 @@ http {
 Create a dedicated pool for the application:
 
 ```ini
-; /etc/php/8.2/fpm/pool.d/inventory-app.conf
+; /etc/php/8.4/fpm/pool.d/inventory-app.conf
 [inventory-app]
 user = www-data
 group = www-data
-listen = /var/run/php/php8.2-fpm-inventory-app.sock
+listen = /var/run/php/php8.4-fpm-inventory-app.sock
 listen.owner = www-data
 listen.group = www-data
 listen.mode = 0660
@@ -425,7 +425,7 @@ rlimit_files = 65536
 rlimit_core = 0
 
 ; Logging
-php_admin_value[error_log] = /var/log/php8.2-fpm-inventory-app.log
+php_admin_value[error_log] = /var/log/php8.4-fpm-inventory-app.log
 php_admin_flag[log_errors] = on
 
 ; Environment variables
@@ -627,7 +627,7 @@ maxretry = 10
 ### Common Issues
 
 1. **502 Bad Gateway (Nginx)**
-   - Check PHP-FPM status: `systemctl status php8.2-fpm`
+   - Check PHP-FPM status: `systemctl status php8.4-fpm`
    - Verify socket permissions
    - Check PHP-FPM logs
 
@@ -661,3 +661,4 @@ maxretry = 10
 - [Development Setup](development-setup) - Local development
 - 🔒 [Security Guide](security) - Security best practices
 - [Monitoring](monitoring) - Application monitoring
+

--- a/docs/deployment/testing-troubleshooting.md
+++ b/docs/deployment/testing-troubleshooting.md
@@ -82,7 +82,7 @@ apache2ctl configtest
 nginx -t
 
 # Test PHP-FPM
-systemctl status php8.2-fpm
+systemctl status php8.4-fpm
 ```
 
 #### Application Testing
@@ -259,7 +259,7 @@ tail -f /var/log/apache2/error.log
 tail -f /var/log/nginx/error.log
 
 # Check PHP-FPM logs
-tail -f /var/log/php8.2-fpm.log
+tail -f /var/log/php8.4-fpm.log
 ```
 
 **Common Solutions**:
@@ -290,7 +290,7 @@ php artisan view:cache
 
 ```bash
 # Check PHP-FPM status
-systemctl status php8.2-fpm
+systemctl status php8.4-fpm
 
 # Check socket permissions
 ls -la /var/run/php/
@@ -303,14 +303,14 @@ nginx -t
 
 ```bash
 # Restart PHP-FPM
-systemctl restart php8.2-fpm
+systemctl restart php8.4-fpm
 
 # Check socket path in Nginx config matches PHP-FPM
-# Nginx: fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
-# PHP-FPM: listen = /var/run/php/php8.2-fpm.sock
+# Nginx: fastcgi_pass unix:/var/run/php/php8.4-fpm.sock;
+# PHP-FPM: listen = /var/run/php/php8.4-fpm.sock
 
 # Fix socket permissions
-chown www-data:www-data /var/run/php/php8.2-fpm.sock
+chown www-data:www-data /var/run/php/php8.4-fpm.sock
 ```
 
 #### Database Connection Issues
@@ -652,3 +652,4 @@ cat .env | grep -v PASSWORD | grep -v KEY | grep -v SECRET
 - [Configuration]({{ '/deployment/configuration' | relative_url }}) - Application configuration
 - [Development Setup]({{ '/deployment/development-setup' | relative_url }}) - Development environment
 - [Server Configuration]({{ '/deployment/server-configuration' | relative_url }}) - Web server setup
+


### PR DESCRIPTION
## Summary
- update deployment docs to reflect the OVH host runtime inventory
- switch PHP-FPM service and socket examples from php8.2 to php8.4
- document the current OVH stack: Ubuntu 25.10, nginx 1.28.0, PHP 8.4.11, MySQL 8.4.8, and Valkey 8.1.6

## Validation
- verified live OVH runtime via SSH
- validated the edited files in the editor with no errors