### PR TITLE
feat(exporter): static JSON exporter + local viewer for Islamic Art

### DIFF
--- a/scripts/exporter/.env.example
+++ b/scripts/exporter/.env.example
@@ -5,6 +5,7 @@ DB_USERNAME=inventory
 DB_PASSWORD=
 DB_DATABASE=inventory
 
-# Base URL for media files served from the inventory app's public storage
-# Used to build absolute image URLs in the exported JSON
-BASE_URL=https://inventory.metanull.eu/storage
+# Base URL prepended to image paths in the exported JSON.
+# Default (when unset): ./images  — relative to wherever the JSON files are served from.
+# Set this to your CDN or storage URL when the images are hosted elsewhere.
+# BASE_URL=https://cdn.example.com/storage

--- a/scripts/exporter/.env.example
+++ b/scripts/exporter/.env.example
@@ -1,0 +1,10 @@
+# Inventory database (same as importer DB_* variables)
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_USERNAME=inventory
+DB_PASSWORD=
+DB_DATABASE=inventory
+
+# Base URL for media files served from the inventory app's public storage
+# Used to build absolute image URLs in the exported JSON
+BASE_URL=https://inventory.metanull.eu/storage

--- a/scripts/exporter/.gitignore
+++ b/scripts/exporter/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+output/
+.env

--- a/scripts/exporter/eslint.config.js
+++ b/scripts/exporter/eslint.config.js
@@ -1,6 +1,6 @@
-import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
-import eslintConfigPrettier from 'eslint-config-prettier';
+import eslint from '@eslint/js'
+import tseslint from 'typescript-eslint'
+import eslintConfigPrettier from 'eslint-config-prettier'
 
 export default tseslint.config(
   eslint.configs.recommended,
@@ -27,4 +27,4 @@ export default tseslint.config(
       '@typescript-eslint/no-non-null-assertion': 'off',
     },
   }
-);
+)

--- a/scripts/exporter/eslint.config.js
+++ b/scripts/exporter/eslint.config.js
@@ -1,0 +1,30 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import eslintConfigPrettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.strict,
+  eslintConfigPrettier,
+  {
+    ignores: ['dist/**', 'node_modules/**', 'output/**', '*.js', '*.mjs', '*.cjs'],
+  },
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  }
+);

--- a/scripts/exporter/package-lock.json
+++ b/scripts/exporter/package-lock.json
@@ -1,0 +1,2093 @@
+{
+  "name": "exporter",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "exporter",
+      "version": "1.0.0",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.2",
+        "dotenv": "^17.4.2",
+        "mysql2": "^3.22.3"
+      },
+      "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "@types/node": "^25.7.0",
+        "@typescript-eslint/eslint-plugin": "^8.59.3",
+        "@typescript-eslint/parser": "^8.59.3",
+        "eslint": "^10.3.0",
+        "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-prettier": "^5.2.1",
+        "prettier": "^3.8.2",
+        "tsx": "^4.19.2",
+        "typescript": "^6.0.2",
+        "typescript-eslint": "^8.59.3"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.1",
+        "synckit": "^0.11.13"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mysql2": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.5.tgz",
+      "integrity": "sha512-95uZ2TrPWAZdwpB3vvvDbmEMcNG8yIeNCyu6GUcr/QnWEE/wXm7+mhOCsdQfWQDTV7qYT/PDUZ4U4UPP4AsXqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.3.3"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.1.tgz",
+      "integrity": "sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sql-escaper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
+      "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.3.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.0",
+        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/scripts/exporter/package.json
+++ b/scripts/exporter/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "exporter",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Static JSON data exporter for MWNF public websites",
+  "scripts": {
+    "build": "tsc",
+    "export": "tsx src/cli/export.ts",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint . --fix",
+    "lint:check": "eslint .",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "chalk": "^5.4.1",
+    "commander": "^14.0.2",
+    "dotenv": "^17.4.2",
+    "mysql2": "^3.22.3"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "@types/node": "^25.7.0",
+    "@typescript-eslint/eslint-plugin": "^8.59.3",
+    "@typescript-eslint/parser": "^8.59.3",
+    "eslint": "^10.3.0",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-prettier": "^5.2.1",
+    "prettier": "^3.8.2",
+    "tsx": "^4.19.2",
+    "typescript": "^6.0.2",
+    "typescript-eslint": "^8.59.3"
+  },
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  }
+}

--- a/scripts/exporter/src/cli/export.ts
+++ b/scripts/exporter/src/cli/export.ts
@@ -49,7 +49,7 @@ program
   .option(
     '--base-url <url>',
     'Base URL for media files',
-    process.env['BASE_URL'] ?? 'https://inventory.metanull.eu/storage'
+    process.env['BASE_URL'] ?? './images'
   )
   .action(
     async (

--- a/scripts/exporter/src/cli/export.ts
+++ b/scripts/exporter/src/cli/export.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Static JSON Exporter CLI
+ *
+ * Reads the inventory database and writes a set of denormalized JSON files
+ * for consumption by frontend applications (e.g., the new Discover Islamic Art site).
+ *
+ * Usage:
+ *   npm run export -- <subdirectory> <project-key> [more-project-keys...]
+ *
+ * Examples:
+ *   npm run export -- islamicart ISL
+ *   npm run export -- combined ISL WHS --force
+ *   npm run export -- islamicart ISL --output-dir /tmp/export --base-url https://cdn.example.com/storage
+ */
+
+import dotenv from 'dotenv';
+import { resolve } from 'path';
+import { existsSync, mkdirSync, rmSync } from 'fs';
+import { Command } from 'commander';
+import chalk from 'chalk';
+
+import { Database } from '../core/database.js';
+import { Logger } from '../core/logger.js';
+import type { ExportContext } from '../core/types.js';
+import {
+  ManifestExporter,
+  LanguageExporter,
+  CountryExporter,
+  DynastyExporter,
+  PartnerExporter,
+  ItemExporter,
+  CollectionExporter,
+  GlossaryExporter,
+} from '../exporters/index.js';
+
+dotenv.config({ path: resolve(process.cwd(), '.env') });
+
+const program = new Command();
+
+program
+  .name('exporter')
+  .description('Static JSON data exporter for MWNF public websites')
+  .version('1.0.0')
+  .argument('<subdirectory>', 'Name of the output subdirectory to create')
+  .argument('<project-keys...>', 'One or more legacy project keys to export (e.g., ISL WHS)')
+  .option('--force', 'Overwrite output directory if it already exists', false)
+  .option('--output-dir <path>', 'Base output directory (relative to cwd or absolute)', 'output')
+  .option(
+    '--base-url <url>',
+    'Base URL for media files',
+    process.env['BASE_URL'] ?? 'https://inventory.metanull.eu/storage'
+  )
+  .action(async (subdirectory: string, projectKeys: string[], options: { force: boolean; outputDir: string; baseUrl: string }) => {
+    const logger = new Logger('Exporter');
+
+    console.log(chalk.bold('='.repeat(70)));
+    console.log(chalk.bold.cyan('MWNF STATIC DATA EXPORTER'));
+    console.log(chalk.bold('='.repeat(70)));
+    console.log(chalk.gray(`Start time:    ${new Date().toISOString()}`));
+    console.log(chalk.gray(`Project keys:  ${projectKeys.join(', ')}`));
+    console.log(chalk.gray(`Subdirectory:  ${subdirectory}`));
+    console.log(chalk.gray(`Force:         ${options.force ? 'YES' : 'NO'}`));
+    console.log('');
+
+    const outputBaseDir = resolve(process.cwd(), options.outputDir);
+    const outputDir = resolve(outputBaseDir, subdirectory);
+
+    // Guard: fail if output directory exists and --force not given
+    if (existsSync(outputDir)) {
+      if (!options.force) {
+        console.error(chalk.red(`\nOutput directory already exists: ${outputDir}`));
+        console.error(chalk.red('Use --force to overwrite it.\n'));
+        process.exit(1);
+      }
+      logger.warning(`Removing existing output directory (--force): ${outputDir}`);
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+
+    mkdirSync(outputDir, { recursive: true });
+    logger.info(`Output directory: ${outputDir}`);
+
+    // Connect to the inventory database
+    const db = new Database();
+
+    try {
+      logger.info('Connecting to database...');
+      await db.connect();
+      console.log(chalk.green('  ✓ Database connected'));
+
+      // Resolve project IDs from the provided backward_compatibility keys
+      logger.info(`Resolving project IDs for: ${projectKeys.join(', ')}`);
+      const projectIds = await db.resolveProjectIds(projectKeys);
+      console.log(chalk.green(`  ✓ Found ${projectIds.length} project(s)`));
+      console.log('');
+
+      const context: ExportContext = {
+        db,
+        outputDir,
+        projectIds,
+        projectKeys,
+        baseUrl: options.baseUrl,
+        logger,
+      };
+
+      const exporters = [
+        new ManifestExporter(context),
+        new LanguageExporter(context),
+        new CountryExporter(context),
+        new DynastyExporter(context),
+        new PartnerExporter(context),
+        new ItemExporter(context),
+        new CollectionExporter(context),
+        new GlossaryExporter(context),
+      ];
+
+      const results = [];
+      for (const exporter of exporters) {
+        try {
+          const result = await exporter.export();
+          results.push({ name: exporter.getName(), ...result, error: null });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.error(`${exporter.getName()} failed: ${message}`);
+          results.push({ name: exporter.getName(), file: '', count: 0, error: message });
+        }
+      }
+
+      const hasErrors = results.some((r) => r.error !== null);
+
+      console.log('');
+      console.log(chalk.bold('='.repeat(70)));
+      if (hasErrors) {
+        console.log(chalk.bold.red('EXPORT COMPLETED WITH ERRORS'));
+      } else {
+        console.log(chalk.bold.green('EXPORT COMPLETED'));
+      }
+      console.log(chalk.gray(`End time: ${new Date().toISOString()}`));
+      console.log(chalk.gray(`Output:   ${outputDir}`));
+      console.log('');
+
+      for (const r of results) {
+        if (r.error) {
+          console.log(chalk.red(`  ✗ ${r.name}: ${r.error}`));
+        } else {
+          console.log(chalk.green(`  ✓ ${r.file} (${r.count})`));
+        }
+      }
+
+      console.log(chalk.bold('='.repeat(70)));
+
+      process.exit(hasErrors ? 1 : 0);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(chalk.red(`\nFatal error: ${message}`));
+      if (err instanceof Error && err.stack) {
+        console.error(chalk.gray(err.stack));
+      }
+      process.exit(1);
+    } finally {
+      await db.disconnect();
+    }
+  });
+
+program.parse();

--- a/scripts/exporter/src/cli/export.ts
+++ b/scripts/exporter/src/cli/export.ts
@@ -14,15 +14,15 @@
  *   npm run export -- islamicart ISL --output-dir /tmp/export --base-url https://cdn.example.com/storage
  */
 
-import dotenv from 'dotenv';
-import { resolve } from 'path';
-import { existsSync, mkdirSync, rmSync } from 'fs';
-import { Command } from 'commander';
-import chalk from 'chalk';
+import dotenv from 'dotenv'
+import { resolve } from 'path'
+import { existsSync, mkdirSync, rmSync } from 'fs'
+import { Command } from 'commander'
+import chalk from 'chalk'
 
-import { Database } from '../core/database.js';
-import { Logger } from '../core/logger.js';
-import type { ExportContext } from '../core/types.js';
+import { Database } from '../core/database.js'
+import { Logger } from '../core/logger.js'
+import type { ExportContext } from '../core/types.js'
 import {
   ManifestExporter,
   LanguageExporter,
@@ -32,11 +32,11 @@ import {
   ItemExporter,
   CollectionExporter,
   GlossaryExporter,
-} from '../exporters/index.js';
+} from '../exporters/index.js'
 
-dotenv.config({ path: resolve(process.cwd(), '.env') });
+dotenv.config({ path: resolve(process.cwd(), '.env') })
 
-const program = new Command();
+const program = new Command()
 
 program
   .name('exporter')
@@ -51,115 +51,121 @@ program
     'Base URL for media files',
     process.env['BASE_URL'] ?? 'https://inventory.metanull.eu/storage'
   )
-  .action(async (subdirectory: string, projectKeys: string[], options: { force: boolean; outputDir: string; baseUrl: string }) => {
-    const logger = new Logger('Exporter');
+  .action(
+    async (
+      subdirectory: string,
+      projectKeys: string[],
+      options: { force: boolean; outputDir: string; baseUrl: string }
+    ) => {
+      const logger = new Logger('Exporter')
 
-    console.log(chalk.bold('='.repeat(70)));
-    console.log(chalk.bold.cyan('MWNF STATIC DATA EXPORTER'));
-    console.log(chalk.bold('='.repeat(70)));
-    console.log(chalk.gray(`Start time:    ${new Date().toISOString()}`));
-    console.log(chalk.gray(`Project keys:  ${projectKeys.join(', ')}`));
-    console.log(chalk.gray(`Subdirectory:  ${subdirectory}`));
-    console.log(chalk.gray(`Force:         ${options.force ? 'YES' : 'NO'}`));
-    console.log('');
+      console.log(chalk.bold('='.repeat(70)))
+      console.log(chalk.bold.cyan('MWNF STATIC DATA EXPORTER'))
+      console.log(chalk.bold('='.repeat(70)))
+      console.log(chalk.gray(`Start time:    ${new Date().toISOString()}`))
+      console.log(chalk.gray(`Project keys:  ${projectKeys.join(', ')}`))
+      console.log(chalk.gray(`Subdirectory:  ${subdirectory}`))
+      console.log(chalk.gray(`Force:         ${options.force ? 'YES' : 'NO'}`))
+      console.log('')
 
-    const outputBaseDir = resolve(process.cwd(), options.outputDir);
-    const outputDir = resolve(outputBaseDir, subdirectory);
+      const outputBaseDir = resolve(process.cwd(), options.outputDir)
+      const outputDir = resolve(outputBaseDir, subdirectory)
 
-    // Guard: fail if output directory exists and --force not given
-    if (existsSync(outputDir)) {
-      if (!options.force) {
-        console.error(chalk.red(`\nOutput directory already exists: ${outputDir}`));
-        console.error(chalk.red('Use --force to overwrite it.\n'));
-        process.exit(1);
-      }
-      logger.warning(`Removing existing output directory (--force): ${outputDir}`);
-      rmSync(outputDir, { recursive: true, force: true });
-    }
-
-    mkdirSync(outputDir, { recursive: true });
-    logger.info(`Output directory: ${outputDir}`);
-
-    // Connect to the inventory database
-    const db = new Database();
-
-    try {
-      logger.info('Connecting to database...');
-      await db.connect();
-      console.log(chalk.green('  ✓ Database connected'));
-
-      // Resolve project IDs from the provided backward_compatibility keys
-      logger.info(`Resolving project IDs for: ${projectKeys.join(', ')}`);
-      const projectIds = await db.resolveProjectIds(projectKeys);
-      console.log(chalk.green(`  ✓ Found ${projectIds.length} project(s)`));
-      console.log('');
-
-      const context: ExportContext = {
-        db,
-        outputDir,
-        projectIds,
-        projectKeys,
-        baseUrl: options.baseUrl,
-        logger,
-      };
-
-      const exporters = [
-        new ManifestExporter(context),
-        new LanguageExporter(context),
-        new CountryExporter(context),
-        new DynastyExporter(context),
-        new PartnerExporter(context),
-        new ItemExporter(context),
-        new CollectionExporter(context),
-        new GlossaryExporter(context),
-      ];
-
-      const results = [];
-      for (const exporter of exporters) {
-        try {
-          const result = await exporter.export();
-          results.push({ name: exporter.getName(), ...result, error: null });
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          logger.error(`${exporter.getName()} failed: ${message}`);
-          results.push({ name: exporter.getName(), file: '', count: 0, error: message });
+      // Guard: fail if output directory exists and --force not given
+      if (existsSync(outputDir)) {
+        if (!options.force) {
+          console.error(chalk.red(`\nOutput directory already exists: ${outputDir}`))
+          console.error(chalk.red('Use --force to overwrite it.\n'))
+          process.exit(1)
         }
+        logger.warning(`Removing existing output directory (--force): ${outputDir}`)
+        rmSync(outputDir, { recursive: true, force: true })
       }
 
-      const hasErrors = results.some((r) => r.error !== null);
+      mkdirSync(outputDir, { recursive: true })
+      logger.info(`Output directory: ${outputDir}`)
 
-      console.log('');
-      console.log(chalk.bold('='.repeat(70)));
-      if (hasErrors) {
-        console.log(chalk.bold.red('EXPORT COMPLETED WITH ERRORS'));
-      } else {
-        console.log(chalk.bold.green('EXPORT COMPLETED'));
-      }
-      console.log(chalk.gray(`End time: ${new Date().toISOString()}`));
-      console.log(chalk.gray(`Output:   ${outputDir}`));
-      console.log('');
+      // Connect to the inventory database
+      const db = new Database()
 
-      for (const r of results) {
-        if (r.error) {
-          console.log(chalk.red(`  ✗ ${r.name}: ${r.error}`));
+      try {
+        logger.info('Connecting to database...')
+        await db.connect()
+        console.log(chalk.green('  ✓ Database connected'))
+
+        // Resolve project IDs from the provided backward_compatibility keys
+        logger.info(`Resolving project IDs for: ${projectKeys.join(', ')}`)
+        const projectIds = await db.resolveProjectIds(projectKeys)
+        console.log(chalk.green(`  ✓ Found ${projectIds.length} project(s)`))
+        console.log('')
+
+        const context: ExportContext = {
+          db,
+          outputDir,
+          projectIds,
+          projectKeys,
+          baseUrl: options.baseUrl,
+          logger,
+        }
+
+        const exporters = [
+          new ManifestExporter(context),
+          new LanguageExporter(context),
+          new CountryExporter(context),
+          new DynastyExporter(context),
+          new PartnerExporter(context),
+          new ItemExporter(context),
+          new CollectionExporter(context),
+          new GlossaryExporter(context),
+        ]
+
+        const results = []
+        for (const exporter of exporters) {
+          try {
+            const result = await exporter.export()
+            results.push({ name: exporter.getName(), ...result, error: null })
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err)
+            logger.error(`${exporter.getName()} failed: ${message}`)
+            results.push({ name: exporter.getName(), file: '', count: 0, error: message })
+          }
+        }
+
+        const hasErrors = results.some(r => r.error !== null)
+
+        console.log('')
+        console.log(chalk.bold('='.repeat(70)))
+        if (hasErrors) {
+          console.log(chalk.bold.red('EXPORT COMPLETED WITH ERRORS'))
         } else {
-          console.log(chalk.green(`  ✓ ${r.file} (${r.count})`));
+          console.log(chalk.bold.green('EXPORT COMPLETED'))
         }
-      }
+        console.log(chalk.gray(`End time: ${new Date().toISOString()}`))
+        console.log(chalk.gray(`Output:   ${outputDir}`))
+        console.log('')
 
-      console.log(chalk.bold('='.repeat(70)));
+        for (const r of results) {
+          if (r.error) {
+            console.log(chalk.red(`  ✗ ${r.name}: ${r.error}`))
+          } else {
+            console.log(chalk.green(`  ✓ ${r.file} (${r.count})`))
+          }
+        }
 
-      process.exit(hasErrors ? 1 : 0);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(chalk.red(`\nFatal error: ${message}`));
-      if (err instanceof Error && err.stack) {
-        console.error(chalk.gray(err.stack));
+        console.log(chalk.bold('='.repeat(70)))
+
+        process.exit(hasErrors ? 1 : 0)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        console.error(chalk.red(`\nFatal error: ${message}`))
+        if (err instanceof Error && err.stack) {
+          console.error(chalk.gray(err.stack))
+        }
+        process.exit(1)
+      } finally {
+        await db.disconnect()
       }
-      process.exit(1);
-    } finally {
-      await db.disconnect();
     }
-  });
+  )
 
-program.parse();
+program.parse()

--- a/scripts/exporter/src/core/database.ts
+++ b/scripts/exporter/src/core/database.ts
@@ -1,7 +1,7 @@
-import mysql from 'mysql2/promise';
+import mysql from 'mysql2/promise'
 
 export class Database {
-  private connection: mysql.Connection | null = null;
+  private connection: mysql.Connection | null = null
 
   async connect(): Promise<void> {
     this.connection = await mysql.createConnection({
@@ -10,45 +10,53 @@ export class Database {
       user: process.env['DB_USERNAME'] ?? 'root',
       password: process.env['DB_PASSWORD'] ?? '',
       database: process.env['DB_DATABASE'] ?? 'inventory',
-    });
+    })
   }
 
   async disconnect(): Promise<void> {
     if (this.connection) {
-      await this.connection.end();
-      this.connection = null;
+      await this.connection.end()
+      this.connection = null
     }
   }
 
   async query<T>(sql: string, params?: (string | number | null)[]): Promise<T[]> {
     if (!this.connection) {
-      throw new Error('Database not connected');
+      throw new Error('Database not connected')
     }
-    const [rows] = await this.connection.execute(sql, params);
-    return rows as T[];
+    const [rows] = await this.connection.execute(sql, params)
+    return rows as T[]
   }
 
+  /**
+   * Resolve project UUIDs from the user-supplied legacy project keys.
+   *
+   * The user supplies short keys like "ISL". The inventory DB stores these as
+   * backward_compatibility = "mwnf3:projects:ISL". This method builds the
+   * lookup values and returns the matching project UUIDs.
+   */
   async resolveProjectIds(projectKeys: string[]): Promise<string[]> {
-    const placeholders = projectKeys.map(() => '?').join(', ');
-    const rows = await this.query<{ id: string }>(
-      `SELECT id FROM projects WHERE backward_compatibility IN (${placeholders})`,
-      projectKeys
-    );
+    const bcValues = projectKeys.map(k => `mwnf3:projects:${k}`)
+    const placeholders = bcValues.map(() => '?').join(', ')
+
+    const rows = await this.query<{ id: string; backward_compatibility: string }>(
+      `SELECT id, backward_compatibility FROM projects WHERE backward_compatibility IN (${placeholders})`,
+      bcValues
+    )
 
     if (rows.length === 0) {
-      throw new Error(`No projects found for keys: ${projectKeys.join(', ')}`);
+      throw new Error(
+        `No projects found. Looked for: ${bcValues.join(', ')}\n` +
+          `Run: SELECT backward_compatibility FROM projects; to list available projects.`
+      )
     }
 
     if (rows.length < projectKeys.length) {
-      const foundKeys = await this.query<{ backward_compatibility: string }>(
-        `SELECT backward_compatibility FROM projects WHERE backward_compatibility IN (${placeholders})`,
-        projectKeys
-      );
-      const found = new Set(foundKeys.map((r) => r.backward_compatibility));
-      const missing = projectKeys.filter((k) => !found.has(k));
-      throw new Error(`Projects not found for keys: ${missing.join(', ')}`);
+      const found = new Set(rows.map(r => r.backward_compatibility))
+      const missing = bcValues.filter(v => !found.has(v))
+      throw new Error(`Projects not found for: ${missing.join(', ')}`)
     }
 
-    return rows.map((r) => r.id);
+    return rows.map(r => r.id)
   }
 }

--- a/scripts/exporter/src/core/database.ts
+++ b/scripts/exporter/src/core/database.ts
@@ -1,0 +1,54 @@
+import mysql from 'mysql2/promise';
+
+export class Database {
+  private connection: mysql.Connection | null = null;
+
+  async connect(): Promise<void> {
+    this.connection = await mysql.createConnection({
+      host: process.env['DB_HOST'] ?? 'localhost',
+      port: parseInt(process.env['DB_PORT'] ?? '3306', 10),
+      user: process.env['DB_USERNAME'] ?? 'root',
+      password: process.env['DB_PASSWORD'] ?? '',
+      database: process.env['DB_DATABASE'] ?? 'inventory',
+    });
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.connection) {
+      await this.connection.end();
+      this.connection = null;
+    }
+  }
+
+  async query<T>(sql: string, params?: (string | number | null)[]): Promise<T[]> {
+    if (!this.connection) {
+      throw new Error('Database not connected');
+    }
+    const [rows] = await this.connection.execute(sql, params);
+    return rows as T[];
+  }
+
+  async resolveProjectIds(projectKeys: string[]): Promise<string[]> {
+    const placeholders = projectKeys.map(() => '?').join(', ');
+    const rows = await this.query<{ id: string }>(
+      `SELECT id FROM projects WHERE backward_compatibility IN (${placeholders})`,
+      projectKeys
+    );
+
+    if (rows.length === 0) {
+      throw new Error(`No projects found for keys: ${projectKeys.join(', ')}`);
+    }
+
+    if (rows.length < projectKeys.length) {
+      const foundKeys = await this.query<{ backward_compatibility: string }>(
+        `SELECT backward_compatibility FROM projects WHERE backward_compatibility IN (${placeholders})`,
+        projectKeys
+      );
+      const found = new Set(foundKeys.map((r) => r.backward_compatibility));
+      const missing = projectKeys.filter((k) => !found.has(k));
+      throw new Error(`Projects not found for keys: ${missing.join(', ')}`);
+    }
+
+    return rows.map((r) => r.id);
+  }
+}

--- a/scripts/exporter/src/core/logger.ts
+++ b/scripts/exporter/src/core/logger.ts
@@ -1,0 +1,25 @@
+import chalk from 'chalk';
+
+export class Logger {
+  private name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  info(message: string): void {
+    console.log(chalk.cyan(`  [${this.name}] ${message}`));
+  }
+
+  success(message: string): void {
+    console.log(chalk.green(`  [${this.name}] ✓ ${message}`));
+  }
+
+  warning(message: string): void {
+    console.log(chalk.yellow(`  [${this.name}] ⚠ ${message}`));
+  }
+
+  error(message: string): void {
+    console.error(chalk.red(`  [${this.name}] ✗ ${message}`));
+  }
+}

--- a/scripts/exporter/src/core/logger.ts
+++ b/scripts/exporter/src/core/logger.ts
@@ -1,25 +1,25 @@
-import chalk from 'chalk';
+import chalk from 'chalk'
 
 export class Logger {
-  private name: string;
+  private name: string
 
   constructor(name: string) {
-    this.name = name;
+    this.name = name
   }
 
   info(message: string): void {
-    console.log(chalk.cyan(`  [${this.name}] ${message}`));
+    console.log(chalk.cyan(`  [${this.name}] ${message}`))
   }
 
   success(message: string): void {
-    console.log(chalk.green(`  [${this.name}] ✓ ${message}`));
+    console.log(chalk.green(`  [${this.name}] ✓ ${message}`))
   }
 
   warning(message: string): void {
-    console.log(chalk.yellow(`  [${this.name}] ⚠ ${message}`));
+    console.log(chalk.yellow(`  [${this.name}] ⚠ ${message}`))
   }
 
   error(message: string): void {
-    console.error(chalk.red(`  [${this.name}] ✗ ${message}`));
+    console.error(chalk.red(`  [${this.name}] ✗ ${message}`))
   }
 }

--- a/scripts/exporter/src/core/types.ts
+++ b/scripts/exporter/src/core/types.ts
@@ -1,20 +1,20 @@
-import type { Database } from './database.js';
-import type { Logger } from './logger.js';
+import type { Database } from './database.js'
+import type { Logger } from './logger.js'
 
 export interface ExportContext {
-  db: Database;
-  outputDir: string;
-  projectIds: string[];
-  projectKeys: string[];
-  baseUrl: string;
-  logger: Logger;
+  db: Database
+  outputDir: string
+  projectIds: string[]
+  projectKeys: string[]
+  baseUrl: string
+  logger: Logger
 }
 
 export interface ExportResult {
-  file: string;
-  count: number;
+  file: string
+  count: number
 }
 
 export interface TranslationMap {
-  [langCode: string]: Record<string, string | null>;
+  [langCode: string]: Record<string, string | null>
 }

--- a/scripts/exporter/src/core/types.ts
+++ b/scripts/exporter/src/core/types.ts
@@ -1,0 +1,20 @@
+import type { Database } from './database.js';
+import type { Logger } from './logger.js';
+
+export interface ExportContext {
+  db: Database;
+  outputDir: string;
+  projectIds: string[];
+  projectKeys: string[];
+  baseUrl: string;
+  logger: Logger;
+}
+
+export interface ExportResult {
+  file: string;
+  count: number;
+}
+
+export interface TranslationMap {
+  [langCode: string]: Record<string, string | null>;
+}

--- a/scripts/exporter/src/exporters/base-exporter.ts
+++ b/scripts/exporter/src/exporters/base-exporter.ts
@@ -1,0 +1,43 @@
+import { writeFile } from 'fs/promises';
+import { resolve } from 'path';
+import type { ExportContext, ExportResult } from '../core/types.js';
+
+export abstract class BaseExporter {
+  protected context: ExportContext;
+
+  constructor(context: ExportContext) {
+    this.context = context;
+  }
+
+  abstract getName(): string;
+  abstract export(): Promise<ExportResult>;
+
+  protected get db() {
+    return this.context.db;
+  }
+
+  protected get projectIds() {
+    return this.context.projectIds;
+  }
+
+  protected get baseUrl() {
+    return this.context.baseUrl;
+  }
+
+  protected get logger() {
+    return this.context.logger;
+  }
+
+  protected async writeJson(filename: string, data: unknown): Promise<void> {
+    const filePath = resolve(this.context.outputDir, filename);
+    await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+  }
+
+  protected placeholders(count: number): string {
+    return Array.from({ length: count }, () => '?').join(', ');
+  }
+
+  protected imageUrl(path: string): string {
+    return `${this.baseUrl}/${path}`;
+  }
+}

--- a/scripts/exporter/src/exporters/base-exporter.ts
+++ b/scripts/exporter/src/exporters/base-exporter.ts
@@ -1,43 +1,63 @@
-import { writeFile } from 'fs/promises';
-import { resolve } from 'path';
-import type { ExportContext, ExportResult } from '../core/types.js';
+import { writeFile } from 'fs/promises'
+import { resolve } from 'path'
+import type { ExportContext, ExportResult } from '../core/types.js'
 
 export abstract class BaseExporter {
-  protected context: ExportContext;
+  protected context: ExportContext
+  private _langCodeMap: Map<string, string> | null = null
 
   constructor(context: ExportContext) {
-    this.context = context;
+    this.context = context
   }
 
-  abstract getName(): string;
-  abstract export(): Promise<ExportResult>;
+  abstract getName(): string
+  abstract export(): Promise<ExportResult>
 
   protected get db() {
-    return this.context.db;
+    return this.context.db
   }
 
   protected get projectIds() {
-    return this.context.projectIds;
+    return this.context.projectIds
   }
 
   protected get baseUrl() {
-    return this.context.baseUrl;
+    return this.context.baseUrl
   }
 
   protected get logger() {
-    return this.context.logger;
+    return this.context.logger
+  }
+
+  /**
+   * Returns a map from language id (3-char ISO, e.g. 'eng') to the 2-char
+   * backward_compatibility code used as the key in exported JSON (e.g. 'en').
+   * Result is cached within the exporter instance.
+   */
+  protected async buildLangCodeMap(): Promise<Map<string, string>> {
+    if (this._langCodeMap) return this._langCodeMap
+
+    const rows = await this.db.query<{ id: string; backward_compatibility: string | null }>(
+      `SELECT id, backward_compatibility FROM languages`
+    )
+    this._langCodeMap = new Map(
+      rows
+        .filter(r => r.backward_compatibility !== null)
+        .map(r => [r.id, r.backward_compatibility as string])
+    )
+    return this._langCodeMap
   }
 
   protected async writeJson(filename: string, data: unknown): Promise<void> {
-    const filePath = resolve(this.context.outputDir, filename);
-    await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+    const filePath = resolve(this.context.outputDir, filename)
+    await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8')
   }
 
   protected placeholders(count: number): string {
-    return Array.from({ length: count }, () => '?').join(', ');
+    return Array.from({ length: count }, () => '?').join(', ')
   }
 
   protected imageUrl(path: string): string {
-    return `${this.baseUrl}/${path}`;
+    return `${this.baseUrl}/${path}`
   }
 }

--- a/scripts/exporter/src/exporters/collection-exporter.ts
+++ b/scripts/exporter/src/exporters/collection-exporter.ts
@@ -1,150 +1,163 @@
-import type { ExportResult } from '../core/types.js';
-import { BaseExporter } from './base-exporter.js';
+import type { ExportResult } from '../core/types.js'
+import { BaseExporter } from './base-exporter.js'
 
 interface CollectionRow {
-  id: string;
-  internal_name: string;
-  type: string;
-  backward_compatibility: string | null;
-  parent_id: string | null;
+  id: string
+  type: string
+  internal_name: string
+  backward_compatibility: string | null
+  parent_id: string | null
+  display_order: number | null
+  country_id: string | null
+  latitude: string | null
+  longitude: string | null
 }
 
 interface CollectionTranslationRow {
-  collection_id: string;
-  language_id: string;
-  title: string;
-  description: string | null;
-  url: string | null;
+  collection_id: string
+  language_id: string
+  title: string
+  description: string | null
+  quote: string | null
+  url: string | null
+  extra: string | null
 }
 
 interface CollectionImageRow {
-  collection_id: string;
-  id: string;
-  path: string;
-  alt_text: string | null;
-  display_order: number;
+  collection_id: string
+  path: string
+  alt_text: string | null
+  display_order: number
 }
 
 interface CollectionItemRow {
-  collection_id: string;
-  item_id: string;
-  display_order: number | null;
+  collection_id: string
+  item_id: string
+  display_order: number | null
 }
 
 export class CollectionExporter extends BaseExporter {
   getName(): string {
-    return 'Collections';
+    return 'Collections'
   }
 
   async export(): Promise<ExportResult> {
-    this.logger.info('Exporting collections.json...');
+    this.logger.info('Exporting collections.json...')
 
-    const ph = this.placeholders(this.projectIds.length);
+    // Collections are scoped to a project via its context_id.
+    // All collections (root + exhibitions + themes + pages) for a project
+    // share the same context_id as the project itself.
+    const ph = this.placeholders(this.projectIds.length)
 
-    // Collections that contain items from the given projects
     const collections = await this.db.query<CollectionRow>(
-      `SELECT DISTINCT c.id, c.internal_name, c.type, c.backward_compatibility, c.parent_id
+      `SELECT c.id, c.type, c.internal_name, c.backward_compatibility,
+              c.parent_id, c.display_order, c.country_id, c.latitude, c.longitude
        FROM collections c
-       JOIN collection_item ci ON c.id = ci.collection_id
-       JOIN items i ON ci.item_id = i.id
-       WHERE i.project_id IN (${ph})
-       ORDER BY c.type, c.internal_name`,
+       WHERE c.context_id IN (
+         SELECT p.context_id FROM projects p WHERE p.id IN (${ph})
+       )
+       ORDER BY c.parent_id IS NOT NULL, c.display_order, c.internal_name`,
       this.projectIds
-    );
+    )
 
     if (collections.length === 0) {
-      await this.writeJson('collections.json', []);
-      this.logger.warning('collections.json (0 collections)');
-      return { file: 'collections.json', count: 0 };
+      await this.writeJson('collections.json', [])
+      this.logger.warning('collections.json (0 collections)')
+      return { file: 'collections.json', count: 0 }
     }
 
-    const collectionIds = collections.map((c) => c.id);
-    const colPh = this.placeholders(collectionIds.length);
+    const collectionIds = collections.map(c => c.id)
+    const colPh = this.placeholders(collectionIds.length)
+    const langCodeMap = await this.buildLangCodeMap()
 
     const [translations, images, itemLinks] = await Promise.all([
       this.db.query<CollectionTranslationRow>(
-        `SELECT ct.collection_id, ct.language_id, ct.title, ct.description, ct.url
-         FROM collection_translations ct
-         WHERE ct.collection_id IN (${colPh})`,
+        `SELECT collection_id, language_id, title, description, quote, url, extra
+         FROM collection_translations
+         WHERE collection_id IN (${colPh})`,
         collectionIds
       ),
       this.db.query<CollectionImageRow>(
-        `SELECT ci.collection_id, ci.id, ci.path, ci.alt_text, ci.display_order
-         FROM collection_images ci
-         WHERE ci.collection_id IN (${colPh})
-         ORDER BY ci.collection_id, ci.display_order`,
+        `SELECT collection_id, path, alt_text, display_order
+         FROM collection_images
+         WHERE collection_id IN (${colPh})
+         ORDER BY collection_id, display_order`,
         collectionIds
       ),
+      // Items in these collections, restricted to non-picture items from the project
       this.db.query<CollectionItemRow>(
         `SELECT ci.collection_id, ci.item_id, ci.display_order
          FROM collection_item ci
-         JOIN items i ON ci.item_id = i.id
+         JOIN items i ON i.id = ci.item_id
          WHERE ci.collection_id IN (${colPh})
            AND i.project_id IN (${ph})
+           AND i.type IN ('object', 'monument', 'detail')
          ORDER BY ci.collection_id, ci.display_order`,
         [...collectionIds, ...this.projectIds]
       ),
-    ]);
+    ])
 
-    const langCodeMap = await this.buildLangCodeMap();
-
-    // Build translation map: collection_id -> lang_code -> fields
-    const translationMap = new Map<string, Record<string, Record<string, string | null>>>();
+    // collection_id -> lang_code -> fields
+    const translationMap = new Map<string, Record<string, Record<string, unknown>>>()
     for (const t of translations) {
-      if (!translationMap.has(t.collection_id)) {
-        translationMap.set(t.collection_id, {});
-      }
-      const code = langCodeMap.get(t.language_id);
-      if (code) {
-        translationMap.get(t.collection_id)![code] = {
-          title: t.title,
-          description: t.description,
-          url: t.url,
-        };
+      if (!translationMap.has(t.collection_id)) translationMap.set(t.collection_id, {})
+      const code = langCodeMap.get(t.language_id)
+      if (!code) continue
+      translationMap.get(t.collection_id)![code] = {
+        title: t.title,
+        description: t.description,
+        quote: t.quote,
+        url: t.url,
+        ...(t.extra ? { extra: parseJson(t.extra) } : {}),
       }
     }
 
-    // Build image map: collection_id -> images[]
-    const imageMap = new Map<string, { url: string; alt_text: string | null; display_order: number }[]>();
+    // collection_id -> images[]
+    const imageMap = new Map<
+      string,
+      { url: string; alt_text: string | null; display_order: number }[]
+    >()
     for (const img of images) {
-      if (!imageMap.has(img.collection_id)) {
-        imageMap.set(img.collection_id, []);
-      }
+      if (!imageMap.has(img.collection_id)) imageMap.set(img.collection_id, [])
       imageMap.get(img.collection_id)!.push({
         url: this.imageUrl(img.path),
         alt_text: img.alt_text,
         display_order: img.display_order,
-      });
+      })
     }
 
-    // Build item map: collection_id -> item_ids[]
-    const itemMap = new Map<string, string[]>();
+    // collection_id -> item_ids[]
+    const itemMap = new Map<string, string[]>()
     for (const link of itemLinks) {
-      if (!itemMap.has(link.collection_id)) {
-        itemMap.set(link.collection_id, []);
-      }
-      itemMap.get(link.collection_id)!.push(link.item_id);
+      if (!itemMap.has(link.collection_id)) itemMap.set(link.collection_id, [])
+      itemMap.get(link.collection_id)!.push(link.item_id)
     }
 
-    const output = collections.map((c) => ({
+    const output = collections.map(c => ({
       id: c.id,
       type: c.type,
       parent_id: c.parent_id,
+      country_id: c.country_id,
+      display_order: c.display_order,
+      latitude: c.latitude !== null ? parseFloat(c.latitude) : null,
+      longitude: c.longitude !== null ? parseFloat(c.longitude) : null,
       translations: translationMap.get(c.id) ?? {},
       images: imageMap.get(c.id) ?? [],
       item_ids: itemMap.get(c.id) ?? [],
-    }));
+    }))
 
-    await this.writeJson('collections.json', output);
-    this.logger.success(`collections.json (${output.length} collections)`);
+    await this.writeJson('collections.json', output)
+    this.logger.success(`collections.json (${output.length} collections)`)
 
-    return { file: 'collections.json', count: output.length };
+    return { file: 'collections.json', count: output.length }
   }
+}
 
-  private async buildLangCodeMap(): Promise<Map<string, string>> {
-    const rows = await this.db.query<{ id: string; backward_compatibility: string }>(
-      `SELECT id, backward_compatibility FROM languages`
-    );
-    return new Map(rows.map((r) => [r.id, r.backward_compatibility]));
+function parseJson(raw: string | null): unknown | null {
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as unknown
+  } catch {
+    return null
   }
 }

--- a/scripts/exporter/src/exporters/collection-exporter.ts
+++ b/scripts/exporter/src/exporters/collection-exporter.ts
@@ -1,0 +1,150 @@
+import type { ExportResult } from '../core/types.js';
+import { BaseExporter } from './base-exporter.js';
+
+interface CollectionRow {
+  id: string;
+  internal_name: string;
+  type: string;
+  backward_compatibility: string | null;
+  parent_id: string | null;
+}
+
+interface CollectionTranslationRow {
+  collection_id: string;
+  language_id: string;
+  title: string;
+  description: string | null;
+  url: string | null;
+}
+
+interface CollectionImageRow {
+  collection_id: string;
+  id: string;
+  path: string;
+  alt_text: string | null;
+  display_order: number;
+}
+
+interface CollectionItemRow {
+  collection_id: string;
+  item_id: string;
+  display_order: number | null;
+}
+
+export class CollectionExporter extends BaseExporter {
+  getName(): string {
+    return 'Collections';
+  }
+
+  async export(): Promise<ExportResult> {
+    this.logger.info('Exporting collections.json...');
+
+    const ph = this.placeholders(this.projectIds.length);
+
+    // Collections that contain items from the given projects
+    const collections = await this.db.query<CollectionRow>(
+      `SELECT DISTINCT c.id, c.internal_name, c.type, c.backward_compatibility, c.parent_id
+       FROM collections c
+       JOIN collection_item ci ON c.id = ci.collection_id
+       JOIN items i ON ci.item_id = i.id
+       WHERE i.project_id IN (${ph})
+       ORDER BY c.type, c.internal_name`,
+      this.projectIds
+    );
+
+    if (collections.length === 0) {
+      await this.writeJson('collections.json', []);
+      this.logger.warning('collections.json (0 collections)');
+      return { file: 'collections.json', count: 0 };
+    }
+
+    const collectionIds = collections.map((c) => c.id);
+    const colPh = this.placeholders(collectionIds.length);
+
+    const [translations, images, itemLinks] = await Promise.all([
+      this.db.query<CollectionTranslationRow>(
+        `SELECT ct.collection_id, ct.language_id, ct.title, ct.description, ct.url
+         FROM collection_translations ct
+         WHERE ct.collection_id IN (${colPh})`,
+        collectionIds
+      ),
+      this.db.query<CollectionImageRow>(
+        `SELECT ci.collection_id, ci.id, ci.path, ci.alt_text, ci.display_order
+         FROM collection_images ci
+         WHERE ci.collection_id IN (${colPh})
+         ORDER BY ci.collection_id, ci.display_order`,
+        collectionIds
+      ),
+      this.db.query<CollectionItemRow>(
+        `SELECT ci.collection_id, ci.item_id, ci.display_order
+         FROM collection_item ci
+         JOIN items i ON ci.item_id = i.id
+         WHERE ci.collection_id IN (${colPh})
+           AND i.project_id IN (${ph})
+         ORDER BY ci.collection_id, ci.display_order`,
+        [...collectionIds, ...this.projectIds]
+      ),
+    ]);
+
+    const langCodeMap = await this.buildLangCodeMap();
+
+    // Build translation map: collection_id -> lang_code -> fields
+    const translationMap = new Map<string, Record<string, Record<string, string | null>>>();
+    for (const t of translations) {
+      if (!translationMap.has(t.collection_id)) {
+        translationMap.set(t.collection_id, {});
+      }
+      const code = langCodeMap.get(t.language_id);
+      if (code) {
+        translationMap.get(t.collection_id)![code] = {
+          title: t.title,
+          description: t.description,
+          url: t.url,
+        };
+      }
+    }
+
+    // Build image map: collection_id -> images[]
+    const imageMap = new Map<string, { url: string; alt_text: string | null; display_order: number }[]>();
+    for (const img of images) {
+      if (!imageMap.has(img.collection_id)) {
+        imageMap.set(img.collection_id, []);
+      }
+      imageMap.get(img.collection_id)!.push({
+        url: this.imageUrl(img.path),
+        alt_text: img.alt_text,
+        display_order: img.display_order,
+      });
+    }
+
+    // Build item map: collection_id -> item_ids[]
+    const itemMap = new Map<string, string[]>();
+    for (const link of itemLinks) {
+      if (!itemMap.has(link.collection_id)) {
+        itemMap.set(link.collection_id, []);
+      }
+      itemMap.get(link.collection_id)!.push(link.item_id);
+    }
+
+    const output = collections.map((c) => ({
+      id: c.id,
+      type: c.type,
+      parent_id: c.parent_id,
+      translations: translationMap.get(c.id) ?? {},
+      images: imageMap.get(c.id) ?? [],
+      item_ids: itemMap.get(c.id) ?? [],
+    }));
+
+    await this.writeJson('collections.json', output);
+    this.logger.success(`collections.json (${output.length} collections)`);
+
+    return { file: 'collections.json', count: output.length };
+  }
+
+  private async buildLangCodeMap(): Promise<Map<string, string>> {
+    const rows = await this.db.query<{ id: string; backward_compatibility: string }>(
+      `SELECT id, backward_compatibility FROM languages`
+    );
+    return new Map(rows.map((r) => [r.id, r.backward_compatibility]));
+  }
+}

--- a/scripts/exporter/src/exporters/country-exporter.ts
+++ b/scripts/exporter/src/exporters/country-exporter.ts
@@ -1,61 +1,58 @@
-import type { ExportResult } from '../core/types.js';
-import { BaseExporter } from './base-exporter.js';
+import type { ExportResult } from '../core/types.js'
+import { BaseExporter } from './base-exporter.js'
 
 interface CountryRow {
-  id: string;
-  internal_name: string;
-  backward_compatibility: string;
+  id: string
+  internal_name: string
+  backward_compatibility: string
 }
 
 interface CountryTranslationRow {
-  country_id: string;
-  language_id: string;
-  name: string;
+  country_id: string
+  language_id: string
+  name: string
 }
 
 export class CountryExporter extends BaseExporter {
   getName(): string {
-    return 'Countries';
+    return 'Countries'
   }
 
   async export(): Promise<ExportResult> {
-    this.logger.info('Exporting countries.json...');
+    this.logger.info('Exporting countries.json...')
 
-    const countries = await this.db.query<CountryRow>(`SELECT id, internal_name, backward_compatibility FROM countries ORDER BY id`);
-    const translations = await this.db.query<CountryTranslationRow>(`SELECT country_id, language_id, name FROM country_translations`);
+    const countries = await this.db.query<CountryRow>(
+      `SELECT id, internal_name, backward_compatibility FROM countries ORDER BY id`
+    )
+    const translations = await this.db.query<CountryTranslationRow>(
+      `SELECT country_id, language_id, name FROM country_translations`
+    )
 
     // language id -> 2-char code
-    const langCodeMap = await this.buildLangCodeMap();
+    const langCodeMap = await this.buildLangCodeMap()
 
     // Build: country_id -> lang_code -> name
-    const translationMap = new Map<string, Record<string, string>>();
+    const translationMap = new Map<string, Record<string, string>>()
     for (const t of translations) {
       if (!translationMap.has(t.country_id)) {
-        translationMap.set(t.country_id, {});
+        translationMap.set(t.country_id, {})
       }
-      const code = langCodeMap.get(t.language_id);
+      const code = langCodeMap.get(t.language_id)
       if (code) {
-        translationMap.get(t.country_id)![code] = t.name;
+        translationMap.get(t.country_id)![code] = t.name
       }
     }
 
-    const output = countries.map((country) => ({
+    const output = countries.map(country => ({
       id: country.id,
       code: country.backward_compatibility,
       internal_name: country.internal_name,
       translations: translationMap.get(country.id) ?? {},
-    }));
+    }))
 
-    await this.writeJson('countries.json', output);
-    this.logger.success(`countries.json (${output.length} countries)`);
+    await this.writeJson('countries.json', output)
+    this.logger.success(`countries.json (${output.length} countries)`)
 
-    return { file: 'countries.json', count: output.length };
-  }
-
-  private async buildLangCodeMap(): Promise<Map<string, string>> {
-    const rows = await this.db.query<{ id: string; backward_compatibility: string }>(
-      `SELECT id, backward_compatibility FROM languages`
-    );
-    return new Map(rows.map((r) => [r.id, r.backward_compatibility]));
+    return { file: 'countries.json', count: output.length }
   }
 }

--- a/scripts/exporter/src/exporters/country-exporter.ts
+++ b/scripts/exporter/src/exporters/country-exporter.ts
@@ -1,0 +1,61 @@
+import type { ExportResult } from '../core/types.js';
+import { BaseExporter } from './base-exporter.js';
+
+interface CountryRow {
+  id: string;
+  internal_name: string;
+  backward_compatibility: string;
+}
+
+interface CountryTranslationRow {
+  country_id: string;
+  language_id: string;
+  name: string;
+}
+
+export class CountryExporter extends BaseExporter {
+  getName(): string {
+    return 'Countries';
+  }
+
+  async export(): Promise<ExportResult> {
+    this.logger.info('Exporting countries.json...');
+
+    const countries = await this.db.query<CountryRow>(`SELECT id, internal_name, backward_compatibility FROM countries ORDER BY id`);
+    const translations = await this.db.query<CountryTranslationRow>(`SELECT country_id, language_id, name FROM country_translations`);
+
+    // language id -> 2-char code
+    const langCodeMap = await this.buildLangCodeMap();
+
+    // Build: country_id -> lang_code -> name
+    const translationMap = new Map<string, Record<string, string>>();
+    for (const t of translations) {
+      if (!translationMap.has(t.country_id)) {
+        translationMap.set(t.country_id, {});
+      }
+      const code = langCodeMap.get(t.language_id);
+      if (code) {
+        translationMap.get(t.country_id)![code] = t.name;
+      }
+    }
+
+    const output = countries.map((country) => ({
+      id: country.id,
+      code: country.backward_compatibility,
+      internal_name: country.internal_name,
+      translations: translationMap.get(country.id) ?? {},
+    }));
+
+    await this.writeJson('countries.json', output);
+    this.logger.success(`countries.json (${output.length} countries)`);
+
+    return { file: 'countries.json', count: output.length };
+  }
+
+  private async buildLangCodeMap(): Promise<Map<string, string>> {
+    const rows = await this.db.query<{ id: string; backward_compatibility: string }>(
+      `SELECT id, backward_compatibility FROM languages`
+    );
+    return new Map(rows.map((r) => [r.id, r.backward_compatibility]));
+  }
+}

--- a/scripts/exporter/src/exporters/dynasty-exporter.ts
+++ b/scripts/exporter/src/exporters/dynasty-exporter.ts
@@ -1,69 +1,72 @@
-import type { ExportResult } from '../core/types.js';
-import { BaseExporter } from './base-exporter.js';
+import type { ExportResult } from '../core/types.js'
+import { BaseExporter } from './base-exporter.js'
 
 interface DynastyRow {
-  id: string;
-  backward_compatibility: string | null;
-  from_ah: number | null;
-  to_ah: number | null;
-  from_ad: number | null;
-  to_ad: number | null;
+  id: string
+  backward_compatibility: string | null
+  from_ah: number | null
+  to_ah: number | null
+  from_ad: number | null
+  to_ad: number | null
 }
 
 interface DynastyTranslationRow {
-  dynasty_id: string;
-  language_id: string;
-  name: string | null;
-  also_known_as: string | null;
-  area: string | null;
-  history: string | null;
-  date_description_ah: string | null;
-  date_description_ad: string | null;
+  dynasty_id: string
+  language_id: string
+  name: string | null
+  also_known_as: string | null
+  area: string | null
+  history: string | null
+  date_description_ah: string | null
+  date_description_ad: string | null
 }
 
 export class DynastyExporter extends BaseExporter {
   getName(): string {
-    return 'Dynasties';
+    return 'Dynasties'
   }
 
   async export(): Promise<ExportResult> {
-    this.logger.info('Exporting dynasties.json...');
+    this.logger.info('Exporting dynasties.json...')
 
-    // Export only dynasties linked to items in the given projects
-    const ph = this.placeholders(this.projectIds.length);
+    const ph = this.placeholders(this.projectIds.length)
+
+    // Only dynasties linked (via item_dynasty pivot) to non-picture items in the given projects
     const dynasties = await this.db.query<DynastyRow>(
       `SELECT DISTINCT d.id, d.backward_compatibility, d.from_ah, d.to_ah, d.from_ad, d.to_ad
        FROM dynasties d
        JOIN item_dynasty id2 ON d.id = id2.dynasty_id
        JOIN items i ON id2.item_id = i.id
        WHERE i.project_id IN (${ph})
+         AND i.type IN ('object', 'monument', 'detail')
        ORDER BY d.from_ad`,
       this.projectIds
-    );
+    )
 
     if (dynasties.length === 0) {
-      await this.writeJson('dynasties.json', []);
-      this.logger.warning('dynasties.json (0 dynasties — none linked to items in these projects)');
-      return { file: 'dynasties.json', count: 0 };
+      await this.writeJson('dynasties.json', [])
+      this.logger.warning('dynasties.json (0 — no dynasties linked to project items)')
+      return { file: 'dynasties.json', count: 0 }
     }
 
-    const dynastyIds = dynasties.map((d) => d.id);
+    const dynastyIds = dynasties.map(d => d.id)
+    const langCodeMap = await this.buildLangCodeMap()
+
     const translations = await this.db.query<DynastyTranslationRow>(
-      `SELECT dynasty_id, language_id, name, also_known_as, area, history, date_description_ah, date_description_ad
+      `SELECT dynasty_id, language_id, name, also_known_as, area, history,
+              date_description_ah, date_description_ad
        FROM dynasty_translations
        WHERE dynasty_id IN (${this.placeholders(dynastyIds.length)})`,
       dynastyIds
-    );
+    )
 
-    const langCodeMap = await this.buildLangCodeMap();
-
-    // Build: dynasty_id -> lang_code -> translation fields
-    const translationMap = new Map<string, Record<string, Record<string, string | null>>>();
+    // dynasty_id -> lang_code -> translation fields
+    const translationMap = new Map<string, Record<string, Record<string, string | null>>>()
     for (const t of translations) {
       if (!translationMap.has(t.dynasty_id)) {
-        translationMap.set(t.dynasty_id, {});
+        translationMap.set(t.dynasty_id, {})
       }
-      const code = langCodeMap.get(t.language_id);
+      const code = langCodeMap.get(t.language_id)
       if (code) {
         translationMap.get(t.dynasty_id)![code] = {
           name: t.name,
@@ -72,30 +75,22 @@ export class DynastyExporter extends BaseExporter {
           history: t.history,
           date_description_ah: t.date_description_ah,
           date_description_ad: t.date_description_ad,
-        };
+        }
       }
     }
 
-    const output = dynasties.map((d) => ({
+    const output = dynasties.map(d => ({
       id: d.id,
-      backward_compatibility: d.backward_compatibility,
       from_ah: d.from_ah,
       to_ah: d.to_ah,
       from_ad: d.from_ad,
       to_ad: d.to_ad,
       translations: translationMap.get(d.id) ?? {},
-    }));
+    }))
 
-    await this.writeJson('dynasties.json', output);
-    this.logger.success(`dynasties.json (${output.length} dynasties)`);
+    await this.writeJson('dynasties.json', output)
+    this.logger.success(`dynasties.json (${output.length} dynasties)`)
 
-    return { file: 'dynasties.json', count: output.length };
-  }
-
-  private async buildLangCodeMap(): Promise<Map<string, string>> {
-    const rows = await this.db.query<{ id: string; backward_compatibility: string }>(
-      `SELECT id, backward_compatibility FROM languages`
-    );
-    return new Map(rows.map((r) => [r.id, r.backward_compatibility]));
+    return { file: 'dynasties.json', count: output.length }
   }
 }

--- a/scripts/exporter/src/exporters/dynasty-exporter.ts
+++ b/scripts/exporter/src/exporters/dynasty-exporter.ts
@@ -1,0 +1,101 @@
+import type { ExportResult } from '../core/types.js';
+import { BaseExporter } from './base-exporter.js';
+
+interface DynastyRow {
+  id: string;
+  backward_compatibility: string | null;
+  from_ah: number | null;
+  to_ah: number | null;
+  from_ad: number | null;
+  to_ad: number | null;
+}
+
+interface DynastyTranslationRow {
+  dynasty_id: string;
+  language_id: string;
+  name: string | null;
+  also_known_as: string | null;
+  area: string | null;
+  history: string | null;
+  date_description_ah: string | null;
+  date_description_ad: string | null;
+}
+
+export class DynastyExporter extends BaseExporter {
+  getName(): string {
+    return 'Dynasties';
+  }
+
+  async export(): Promise<ExportResult> {
+    this.logger.info('Exporting dynasties.json...');
+
+    // Export only dynasties linked to items in the given projects
+    const ph = this.placeholders(this.projectIds.length);
+    const dynasties = await this.db.query<DynastyRow>(
+      `SELECT DISTINCT d.id, d.backward_compatibility, d.from_ah, d.to_ah, d.from_ad, d.to_ad
+       FROM dynasties d
+       JOIN item_dynasty id2 ON d.id = id2.dynasty_id
+       JOIN items i ON id2.item_id = i.id
+       WHERE i.project_id IN (${ph})
+       ORDER BY d.from_ad`,
+      this.projectIds
+    );
+
+    if (dynasties.length === 0) {
+      await this.writeJson('dynasties.json', []);
+      this.logger.warning('dynasties.json (0 dynasties — none linked to items in these projects)');
+      return { file: 'dynasties.json', count: 0 };
+    }
+
+    const dynastyIds = dynasties.map((d) => d.id);
+    const translations = await this.db.query<DynastyTranslationRow>(
+      `SELECT dynasty_id, language_id, name, also_known_as, area, history, date_description_ah, date_description_ad
+       FROM dynasty_translations
+       WHERE dynasty_id IN (${this.placeholders(dynastyIds.length)})`,
+      dynastyIds
+    );
+
+    const langCodeMap = await this.buildLangCodeMap();
+
+    // Build: dynasty_id -> lang_code -> translation fields
+    const translationMap = new Map<string, Record<string, Record<string, string | null>>>();
+    for (const t of translations) {
+      if (!translationMap.has(t.dynasty_id)) {
+        translationMap.set(t.dynasty_id, {});
+      }
+      const code = langCodeMap.get(t.language_id);
+      if (code) {
+        translationMap.get(t.dynasty_id)![code] = {
+          name: t.name,
+          also_known_as: t.also_known_as,
+          area: t.area,
+          history: t.history,
+          date_description_ah: t.date_description_ah,
+          date_description_ad: t.date_description_ad,
+        };
+      }
+    }
+
+    const output = dynasties.map((d) => ({
+      id: d.id,
+      backward_compatibility: d.backward_compatibility,
+      from_ah: d.from_ah,
+      to_ah: d.to_ah,
+      from_ad: d.from_ad,
+      to_ad: d.to_ad,
+      translations: translationMap.get(d.id) ?? {},
+    }));
+
+    await this.writeJson('dynasties.json', output);
+    this.logger.success(`dynasties.json (${output.length} dynasties)`);
+
+    return { file: 'dynasties.json', count: output.length };
+  }
+
+  private async buildLangCodeMap(): Promise<Map<string, string>> {
+    const rows = await this.db.query<{ id: string; backward_compatibility: string }>(
+      `SELECT id, backward_compatibility FROM languages`
+    );
+    return new Map(rows.map((r) => [r.id, r.backward_compatibility]));
+  }
+}

--- a/scripts/exporter/src/exporters/glossary-exporter.ts
+++ b/scripts/exporter/src/exporters/glossary-exporter.ts
@@ -1,0 +1,103 @@
+import type { ExportResult } from '../core/types.js';
+import { BaseExporter } from './base-exporter.js';
+
+interface GlossaryRow {
+  id: string;
+  internal_name: string;
+  backward_compatibility: string | null;
+}
+
+interface GlossaryTranslationRow {
+  glossary_id: string;
+  language_id: string;
+  definition: string;
+}
+
+interface GlossarySpellingRow {
+  glossary_id: string;
+  language_id: string;
+  spelling: string;
+}
+
+export class GlossaryExporter extends BaseExporter {
+  getName(): string {
+    return 'Glossary';
+  }
+
+  async export(): Promise<ExportResult> {
+    this.logger.info('Exporting glossary.json...');
+
+    const entries = await this.db.query<GlossaryRow>(
+      `SELECT id, internal_name, backward_compatibility FROM glossaries ORDER BY internal_name`
+    );
+
+    if (entries.length === 0) {
+      await this.writeJson('glossary.json', []);
+      this.logger.warning('glossary.json (0 entries)');
+      return { file: 'glossary.json', count: 0 };
+    }
+
+    const glossaryIds = entries.map((e) => e.id);
+    const glossPh = this.placeholders(glossaryIds.length);
+
+    const [translations, spellings] = await Promise.all([
+      this.db.query<GlossaryTranslationRow>(
+        `SELECT glossary_id, language_id, definition FROM glossary_translations WHERE glossary_id IN (${glossPh})`,
+        glossaryIds
+      ),
+      this.db.query<GlossarySpellingRow>(
+        `SELECT glossary_id, language_id, spelling FROM glossary_spellings WHERE glossary_id IN (${glossPh})`,
+        glossaryIds
+      ),
+    ]);
+
+    const langCodeMap = await this.buildLangCodeMap();
+
+    // Build: glossary_id -> lang_code -> definition
+    const definitionMap = new Map<string, Record<string, string>>();
+    for (const t of translations) {
+      if (!definitionMap.has(t.glossary_id)) {
+        definitionMap.set(t.glossary_id, {});
+      }
+      const code = langCodeMap.get(t.language_id);
+      if (code) {
+        definitionMap.get(t.glossary_id)![code] = t.definition;
+      }
+    }
+
+    // Build: glossary_id -> lang_code -> spellings[]
+    const spellingMap = new Map<string, Record<string, string[]>>();
+    for (const s of spellings) {
+      if (!spellingMap.has(s.glossary_id)) {
+        spellingMap.set(s.glossary_id, {});
+      }
+      const code = langCodeMap.get(s.language_id);
+      if (code) {
+        const map = spellingMap.get(s.glossary_id)!;
+        if (!map[code]) {
+          map[code] = [];
+        }
+        map[code].push(s.spelling);
+      }
+    }
+
+    const output = entries.map((entry) => ({
+      id: entry.id,
+      word: entry.internal_name,
+      definitions: definitionMap.get(entry.id) ?? {},
+      spellings: spellingMap.get(entry.id) ?? {},
+    }));
+
+    await this.writeJson('glossary.json', output);
+    this.logger.success(`glossary.json (${output.length} entries)`);
+
+    return { file: 'glossary.json', count: output.length };
+  }
+
+  private async buildLangCodeMap(): Promise<Map<string, string>> {
+    const rows = await this.db.query<{ id: string; backward_compatibility: string }>(
+      `SELECT id, backward_compatibility FROM languages`
+    );
+    return new Map(rows.map((r) => [r.id, r.backward_compatibility]));
+  }
+}

--- a/scripts/exporter/src/exporters/glossary-exporter.ts
+++ b/scripts/exporter/src/exporters/glossary-exporter.ts
@@ -1,44 +1,44 @@
-import type { ExportResult } from '../core/types.js';
-import { BaseExporter } from './base-exporter.js';
+import type { ExportResult } from '../core/types.js'
+import { BaseExporter } from './base-exporter.js'
 
 interface GlossaryRow {
-  id: string;
-  internal_name: string;
-  backward_compatibility: string | null;
+  id: string
+  internal_name: string
+  backward_compatibility: string | null
 }
 
 interface GlossaryTranslationRow {
-  glossary_id: string;
-  language_id: string;
-  definition: string;
+  glossary_id: string
+  language_id: string
+  definition: string
 }
 
 interface GlossarySpellingRow {
-  glossary_id: string;
-  language_id: string;
-  spelling: string;
+  glossary_id: string
+  language_id: string
+  spelling: string
 }
 
 export class GlossaryExporter extends BaseExporter {
   getName(): string {
-    return 'Glossary';
+    return 'Glossary'
   }
 
   async export(): Promise<ExportResult> {
-    this.logger.info('Exporting glossary.json...');
+    this.logger.info('Exporting glossary.json...')
 
     const entries = await this.db.query<GlossaryRow>(
       `SELECT id, internal_name, backward_compatibility FROM glossaries ORDER BY internal_name`
-    );
+    )
 
     if (entries.length === 0) {
-      await this.writeJson('glossary.json', []);
-      this.logger.warning('glossary.json (0 entries)');
-      return { file: 'glossary.json', count: 0 };
+      await this.writeJson('glossary.json', [])
+      this.logger.warning('glossary.json (0 entries)')
+      return { file: 'glossary.json', count: 0 }
     }
 
-    const glossaryIds = entries.map((e) => e.id);
-    const glossPh = this.placeholders(glossaryIds.length);
+    const glossaryIds = entries.map(e => e.id)
+    const glossPh = this.placeholders(glossaryIds.length)
 
     const [translations, spellings] = await Promise.all([
       this.db.query<GlossaryTranslationRow>(
@@ -49,55 +49,48 @@ export class GlossaryExporter extends BaseExporter {
         `SELECT glossary_id, language_id, spelling FROM glossary_spellings WHERE glossary_id IN (${glossPh})`,
         glossaryIds
       ),
-    ]);
+    ])
 
-    const langCodeMap = await this.buildLangCodeMap();
+    const langCodeMap = await this.buildLangCodeMap()
 
     // Build: glossary_id -> lang_code -> definition
-    const definitionMap = new Map<string, Record<string, string>>();
+    const definitionMap = new Map<string, Record<string, string>>()
     for (const t of translations) {
       if (!definitionMap.has(t.glossary_id)) {
-        definitionMap.set(t.glossary_id, {});
+        definitionMap.set(t.glossary_id, {})
       }
-      const code = langCodeMap.get(t.language_id);
+      const code = langCodeMap.get(t.language_id)
       if (code) {
-        definitionMap.get(t.glossary_id)![code] = t.definition;
+        definitionMap.get(t.glossary_id)![code] = t.definition
       }
     }
 
     // Build: glossary_id -> lang_code -> spellings[]
-    const spellingMap = new Map<string, Record<string, string[]>>();
+    const spellingMap = new Map<string, Record<string, string[]>>()
     for (const s of spellings) {
       if (!spellingMap.has(s.glossary_id)) {
-        spellingMap.set(s.glossary_id, {});
+        spellingMap.set(s.glossary_id, {})
       }
-      const code = langCodeMap.get(s.language_id);
+      const code = langCodeMap.get(s.language_id)
       if (code) {
-        const map = spellingMap.get(s.glossary_id)!;
+        const map = spellingMap.get(s.glossary_id)!
         if (!map[code]) {
-          map[code] = [];
+          map[code] = []
         }
-        map[code].push(s.spelling);
+        map[code].push(s.spelling)
       }
     }
 
-    const output = entries.map((entry) => ({
+    const output = entries.map(entry => ({
       id: entry.id,
       word: entry.internal_name,
       definitions: definitionMap.get(entry.id) ?? {},
       spellings: spellingMap.get(entry.id) ?? {},
-    }));
+    }))
 
-    await this.writeJson('glossary.json', output);
-    this.logger.success(`glossary.json (${output.length} entries)`);
+    await this.writeJson('glossary.json', output)
+    this.logger.success(`glossary.json (${output.length} entries)`)
 
-    return { file: 'glossary.json', count: output.length };
-  }
-
-  private async buildLangCodeMap(): Promise<Map<string, string>> {
-    const rows = await this.db.query<{ id: string; backward_compatibility: string }>(
-      `SELECT id, backward_compatibility FROM languages`
-    );
-    return new Map(rows.map((r) => [r.id, r.backward_compatibility]));
+    return { file: 'glossary.json', count: output.length }
   }
 }

--- a/scripts/exporter/src/exporters/index.ts
+++ b/scripts/exporter/src/exporters/index.ts
@@ -1,8 +1,8 @@
-export { ManifestExporter } from './manifest-exporter.js';
-export { LanguageExporter } from './language-exporter.js';
-export { CountryExporter } from './country-exporter.js';
-export { DynastyExporter } from './dynasty-exporter.js';
-export { PartnerExporter } from './partner-exporter.js';
-export { ItemExporter } from './item-exporter.js';
-export { CollectionExporter } from './collection-exporter.js';
-export { GlossaryExporter } from './glossary-exporter.js';
+export { ManifestExporter } from './manifest-exporter.js'
+export { LanguageExporter } from './language-exporter.js'
+export { CountryExporter } from './country-exporter.js'
+export { DynastyExporter } from './dynasty-exporter.js'
+export { PartnerExporter } from './partner-exporter.js'
+export { ItemExporter } from './item-exporter.js'
+export { CollectionExporter } from './collection-exporter.js'
+export { GlossaryExporter } from './glossary-exporter.js'

--- a/scripts/exporter/src/exporters/index.ts
+++ b/scripts/exporter/src/exporters/index.ts
@@ -1,0 +1,8 @@
+export { ManifestExporter } from './manifest-exporter.js';
+export { LanguageExporter } from './language-exporter.js';
+export { CountryExporter } from './country-exporter.js';
+export { DynastyExporter } from './dynasty-exporter.js';
+export { PartnerExporter } from './partner-exporter.js';
+export { ItemExporter } from './item-exporter.js';
+export { CollectionExporter } from './collection-exporter.js';
+export { GlossaryExporter } from './glossary-exporter.js';

--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -39,18 +39,25 @@ interface ItemTranslationRow {
   provenance: string | null
   obtention: string | null
   bibliography: string | null
-  extra: string | null
   author_name: string | null
   copy_editor_name: string | null
   translator_name: string | null
   translation_copy_editor_name: string | null
 }
 
-interface ItemImageRow {
-  item_id: string
+interface PictureItemRow {
+  picture_id: string
+  item_id: string // parent_id
+  display_order: number | null
   path: string
   alt_text: string | null
-  display_order: number
+}
+
+interface PictureTranslationRow {
+  picture_id: string
+  language_id: string
+  caption: string | null // name field on picture item translations
+  extra: string | null // JSON: { photographer, copyright }
 }
 
 interface ItemDynastyRow {
@@ -73,8 +80,7 @@ export class ItemExporter extends BaseExporter {
 
     const ph = this.placeholders(this.projectIds.length)
 
-    // Exclude 'picture' child items — those are internal importer artefacts.
-    // We export objects, monuments, and monument details.
+    // Exclude 'picture' child items — those are exported as images on their parent.
     const items = await this.db.query<ItemRow>(
       `SELECT id, type, internal_name, backward_compatibility, parent_id,
               partner_id, country_id, collection_id, project_id,
@@ -97,36 +103,57 @@ export class ItemExporter extends BaseExporter {
     const itemPh = this.placeholders(itemIds.length)
     const langCodeMap = await this.buildLangCodeMap()
 
-    const [translations, images, dynastyLinks, tagLinks] = await Promise.all([
-      // Join authors to resolve their names directly — avoids a second round-trip
-      this.db.query<ItemTranslationRow>(
-        `SELECT it.item_id, it.language_id,
-                it.name, it.alternate_name, it.description,
-                it.type, it.holder, it.owner, it.initial_owner, it.dates,
-                it.location, it.dimensions, it.place_of_production,
-                it.method_for_datation, it.method_for_provenance,
-                it.provenance, it.obtention, it.bibliography, it.extra,
-                a1.name AS author_name,
-                a2.name AS copy_editor_name,
-                a3.name AS translator_name,
-                a4.name AS translation_copy_editor_name
-         FROM item_translations it
-         LEFT JOIN authors a1 ON a1.id = it.author_id
-         LEFT JOIN authors a2 ON a2.id = it.text_copy_editor_id
-         LEFT JOIN authors a3 ON a3.id = it.translator_id
-         LEFT JOIN authors a4 ON a4.id = it.translation_copy_editor_id
-         WHERE it.item_id IN (${itemPh})`,
-        itemIds
-      ),
-      // item_images: the importer attaches the first picture's image directly to the
-      // parent object/monument. Only these direct attachments are exported here.
-      this.db.query<ItemImageRow>(
-        `SELECT item_id, path, alt_text, display_order
-         FROM item_images
-         WHERE item_id IN (${itemPh})
-         ORDER BY item_id, display_order`,
-        itemIds
-      ),
+    // ── 1. Content translations (name, description, …) ──────────────────────
+    const translations = await this.db.query<ItemTranslationRow>(
+      `SELECT it.item_id, it.language_id,
+              it.name, it.alternate_name, it.description,
+              it.type, it.holder, it.owner, it.initial_owner, it.dates,
+              it.location, it.dimensions, it.place_of_production,
+              it.method_for_datation, it.method_for_provenance,
+              it.provenance, it.obtention, it.bibliography,
+              a1.name AS author_name,
+              a2.name AS copy_editor_name,
+              a3.name AS translator_name,
+              a4.name AS translation_copy_editor_name
+       FROM item_translations it
+       LEFT JOIN authors a1 ON a1.id = it.author_id
+       LEFT JOIN authors a2 ON a2.id = it.text_copy_editor_id
+       LEFT JOIN authors a3 ON a3.id = it.translator_id
+       LEFT JOIN authors a4 ON a4.id = it.translation_copy_editor_id
+       WHERE it.item_id IN (${itemPh})`,
+      itemIds
+    )
+
+    // ── 2. Images via picture child items ────────────────────────────────────
+    // Each image is a child item of type 'picture'. It carries:
+    //   - items.display_order  → position in the gallery
+    //   - item_images.path     → the file path
+    //   - item_translations.name (caption, per language)
+    //   - item_translations.extra JSON { photographer, copyright }
+    const pictureItems = await this.db.query<PictureItemRow>(
+      `SELECT pic.id AS picture_id, pic.parent_id AS item_id,
+              pic.display_order, ii.path, ii.alt_text
+       FROM items pic
+       JOIN item_images ii ON ii.item_id = pic.id
+       WHERE pic.type = 'picture'
+         AND pic.parent_id IN (${itemPh})
+       ORDER BY pic.parent_id, pic.display_order`,
+      itemIds
+    )
+
+    let pictureTranslations: PictureTranslationRow[] = []
+    if (pictureItems.length > 0) {
+      const pictureIds = [...new Set(pictureItems.map(p => p.picture_id))]
+      pictureTranslations = await this.db.query<PictureTranslationRow>(
+        `SELECT item_id AS picture_id, language_id, name AS caption, extra
+         FROM item_translations
+         WHERE item_id IN (${this.placeholders(pictureIds.length)})`,
+        pictureIds
+      )
+    }
+
+    // ── 3. Dynasty and tag links ─────────────────────────────────────────────
+    const [dynastyLinks, tagLinks] = await Promise.all([
       this.db.query<ItemDynastyRow>(
         `SELECT item_id, dynasty_id FROM item_dynasty WHERE item_id IN (${itemPh})`,
         itemIds
@@ -140,17 +167,14 @@ export class ItemExporter extends BaseExporter {
       ),
     ])
 
+    // ── Build maps ───────────────────────────────────────────────────────────
+
     // item_id -> lang_code -> translation fields
     const translationMap = new Map<string, Record<string, Record<string, unknown>>>()
     for (const t of translations) {
-      if (!translationMap.has(t.item_id)) {
-        translationMap.set(t.item_id, {})
-      }
+      if (!translationMap.has(t.item_id)) translationMap.set(t.item_id, {})
       const code = langCodeMap.get(t.language_id)
       if (!code) continue
-
-      const extraParsed = parseJson(t.extra)
-
       translationMap.get(t.item_id)![code] = {
         name: t.name,
         alternate_name: t.alternate_name,
@@ -172,21 +196,50 @@ export class ItemExporter extends BaseExporter {
         copy_editor: t.copy_editor_name,
         translator: t.translator_name,
         translation_copy_editor: t.translation_copy_editor_name,
-        ...(extraParsed ? { extra: extraParsed } : {}),
       }
     }
 
-    // item_id -> images[]
-    const imageMap = new Map<
+    // picture_id -> lang_code -> { caption, photographer, copyright }
+    const picTransMap = new Map<
       string,
-      { url: string; alt_text: string | null; display_order: number }[]
+      Record<
+        string,
+        { caption: string | null; photographer: string | null; copyright: string | null }
+      >
     >()
-    for (const img of images) {
-      if (!imageMap.has(img.item_id)) imageMap.set(img.item_id, [])
-      imageMap.get(img.item_id)!.push({
-        url: this.imageUrl(img.path),
-        alt_text: img.alt_text,
-        display_order: img.display_order,
+    for (const t of pictureTranslations) {
+      if (!picTransMap.has(t.picture_id)) picTransMap.set(t.picture_id, {})
+      const code = langCodeMap.get(t.language_id)
+      if (!code) continue
+      const extra = parseJson(t.extra) as Record<string, string> | null
+      picTransMap.get(t.picture_id)![code] = {
+        caption: t.caption,
+        photographer: extra?.photographer ?? null,
+        copyright: extra?.copyright ?? null,
+      }
+    }
+
+    // item_id -> images[] (built from picture children)
+    const imageMap = new Map<string, ImageEntry[]>()
+    for (const pic of pictureItems) {
+      if (!imageMap.has(pic.item_id)) imageMap.set(pic.item_id, [])
+      const perLang = picTransMap.get(pic.picture_id) ?? {}
+
+      // photographer/copyright are not language-specific; pick from first available lang
+      const firstLang = Object.values(perLang)[0]
+
+      // Collect captions keyed by lang code
+      const captions: Record<string, string | null> = {}
+      for (const [lang, t] of Object.entries(perLang)) {
+        captions[lang] = t.caption
+      }
+
+      imageMap.get(pic.item_id)!.push({
+        url: this.imageUrl(pic.path),
+        display_order: pic.display_order,
+        captions,
+        photographer: firstLang?.photographer ?? null,
+        copyright: firstLang?.copyright ?? null,
       })
     }
 
@@ -228,6 +281,14 @@ export class ItemExporter extends BaseExporter {
 
     return { file: 'items.json', count: output.length }
   }
+}
+
+interface ImageEntry {
+  url: string
+  display_order: number | null
+  captions: Record<string, string | null>
+  photographer: string | null
+  copyright: string | null
 }
 
 function parseJson(raw: string | null): unknown | null {

--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -1,97 +1,130 @@
-import type { ExportResult } from '../core/types.js';
-import { BaseExporter } from './base-exporter.js';
+import type { ExportResult } from '../core/types.js'
+import { BaseExporter } from './base-exporter.js'
 
 interface ItemRow {
-  id: string;
-  internal_name: string;
-  backward_compatibility: string | null;
-  type: string;
-  partner_id: string | null;
-  country_id: string | null;
-  collection_id: string | null;
-  owner_reference: string | null;
-  mwnf_reference: string | null;
-  latitude: string | null;
-  longitude: string | null;
+  id: string
+  type: string
+  internal_name: string
+  backward_compatibility: string | null
+  parent_id: string | null
+  partner_id: string | null
+  country_id: string | null
+  collection_id: string | null
+  project_id: string | null
+  owner_reference: string | null
+  mwnf_reference: string | null
+  start_date: number | null
+  end_date: number | null
+  display_order: number | null
+  latitude: string | null
+  longitude: string | null
 }
 
 interface ItemTranslationRow {
-  item_id: string;
-  language_id: string;
-  name: string;
-  alternate_name: string | null;
-  description: string | null;
-  type: string | null;
-  holder: string | null;
-  owner: string | null;
-  dates: string | null;
-  location: string | null;
-  dimensions: string | null;
-  place_of_production: string | null;
-  bibliography: string | null;
-  provenance: string | null;
+  item_id: string
+  language_id: string
+  name: string
+  alternate_name: string | null
+  description: string | null
+  type: string | null
+  holder: string | null
+  owner: string | null
+  initial_owner: string | null
+  dates: string | null
+  location: string | null
+  dimensions: string | null
+  place_of_production: string | null
+  method_for_datation: string | null
+  method_for_provenance: string | null
+  provenance: string | null
+  obtention: string | null
+  bibliography: string | null
+  extra: string | null
+  author_name: string | null
+  copy_editor_name: string | null
+  translator_name: string | null
+  translation_copy_editor_name: string | null
 }
 
 interface ItemImageRow {
-  item_id: string;
-  id: string;
-  path: string;
-  alt_text: string | null;
-  display_order: number;
+  item_id: string
+  path: string
+  alt_text: string | null
+  display_order: number
 }
 
 interface ItemDynastyRow {
-  item_id: string;
-  dynasty_id: string;
+  item_id: string
+  dynasty_id: string
 }
 
 interface ItemTagRow {
-  item_id: string;
-  tag_description: string;
+  item_id: string
+  tag: string
 }
 
 export class ItemExporter extends BaseExporter {
   getName(): string {
-    return 'Items';
+    return 'Items'
   }
 
   async export(): Promise<ExportResult> {
-    this.logger.info('Exporting items.json...');
+    this.logger.info('Exporting items.json...')
 
-    const ph = this.placeholders(this.projectIds.length);
+    const ph = this.placeholders(this.projectIds.length)
 
+    // Exclude 'picture' child items — those are internal importer artefacts.
+    // We export objects, monuments, and monument details.
     const items = await this.db.query<ItemRow>(
-      `SELECT id, internal_name, backward_compatibility, type, partner_id, country_id,
-              collection_id, owner_reference, mwnf_reference, latitude, longitude
+      `SELECT id, type, internal_name, backward_compatibility, parent_id,
+              partner_id, country_id, collection_id, project_id,
+              owner_reference, mwnf_reference, start_date, end_date,
+              display_order, latitude, longitude
        FROM items
        WHERE project_id IN (${ph})
-       ORDER BY type, internal_name`,
+         AND type IN ('object', 'monument', 'detail')
+       ORDER BY type, display_order, internal_name`,
       this.projectIds
-    );
+    )
 
     if (items.length === 0) {
-      await this.writeJson('items.json', []);
-      this.logger.warning('items.json (0 items)');
-      return { file: 'items.json', count: 0 };
+      await this.writeJson('items.json', [])
+      this.logger.warning('items.json (0 items)')
+      return { file: 'items.json', count: 0 }
     }
 
-    const itemIds = items.map((i) => i.id);
-    const itemPh = this.placeholders(itemIds.length);
+    const itemIds = items.map(i => i.id)
+    const itemPh = this.placeholders(itemIds.length)
+    const langCodeMap = await this.buildLangCodeMap()
 
     const [translations, images, dynastyLinks, tagLinks] = await Promise.all([
+      // Join authors to resolve their names directly — avoids a second round-trip
       this.db.query<ItemTranslationRow>(
-        `SELECT it.item_id, it.language_id, it.name, it.alternate_name, it.description,
-                it.type, it.holder, it.owner, it.dates, it.location, it.dimensions,
-                it.place_of_production, it.bibliography, it.provenance
+        `SELECT it.item_id, it.language_id,
+                it.name, it.alternate_name, it.description,
+                it.type, it.holder, it.owner, it.initial_owner, it.dates,
+                it.location, it.dimensions, it.place_of_production,
+                it.method_for_datation, it.method_for_provenance,
+                it.provenance, it.obtention, it.bibliography, it.extra,
+                a1.name AS author_name,
+                a2.name AS copy_editor_name,
+                a3.name AS translator_name,
+                a4.name AS translation_copy_editor_name
          FROM item_translations it
+         LEFT JOIN authors a1 ON a1.id = it.author_id
+         LEFT JOIN authors a2 ON a2.id = it.text_copy_editor_id
+         LEFT JOIN authors a3 ON a3.id = it.translator_id
+         LEFT JOIN authors a4 ON a4.id = it.translation_copy_editor_id
          WHERE it.item_id IN (${itemPh})`,
         itemIds
       ),
+      // item_images: the importer attaches the first picture's image directly to the
+      // parent object/monument. Only these direct attachments are exported here.
       this.db.query<ItemImageRow>(
-        `SELECT ii.item_id, ii.id, ii.path, ii.alt_text, ii.display_order
-         FROM item_images ii
-         WHERE ii.item_id IN (${itemPh})
-         ORDER BY ii.item_id, ii.display_order`,
+        `SELECT item_id, path, alt_text, display_order
+         FROM item_images
+         WHERE item_id IN (${itemPh})
+         ORDER BY item_id, display_order`,
         itemIds
       ),
       this.db.query<ItemDynastyRow>(
@@ -99,98 +132,109 @@ export class ItemExporter extends BaseExporter {
         itemIds
       ),
       this.db.query<ItemTagRow>(
-        `SELECT it.item_id, t.description AS tag_description
-         FROM item_tag it
-         JOIN tags t ON t.id = it.tag_id
-         WHERE it.item_id IN (${itemPh})`,
+        `SELECT it2.item_id, t.description AS tag
+         FROM item_tag it2
+         JOIN tags t ON t.id = it2.tag_id
+         WHERE it2.item_id IN (${itemPh})`,
         itemIds
       ),
-    ]);
+    ])
 
-    const langCodeMap = await this.buildLangCodeMap();
-
-    // Build translation map: item_id -> lang_code -> fields
-    const translationMap = new Map<string, Record<string, Record<string, string | null>>>();
+    // item_id -> lang_code -> translation fields
+    const translationMap = new Map<string, Record<string, Record<string, unknown>>>()
     for (const t of translations) {
       if (!translationMap.has(t.item_id)) {
-        translationMap.set(t.item_id, {});
+        translationMap.set(t.item_id, {})
       }
-      const code = langCodeMap.get(t.language_id);
-      if (code) {
-        translationMap.get(t.item_id)![code] = {
-          name: t.name,
-          alternate_name: t.alternate_name,
-          description: t.description,
-          type: t.type,
-          holder: t.holder,
-          owner: t.owner,
-          dates: t.dates,
-          location: t.location,
-          dimensions: t.dimensions,
-          place_of_production: t.place_of_production,
-          bibliography: t.bibliography,
-          provenance: t.provenance,
-        };
+      const code = langCodeMap.get(t.language_id)
+      if (!code) continue
+
+      const extraParsed = parseJson(t.extra)
+
+      translationMap.get(t.item_id)![code] = {
+        name: t.name,
+        alternate_name: t.alternate_name,
+        description: t.description,
+        type: t.type,
+        holder: t.holder,
+        owner: t.owner,
+        initial_owner: t.initial_owner,
+        dates: t.dates,
+        location: t.location,
+        dimensions: t.dimensions,
+        place_of_production: t.place_of_production,
+        method_for_datation: t.method_for_datation,
+        method_for_provenance: t.method_for_provenance,
+        provenance: t.provenance,
+        obtention: t.obtention,
+        bibliography: t.bibliography,
+        author: t.author_name,
+        copy_editor: t.copy_editor_name,
+        translator: t.translator_name,
+        translation_copy_editor: t.translation_copy_editor_name,
+        ...(extraParsed ? { extra: extraParsed } : {}),
       }
     }
 
-    // Build image map: item_id -> images[]
-    const imageMap = new Map<string, { url: string; alt_text: string | null; display_order: number }[]>();
+    // item_id -> images[]
+    const imageMap = new Map<
+      string,
+      { url: string; alt_text: string | null; display_order: number }[]
+    >()
     for (const img of images) {
-      if (!imageMap.has(img.item_id)) {
-        imageMap.set(img.item_id, []);
-      }
+      if (!imageMap.has(img.item_id)) imageMap.set(img.item_id, [])
       imageMap.get(img.item_id)!.push({
         url: this.imageUrl(img.path),
         alt_text: img.alt_text,
         display_order: img.display_order,
-      });
+      })
     }
 
-    // Build dynasty map: item_id -> dynasty_ids[]
-    const dynastyMap = new Map<string, string[]>();
+    // item_id -> dynasty_ids[]
+    const dynastyMap = new Map<string, string[]>()
     for (const link of dynastyLinks) {
-      if (!dynastyMap.has(link.item_id)) {
-        dynastyMap.set(link.item_id, []);
-      }
-      dynastyMap.get(link.item_id)!.push(link.dynasty_id);
+      if (!dynastyMap.has(link.item_id)) dynastyMap.set(link.item_id, [])
+      dynastyMap.get(link.item_id)!.push(link.dynasty_id)
     }
 
-    // Build tag map: item_id -> tag descriptions[]
-    const tagMap = new Map<string, string[]>();
+    // item_id -> tags[]
+    const tagMap = new Map<string, string[]>()
     for (const link of tagLinks) {
-      if (!tagMap.has(link.item_id)) {
-        tagMap.set(link.item_id, []);
-      }
-      tagMap.get(link.item_id)!.push(link.tag_description);
+      if (!tagMap.has(link.item_id)) tagMap.set(link.item_id, [])
+      tagMap.get(link.item_id)!.push(link.tag)
     }
 
-    const output = items.map((item) => ({
+    const output = items.map(item => ({
       id: item.id,
       type: item.type,
+      parent_id: item.parent_id,
       partner_id: item.partner_id,
       country_id: item.country_id,
-      collection_id: item.collection_id,
+      project_id: item.project_id,
       owner_reference: item.owner_reference,
       mwnf_reference: item.mwnf_reference,
-      latitude: item.latitude ? parseFloat(item.latitude) : null,
-      longitude: item.longitude ? parseFloat(item.longitude) : null,
+      start_date: item.start_date,
+      end_date: item.end_date,
+      latitude: item.latitude !== null ? parseFloat(item.latitude) : null,
+      longitude: item.longitude !== null ? parseFloat(item.longitude) : null,
       translations: translationMap.get(item.id) ?? {},
       images: imageMap.get(item.id) ?? [],
       dynasty_ids: dynastyMap.get(item.id) ?? [],
       tags: tagMap.get(item.id) ?? [],
-    }));
+    }))
 
-    await this.writeJson('items.json', output);
-    this.logger.success(`items.json (${output.length} items)`);
+    await this.writeJson('items.json', output)
+    this.logger.success(`items.json (${output.length} items)`)
 
-    return { file: 'items.json', count: output.length };
+    return { file: 'items.json', count: output.length }
   }
+}
 
-  private async buildLangCodeMap(): Promise<Map<string, string>> {
-    const rows = await this.db.query<{ id: string; backward_compatibility: string }>(
-      `SELECT id, backward_compatibility FROM languages`
-    );
-    return new Map(rows.map((r) => [r.id, r.backward_compatibility]));
+function parseJson(raw: string | null): unknown | null {
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as unknown
+  } catch {
+    return null
   }
 }

--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -1,0 +1,196 @@
+import type { ExportResult } from '../core/types.js';
+import { BaseExporter } from './base-exporter.js';
+
+interface ItemRow {
+  id: string;
+  internal_name: string;
+  backward_compatibility: string | null;
+  type: string;
+  partner_id: string | null;
+  country_id: string | null;
+  collection_id: string | null;
+  owner_reference: string | null;
+  mwnf_reference: string | null;
+  latitude: string | null;
+  longitude: string | null;
+}
+
+interface ItemTranslationRow {
+  item_id: string;
+  language_id: string;
+  name: string;
+  alternate_name: string | null;
+  description: string | null;
+  type: string | null;
+  holder: string | null;
+  owner: string | null;
+  dates: string | null;
+  location: string | null;
+  dimensions: string | null;
+  place_of_production: string | null;
+  bibliography: string | null;
+  provenance: string | null;
+}
+
+interface ItemImageRow {
+  item_id: string;
+  id: string;
+  path: string;
+  alt_text: string | null;
+  display_order: number;
+}
+
+interface ItemDynastyRow {
+  item_id: string;
+  dynasty_id: string;
+}
+
+interface ItemTagRow {
+  item_id: string;
+  tag_description: string;
+}
+
+export class ItemExporter extends BaseExporter {
+  getName(): string {
+    return 'Items';
+  }
+
+  async export(): Promise<ExportResult> {
+    this.logger.info('Exporting items.json...');
+
+    const ph = this.placeholders(this.projectIds.length);
+
+    const items = await this.db.query<ItemRow>(
+      `SELECT id, internal_name, backward_compatibility, type, partner_id, country_id,
+              collection_id, owner_reference, mwnf_reference, latitude, longitude
+       FROM items
+       WHERE project_id IN (${ph})
+       ORDER BY type, internal_name`,
+      this.projectIds
+    );
+
+    if (items.length === 0) {
+      await this.writeJson('items.json', []);
+      this.logger.warning('items.json (0 items)');
+      return { file: 'items.json', count: 0 };
+    }
+
+    const itemIds = items.map((i) => i.id);
+    const itemPh = this.placeholders(itemIds.length);
+
+    const [translations, images, dynastyLinks, tagLinks] = await Promise.all([
+      this.db.query<ItemTranslationRow>(
+        `SELECT it.item_id, it.language_id, it.name, it.alternate_name, it.description,
+                it.type, it.holder, it.owner, it.dates, it.location, it.dimensions,
+                it.place_of_production, it.bibliography, it.provenance
+         FROM item_translations it
+         WHERE it.item_id IN (${itemPh})`,
+        itemIds
+      ),
+      this.db.query<ItemImageRow>(
+        `SELECT ii.item_id, ii.id, ii.path, ii.alt_text, ii.display_order
+         FROM item_images ii
+         WHERE ii.item_id IN (${itemPh})
+         ORDER BY ii.item_id, ii.display_order`,
+        itemIds
+      ),
+      this.db.query<ItemDynastyRow>(
+        `SELECT item_id, dynasty_id FROM item_dynasty WHERE item_id IN (${itemPh})`,
+        itemIds
+      ),
+      this.db.query<ItemTagRow>(
+        `SELECT it.item_id, t.description AS tag_description
+         FROM item_tag it
+         JOIN tags t ON t.id = it.tag_id
+         WHERE it.item_id IN (${itemPh})`,
+        itemIds
+      ),
+    ]);
+
+    const langCodeMap = await this.buildLangCodeMap();
+
+    // Build translation map: item_id -> lang_code -> fields
+    const translationMap = new Map<string, Record<string, Record<string, string | null>>>();
+    for (const t of translations) {
+      if (!translationMap.has(t.item_id)) {
+        translationMap.set(t.item_id, {});
+      }
+      const code = langCodeMap.get(t.language_id);
+      if (code) {
+        translationMap.get(t.item_id)![code] = {
+          name: t.name,
+          alternate_name: t.alternate_name,
+          description: t.description,
+          type: t.type,
+          holder: t.holder,
+          owner: t.owner,
+          dates: t.dates,
+          location: t.location,
+          dimensions: t.dimensions,
+          place_of_production: t.place_of_production,
+          bibliography: t.bibliography,
+          provenance: t.provenance,
+        };
+      }
+    }
+
+    // Build image map: item_id -> images[]
+    const imageMap = new Map<string, { url: string; alt_text: string | null; display_order: number }[]>();
+    for (const img of images) {
+      if (!imageMap.has(img.item_id)) {
+        imageMap.set(img.item_id, []);
+      }
+      imageMap.get(img.item_id)!.push({
+        url: this.imageUrl(img.path),
+        alt_text: img.alt_text,
+        display_order: img.display_order,
+      });
+    }
+
+    // Build dynasty map: item_id -> dynasty_ids[]
+    const dynastyMap = new Map<string, string[]>();
+    for (const link of dynastyLinks) {
+      if (!dynastyMap.has(link.item_id)) {
+        dynastyMap.set(link.item_id, []);
+      }
+      dynastyMap.get(link.item_id)!.push(link.dynasty_id);
+    }
+
+    // Build tag map: item_id -> tag descriptions[]
+    const tagMap = new Map<string, string[]>();
+    for (const link of tagLinks) {
+      if (!tagMap.has(link.item_id)) {
+        tagMap.set(link.item_id, []);
+      }
+      tagMap.get(link.item_id)!.push(link.tag_description);
+    }
+
+    const output = items.map((item) => ({
+      id: item.id,
+      type: item.type,
+      partner_id: item.partner_id,
+      country_id: item.country_id,
+      collection_id: item.collection_id,
+      owner_reference: item.owner_reference,
+      mwnf_reference: item.mwnf_reference,
+      latitude: item.latitude ? parseFloat(item.latitude) : null,
+      longitude: item.longitude ? parseFloat(item.longitude) : null,
+      translations: translationMap.get(item.id) ?? {},
+      images: imageMap.get(item.id) ?? [],
+      dynasty_ids: dynastyMap.get(item.id) ?? [],
+      tags: tagMap.get(item.id) ?? [],
+    }));
+
+    await this.writeJson('items.json', output);
+    this.logger.success(`items.json (${output.length} items)`);
+
+    return { file: 'items.json', count: output.length };
+  }
+
+  private async buildLangCodeMap(): Promise<Map<string, string>> {
+    const rows = await this.db.query<{ id: string; backward_compatibility: string }>(
+      `SELECT id, backward_compatibility FROM languages`
+    );
+    return new Map(rows.map((r) => [r.id, r.backward_compatibility]));
+  }
+}

--- a/scripts/exporter/src/exporters/language-exporter.ts
+++ b/scripts/exporter/src/exporters/language-exporter.ts
@@ -1,61 +1,73 @@
-import type { ExportResult } from '../core/types.js';
-import { BaseExporter } from './base-exporter.js';
+import type { ExportResult } from '../core/types.js'
+import { BaseExporter } from './base-exporter.js'
 
 interface LangRow {
-  id: string;
-  internal_name: string;
-  backward_compatibility: string;
+  id: string
+  internal_name: string
+  backward_compatibility: string | null
+  is_default: number
 }
 
 interface LangTranslationRow {
-  language_id: string;
-  display_language_id: string;
-  name: string;
+  language_id: string
+  display_language_id: string
+  name: string
 }
 
 export class LanguageExporter extends BaseExporter {
   getName(): string {
-    return 'Languages';
+    return 'Languages'
   }
 
   async export(): Promise<ExportResult> {
-    this.logger.info('Exporting languages.json...');
+    this.logger.info('Exporting languages.json...')
 
-    const langs = await this.db.query<LangRow>(`SELECT id, internal_name, backward_compatibility FROM languages ORDER BY id`);
-    const translations = await this.db.query<LangTranslationRow>(`SELECT language_id, display_language_id, name FROM language_translations`);
+    const langs = await this.db.query<LangRow>(
+      `SELECT id, internal_name, backward_compatibility, is_default
+       FROM languages
+       ORDER BY id`
+    )
 
-    // Build lookup: language_id -> display_language_id -> name
-    const translationMap = new Map<string, Map<string, string>>();
+    const translations = await this.db.query<LangTranslationRow>(
+      `SELECT language_id, display_language_id, name FROM language_translations`
+    )
+
+    // id -> backward_compatibility (2-char code, e.g. 'en')
+    const idToCode = new Map<string, string>(
+      langs
+        .filter(l => l.backward_compatibility !== null)
+        .map(l => [l.id, l.backward_compatibility as string])
+    )
+
+    // language_id -> display_language_id (2-char code) -> name
+    const translationMap = new Map<string, Map<string, string>>()
     for (const t of translations) {
       if (!translationMap.has(t.language_id)) {
-        translationMap.set(t.language_id, new Map());
+        translationMap.set(t.language_id, new Map())
       }
-      translationMap.get(t.language_id)!.set(t.display_language_id, t.name);
+      const displayCode = idToCode.get(t.display_language_id)
+      if (displayCode) {
+        translationMap.get(t.language_id)!.set(displayCode, t.name)
+      }
     }
 
-    // Also build id -> backward_compatibility for resolving display_language_id keys
-    const idToCode = new Map<string, string>(langs.map((l) => [l.id, l.backward_compatibility]));
-
-    const output = langs.map((lang) => {
-      const rawTranslations = translationMap.get(lang.id) ?? new Map<string, string>();
-      const translations: Record<string, string> = {};
-      for (const [displayLangId, name] of rawTranslations) {
-        const code = idToCode.get(displayLangId);
-        if (code) {
-          translations[code] = name;
-        }
+    const output = langs.map(lang => {
+      const rawNames = translationMap.get(lang.id) ?? new Map<string, string>()
+      const names: Record<string, string> = {}
+      for (const [code, name] of rawNames) {
+        names[code] = name
       }
       return {
         id: lang.id,
         code: lang.backward_compatibility,
-        internal_name: lang.internal_name,
-        translations,
-      };
-    });
+        is_default: lang.is_default === 1,
+        names,
+      }
+    })
 
-    await this.writeJson('languages.json', output);
-    this.logger.success(`languages.json (${output.length} languages)`);
+    await this.writeJson('languages.json', output)
+    this.logger.success(`languages.json (${output.length} languages)`)
 
-    return { file: 'languages.json', count: output.length };
+    return { file: 'languages.json', count: output.length }
   }
 }

--- a/scripts/exporter/src/exporters/language-exporter.ts
+++ b/scripts/exporter/src/exporters/language-exporter.ts
@@ -1,0 +1,61 @@
+import type { ExportResult } from '../core/types.js';
+import { BaseExporter } from './base-exporter.js';
+
+interface LangRow {
+  id: string;
+  internal_name: string;
+  backward_compatibility: string;
+}
+
+interface LangTranslationRow {
+  language_id: string;
+  display_language_id: string;
+  name: string;
+}
+
+export class LanguageExporter extends BaseExporter {
+  getName(): string {
+    return 'Languages';
+  }
+
+  async export(): Promise<ExportResult> {
+    this.logger.info('Exporting languages.json...');
+
+    const langs = await this.db.query<LangRow>(`SELECT id, internal_name, backward_compatibility FROM languages ORDER BY id`);
+    const translations = await this.db.query<LangTranslationRow>(`SELECT language_id, display_language_id, name FROM language_translations`);
+
+    // Build lookup: language_id -> display_language_id -> name
+    const translationMap = new Map<string, Map<string, string>>();
+    for (const t of translations) {
+      if (!translationMap.has(t.language_id)) {
+        translationMap.set(t.language_id, new Map());
+      }
+      translationMap.get(t.language_id)!.set(t.display_language_id, t.name);
+    }
+
+    // Also build id -> backward_compatibility for resolving display_language_id keys
+    const idToCode = new Map<string, string>(langs.map((l) => [l.id, l.backward_compatibility]));
+
+    const output = langs.map((lang) => {
+      const rawTranslations = translationMap.get(lang.id) ?? new Map<string, string>();
+      const translations: Record<string, string> = {};
+      for (const [displayLangId, name] of rawTranslations) {
+        const code = idToCode.get(displayLangId);
+        if (code) {
+          translations[code] = name;
+        }
+      }
+      return {
+        id: lang.id,
+        code: lang.backward_compatibility,
+        internal_name: lang.internal_name,
+        translations,
+      };
+    });
+
+    await this.writeJson('languages.json', output);
+    this.logger.success(`languages.json (${output.length} languages)`);
+
+    return { file: 'languages.json', count: output.length };
+  }
+}

--- a/scripts/exporter/src/exporters/manifest-exporter.ts
+++ b/scripts/exporter/src/exporters/manifest-exporter.ts
@@ -1,24 +1,24 @@
-import type { ExportResult } from '../core/types.js';
-import { BaseExporter } from './base-exporter.js';
+import type { ExportResult } from '../core/types.js'
+import { BaseExporter } from './base-exporter.js'
 
 export class ManifestExporter extends BaseExporter {
   getName(): string {
-    return 'Manifest';
+    return 'Manifest'
   }
 
   async export(): Promise<ExportResult> {
-    this.logger.info('Writing manifest.json...');
+    this.logger.info('Writing manifest.json...')
 
     const manifest = {
       generatedAt: new Date().toISOString(),
       projectKeys: this.context.projectKeys,
       projectIds: this.context.projectIds,
       version: '1.0.0',
-    };
+    }
 
-    await this.writeJson('manifest.json', manifest);
-    this.logger.success('manifest.json');
+    await this.writeJson('manifest.json', manifest)
+    this.logger.success('manifest.json')
 
-    return { file: 'manifest.json', count: 1 };
+    return { file: 'manifest.json', count: 1 }
   }
 }

--- a/scripts/exporter/src/exporters/manifest-exporter.ts
+++ b/scripts/exporter/src/exporters/manifest-exporter.ts
@@ -1,0 +1,24 @@
+import type { ExportResult } from '../core/types.js';
+import { BaseExporter } from './base-exporter.js';
+
+export class ManifestExporter extends BaseExporter {
+  getName(): string {
+    return 'Manifest';
+  }
+
+  async export(): Promise<ExportResult> {
+    this.logger.info('Writing manifest.json...');
+
+    const manifest = {
+      generatedAt: new Date().toISOString(),
+      projectKeys: this.context.projectKeys,
+      projectIds: this.context.projectIds,
+      version: '1.0.0',
+    };
+
+    await this.writeJson('manifest.json', manifest);
+    this.logger.success('manifest.json');
+
+    return { file: 'manifest.json', count: 1 };
+  }
+}

--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -1,0 +1,126 @@
+import type { ExportResult } from '../core/types.js';
+import { BaseExporter } from './base-exporter.js';
+
+interface PartnerRow {
+  id: string;
+  internal_name: string;
+  backward_compatibility: string | null;
+  type: string;
+  country_id: string | null;
+}
+
+interface PartnerTranslationRow {
+  partner_id: string;
+  language_id: string;
+  name: string;
+  description: string | null;
+  city_display: string | null;
+  contact_website: string | null;
+}
+
+interface PartnerImageRow {
+  partner_id: string;
+  id: string;
+  path: string;
+  alt_text: string | null;
+  display_order: number;
+}
+
+export class PartnerExporter extends BaseExporter {
+  getName(): string {
+    return 'Partners';
+  }
+
+  async export(): Promise<ExportResult> {
+    this.logger.info('Exporting partners.json...');
+
+    const ph = this.placeholders(this.projectIds.length);
+
+    // Partners that have at least one item in the given projects
+    const partners = await this.db.query<PartnerRow>(
+      `SELECT DISTINCT p.id, p.internal_name, p.backward_compatibility, p.type, p.country_id
+       FROM partners p
+       JOIN items i ON i.partner_id = p.id
+       WHERE i.project_id IN (${ph})
+       ORDER BY p.internal_name`,
+      this.projectIds
+    );
+
+    if (partners.length === 0) {
+      await this.writeJson('partners.json', []);
+      this.logger.warning('partners.json (0 partners)');
+      return { file: 'partners.json', count: 0 };
+    }
+
+    const partnerIds = partners.map((p) => p.id);
+    const partnerPh = this.placeholders(partnerIds.length);
+
+    const [translations, images] = await Promise.all([
+      this.db.query<PartnerTranslationRow>(
+        `SELECT pt.partner_id, pt.language_id, pt.name, pt.description, pt.city_display, pt.contact_website
+         FROM partner_translations pt
+         WHERE pt.partner_id IN (${partnerPh})`,
+        partnerIds
+      ),
+      this.db.query<PartnerImageRow>(
+        `SELECT pi.partner_id, pi.id, pi.path, pi.alt_text, pi.display_order
+         FROM partner_images pi
+         WHERE pi.partner_id IN (${partnerPh})
+         ORDER BY pi.partner_id, pi.display_order`,
+        partnerIds
+      ),
+    ]);
+
+    const langCodeMap = await this.buildLangCodeMap();
+
+    // Build translation map: partner_id -> lang_code -> fields
+    const translationMap = new Map<string, Record<string, Record<string, string | null>>>();
+    for (const t of translations) {
+      if (!translationMap.has(t.partner_id)) {
+        translationMap.set(t.partner_id, {});
+      }
+      const code = langCodeMap.get(t.language_id);
+      if (code) {
+        translationMap.get(t.partner_id)![code] = {
+          name: t.name,
+          description: t.description,
+          city: t.city_display,
+          website: t.contact_website,
+        };
+      }
+    }
+
+    // Build image map: partner_id -> images[]
+    const imageMap = new Map<string, { url: string; alt_text: string | null; display_order: number }[]>();
+    for (const img of images) {
+      if (!imageMap.has(img.partner_id)) {
+        imageMap.set(img.partner_id, []);
+      }
+      imageMap.get(img.partner_id)!.push({
+        url: this.imageUrl(img.path),
+        alt_text: img.alt_text,
+        display_order: img.display_order,
+      });
+    }
+
+    const output = partners.map((p) => ({
+      id: p.id,
+      type: p.type,
+      country_id: p.country_id,
+      translations: translationMap.get(p.id) ?? {},
+      images: imageMap.get(p.id) ?? [],
+    }));
+
+    await this.writeJson('partners.json', output);
+    this.logger.success(`partners.json (${output.length} partners)`);
+
+    return { file: 'partners.json', count: output.length };
+  }
+
+  private async buildLangCodeMap(): Promise<Map<string, string>> {
+    const rows = await this.db.query<{ id: string; backward_compatibility: string }>(
+      `SELECT id, backward_compatibility FROM languages`
+    );
+    return new Map(rows.map((r) => [r.id, r.backward_compatibility]));
+  }
+}

--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -1,126 +1,162 @@
-import type { ExportResult } from '../core/types.js';
-import { BaseExporter } from './base-exporter.js';
+import type { ExportResult } from '../core/types.js'
+import { BaseExporter } from './base-exporter.js'
 
 interface PartnerRow {
-  id: string;
-  internal_name: string;
-  backward_compatibility: string | null;
-  type: string;
-  country_id: string | null;
+  id: string
+  type: string
+  internal_name: string
+  backward_compatibility: string | null
+  country_id: string | null
+  latitude: string | null
+  longitude: string | null
+  monument_item_id: string | null
 }
 
 interface PartnerTranslationRow {
-  partner_id: string;
-  language_id: string;
-  name: string;
-  description: string | null;
-  city_display: string | null;
-  contact_website: string | null;
+  partner_id: string
+  language_id: string
+  name: string
+  description: string | null
+  city_display: string | null
+  contact_website: string | null
+  contact_phone: string | null
+  contact_email_general: string | null
 }
 
 interface PartnerImageRow {
-  partner_id: string;
-  id: string;
-  path: string;
-  alt_text: string | null;
-  display_order: number;
+  partner_id: string
+  path: string
+  alt_text: string | null
+  display_order: number
+}
+
+interface PartnerLogoRow {
+  partner_id: string
+  path: string
+  logo_type: string
+  alt_text: string | null
+  display_order: number
 }
 
 export class PartnerExporter extends BaseExporter {
   getName(): string {
-    return 'Partners';
+    return 'Partners'
   }
 
   async export(): Promise<ExportResult> {
-    this.logger.info('Exporting partners.json...');
+    this.logger.info('Exporting partners.json...')
 
-    const ph = this.placeholders(this.projectIds.length);
+    const ph = this.placeholders(this.projectIds.length)
 
-    // Partners that have at least one item in the given projects
+    // Partners that hold at least one object/monument in these projects.
+    // items.partner_id is the authoritative link: museums hold objects,
+    // institutions hold monuments.
     const partners = await this.db.query<PartnerRow>(
-      `SELECT DISTINCT p.id, p.internal_name, p.backward_compatibility, p.type, p.country_id
+      `SELECT DISTINCT p.id, p.type, p.internal_name, p.backward_compatibility,
+              p.country_id, p.latitude, p.longitude, p.monument_item_id
        FROM partners p
        JOIN items i ON i.partner_id = p.id
        WHERE i.project_id IN (${ph})
-       ORDER BY p.internal_name`,
+         AND i.type IN ('object', 'monument', 'detail')
+       ORDER BY p.type, p.internal_name`,
       this.projectIds
-    );
+    )
 
     if (partners.length === 0) {
-      await this.writeJson('partners.json', []);
-      this.logger.warning('partners.json (0 partners)');
-      return { file: 'partners.json', count: 0 };
+      await this.writeJson('partners.json', [])
+      this.logger.warning('partners.json (0 partners)')
+      return { file: 'partners.json', count: 0 }
     }
 
-    const partnerIds = partners.map((p) => p.id);
-    const partnerPh = this.placeholders(partnerIds.length);
+    const partnerIds = partners.map(p => p.id)
+    const partnerPh = this.placeholders(partnerIds.length)
+    const langCodeMap = await this.buildLangCodeMap()
 
-    const [translations, images] = await Promise.all([
+    const [translations, images, logos] = await Promise.all([
       this.db.query<PartnerTranslationRow>(
-        `SELECT pt.partner_id, pt.language_id, pt.name, pt.description, pt.city_display, pt.contact_website
-         FROM partner_translations pt
-         WHERE pt.partner_id IN (${partnerPh})`,
+        `SELECT partner_id, language_id, name, description, city_display,
+                contact_website, contact_phone, contact_email_general
+         FROM partner_translations
+         WHERE partner_id IN (${partnerPh})`,
         partnerIds
       ),
       this.db.query<PartnerImageRow>(
-        `SELECT pi.partner_id, pi.id, pi.path, pi.alt_text, pi.display_order
-         FROM partner_images pi
-         WHERE pi.partner_id IN (${partnerPh})
-         ORDER BY pi.partner_id, pi.display_order`,
+        `SELECT partner_id, path, alt_text, display_order
+         FROM partner_images
+         WHERE partner_id IN (${partnerPh})
+         ORDER BY partner_id, display_order`,
         partnerIds
       ),
-    ]);
+      this.db.query<PartnerLogoRow>(
+        `SELECT partner_id, path, logo_type, alt_text, display_order
+         FROM partner_logos
+         WHERE partner_id IN (${partnerPh})
+         ORDER BY partner_id, display_order`,
+        partnerIds
+      ),
+    ])
 
-    const langCodeMap = await this.buildLangCodeMap();
-
-    // Build translation map: partner_id -> lang_code -> fields
-    const translationMap = new Map<string, Record<string, Record<string, string | null>>>();
+    // partner_id -> lang_code -> fields
+    const translationMap = new Map<string, Record<string, Record<string, string | null>>>()
     for (const t of translations) {
-      if (!translationMap.has(t.partner_id)) {
-        translationMap.set(t.partner_id, {});
-      }
-      const code = langCodeMap.get(t.language_id);
+      if (!translationMap.has(t.partner_id)) translationMap.set(t.partner_id, {})
+      const code = langCodeMap.get(t.language_id)
       if (code) {
         translationMap.get(t.partner_id)![code] = {
           name: t.name,
           description: t.description,
           city: t.city_display,
           website: t.contact_website,
-        };
+          phone: t.contact_phone,
+          email: t.contact_email_general,
+        }
       }
     }
 
-    // Build image map: partner_id -> images[]
-    const imageMap = new Map<string, { url: string; alt_text: string | null; display_order: number }[]>();
+    // partner_id -> images[]
+    const imageMap = new Map<
+      string,
+      { url: string; alt_text: string | null; display_order: number }[]
+    >()
     for (const img of images) {
-      if (!imageMap.has(img.partner_id)) {
-        imageMap.set(img.partner_id, []);
-      }
+      if (!imageMap.has(img.partner_id)) imageMap.set(img.partner_id, [])
       imageMap.get(img.partner_id)!.push({
         url: this.imageUrl(img.path),
         alt_text: img.alt_text,
         display_order: img.display_order,
-      });
+      })
     }
 
-    const output = partners.map((p) => ({
+    // partner_id -> logos[]
+    const logoMap = new Map<
+      string,
+      { url: string; logo_type: string; alt_text: string | null; display_order: number }[]
+    >()
+    for (const logo of logos) {
+      if (!logoMap.has(logo.partner_id)) logoMap.set(logo.partner_id, [])
+      logoMap.get(logo.partner_id)!.push({
+        url: this.imageUrl(logo.path),
+        logo_type: logo.logo_type,
+        alt_text: logo.alt_text,
+        display_order: logo.display_order,
+      })
+    }
+
+    const output = partners.map(p => ({
       id: p.id,
       type: p.type,
       country_id: p.country_id,
+      latitude: p.latitude !== null ? parseFloat(p.latitude) : null,
+      longitude: p.longitude !== null ? parseFloat(p.longitude) : null,
+      monument_item_id: p.monument_item_id,
       translations: translationMap.get(p.id) ?? {},
       images: imageMap.get(p.id) ?? [],
-    }));
+      logos: logoMap.get(p.id) ?? [],
+    }))
 
-    await this.writeJson('partners.json', output);
-    this.logger.success(`partners.json (${output.length} partners)`);
+    await this.writeJson('partners.json', output)
+    this.logger.success(`partners.json (${output.length} partners)`)
 
-    return { file: 'partners.json', count: output.length };
-  }
-
-  private async buildLangCodeMap(): Promise<Map<string, string>> {
-    const rows = await this.db.query<{ id: string; backward_compatibility: string }>(
-      `SELECT id, backward_compatibility FROM languages`
-    );
-    return new Map(rows.map((r) => [r.id, r.backward_compatibility]));
+    return { file: 'partners.json', count: output.length }
   }
 }

--- a/scripts/exporter/tsconfig.json
+++ b/scripts/exporter/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "output"]
+}

--- a/scripts/viewer/.env.example
+++ b/scripts/viewer/.env.example
@@ -1,0 +1,8 @@
+# Filesystem path to the exported JSON directory (used by the Vite dev server).
+# Relative paths are resolved from scripts/viewer/.
+DATA_DIR=../exporter/output/islamicart
+
+# URL prefix the browser fetches JSON from.
+# In dev this is served by the Vite dev server from DATA_DIR.
+# In production point this to your CDN or static hosting URL.
+VITE_DATA_PATH=/data

--- a/scripts/viewer/.gitignore
+++ b/scripts/viewer/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/scripts/viewer/index.html
+++ b/scripts/viewer/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Inventory Viewer</title>
+    <style>
+      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: system-ui, sans-serif; color: #1a1a1a; background: #f5f5f5; }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/scripts/viewer/package-lock.json
+++ b/scripts/viewer/package-lock.json
@@ -1,0 +1,1095 @@
+{
+  "name": "inventory-viewer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "inventory-viewer",
+      "version": "1.0.0",
+      "dependencies": {
+        "vue": "^3.5.39"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^6.0.7",
+        "vite": "^8.1.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.7.tgz",
+      "integrity": "sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "vue": "3.5.39"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.137.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "~1.1.2",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/scripts/viewer/package.json
+++ b/scripts/viewer/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "inventory-viewer",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.5.39"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.7",
+    "vite": "^8.1.0"
+  }
+}

--- a/scripts/viewer/src/App.vue
+++ b/scripts/viewer/src/App.vue
@@ -1,0 +1,202 @@
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+const DATA_PATH = import.meta.env.VITE_DATA_PATH?.replace(/\/$/, '') ?? ''
+
+const items = ref([])
+const loading = ref(true)
+const error = ref(null)
+const selected = ref(null)
+
+onMounted(async () => {
+  try {
+    const res = await fetch(`${DATA_PATH}/items.json`)
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    items.value = await res.json()
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+})
+
+function label(item) {
+  return item.translations?.en?.name ?? item.internal_name ?? item.id
+}
+
+function selectItem(item) {
+  selected.value = item
+  window.scrollTo(0, 0)
+}
+
+function back() {
+  selected.value = null
+}
+
+// Fields to show in detail view, in order
+const DETAIL_FIELDS = [
+  ['type', 'Type'],
+  ['alternate_name', 'Alternate name'],
+  ['description', 'Description'],
+  ['dates', 'Dates'],
+  ['location', 'Location'],
+  ['holder', 'Holder'],
+  ['owner', 'Owner'],
+  ['initial_owner', 'Initial owner'],
+  ['dimensions', 'Dimensions'],
+  ['place_of_production', 'Place of production'],
+  ['method_for_datation', 'Method for datation'],
+  ['method_for_provenance', 'Method for provenance'],
+  ['provenance', 'Provenance'],
+  ['obtention', 'Obtention'],
+  ['bibliography', 'Bibliography'],
+]
+
+const detailFields = computed(() => {
+  if (!selected.value) return []
+  const en = selected.value.translations?.en ?? {}
+  return DETAIL_FIELDS
+    .map(([key, label]) => ({ label, value: en[key] }))
+    .filter(f => f.value)
+})
+</script>
+
+<template>
+  <div class="shell">
+    <header>
+      <span class="logo">Inventory Viewer</span>
+      <span v-if="!loading && !error" class="count">{{ items.length }} items</span>
+    </header>
+
+    <main>
+      <!-- Loading -->
+      <div v-if="loading" class="state">Loading…</div>
+
+      <!-- Error -->
+      <div v-else-if="error" class="state error">
+        Could not load items.json<br />
+        <small>{{ error }}</small><br />
+        <small>DATA_PATH: {{ DATA_PATH || '(not set)' }}</small>
+      </div>
+
+      <!-- Detail -->
+      <template v-else-if="selected">
+        <a class="back" href="#" @click.prevent="back">← Back to list</a>
+
+        <div class="detail">
+          <div class="detail-type">{{ selected.type }}</div>
+          <h1>{{ label(selected) }}</h1>
+
+          <div v-if="selected.images?.length" class="images">
+            <figure v-for="(img, i) in selected.images" :key="i">
+              <img :src="img.url" :alt="img.captions?.en ?? ''" loading="lazy" />
+              <figcaption v-if="img.captions?.en || img.photographer">
+                <span v-if="img.captions?.en">{{ img.captions.en }}</span>
+                <span v-if="img.photographer" class="credit">© {{ img.photographer }}</span>
+              </figcaption>
+            </figure>
+          </div>
+
+          <dl v-if="detailFields.length">
+            <template v-for="f in detailFields" :key="f.label">
+              <dt>{{ f.label }}</dt>
+              <dd>{{ f.value }}</dd>
+            </template>
+          </dl>
+
+          <div class="meta">
+            <span v-if="selected.country_id">Country: {{ selected.country_id }}</span>
+            <span v-if="selected.start_date">
+              Period: {{ selected.start_date }}{{ selected.end_date ? ' – ' + selected.end_date : '' }}
+            </span>
+            <span v-if="selected.mwnf_reference">Ref: {{ selected.mwnf_reference }}</span>
+          </div>
+        </div>
+      </template>
+
+      <!-- List -->
+      <template v-else>
+        <ul class="list">
+          <li
+            v-for="item in items"
+            :key="item.id"
+            class="list-item"
+            @click="selectItem(item)"
+          >
+            <div class="item-thumb" v-if="item.images?.length">
+              <img :src="item.images[0].url" :alt="label(item)" loading="lazy" />
+            </div>
+            <div class="item-thumb placeholder" v-else></div>
+            <div class="item-info">
+              <span class="item-name">{{ label(item) }}</span>
+              <span class="item-type">{{ item.type }}</span>
+            </div>
+          </li>
+        </ul>
+      </template>
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.shell { min-height: 100vh; display: flex; flex-direction: column; }
+
+header {
+  position: sticky; top: 0; z-index: 10;
+  display: flex; align-items: center; gap: 1rem;
+  padding: .75rem 1.5rem;
+  background: #1a1a2e; color: #fff;
+}
+.logo { font-weight: 700; font-size: 1rem; letter-spacing: .02em; }
+.count { font-size: .8rem; opacity: .6; }
+
+main { flex: 1; max-width: 900px; width: 100%; margin: 0 auto; padding: 1.5rem; }
+
+.state { padding: 3rem; text-align: center; color: #666; }
+.state.error { color: #c0392b; }
+
+/* List */
+.list { list-style: none; display: flex; flex-direction: column; gap: .5rem; }
+
+.list-item {
+  display: flex; align-items: center; gap: 1rem;
+  padding: .75rem 1rem;
+  background: #fff; border-radius: 8px;
+  cursor: pointer; transition: box-shadow .15s;
+}
+.list-item:hover { box-shadow: 0 2px 12px rgba(0,0,0,.12); }
+
+.item-thumb { width: 56px; height: 56px; flex-shrink: 0; border-radius: 4px; overflow: hidden; background: #eee; }
+.item-thumb img { width: 100%; height: 100%; object-fit: cover; }
+.item-thumb.placeholder { background: #e0e0e0; }
+
+.item-info { display: flex; flex-direction: column; gap: .2rem; min-width: 0; }
+.item-name { font-weight: 600; font-size: .95rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.item-type { font-size: .75rem; color: #888; text-transform: uppercase; letter-spacing: .05em; }
+
+/* Detail */
+.back {
+  display: inline-block; margin-bottom: 1.25rem;
+  color: #1a1a2e; font-size: .9rem; text-decoration: none;
+}
+.back:hover { text-decoration: underline; }
+
+.detail { background: #fff; border-radius: 8px; padding: 1.5rem; }
+.detail-type { font-size: .75rem; text-transform: uppercase; letter-spacing: .08em; color: #888; margin-bottom: .5rem; }
+.detail h1 { font-size: 1.5rem; margin-bottom: 1.25rem; }
+
+.images {
+  display: flex; gap: 1rem; flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+.images figure { width: 180px; }
+.images img { width: 100%; height: 130px; object-fit: cover; border-radius: 4px; }
+.images figcaption { font-size: .75rem; color: #666; margin-top: .3rem; }
+.images .credit { display: block; }
+
+dl { display: grid; grid-template-columns: max-content 1fr; gap: .4rem 1rem; margin-bottom: 1.25rem; }
+dt { font-weight: 600; font-size: .85rem; color: #555; white-space: nowrap; }
+dd { font-size: .9rem; line-height: 1.5; }
+
+.meta { display: flex; flex-wrap: wrap; gap: .5rem 1.5rem; font-size: .8rem; color: #888; border-top: 1px solid #eee; padding-top: 1rem; }
+</style>

--- a/scripts/viewer/src/main.js
+++ b/scripts/viewer/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/scripts/viewer/vite.config.js
+++ b/scripts/viewer/vite.config.js
@@ -1,0 +1,52 @@
+import { defineConfig, loadEnv } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import { createReadStream, existsSync, statSync } from 'fs'
+import { join, resolve } from 'path'
+
+export default defineConfig(({ mode }) => {
+  // Load all env vars (DATA_DIR has no VITE_ prefix so we use '' as prefix)
+  const env = loadEnv(mode, process.cwd(), '')
+  const dataDir = env.DATA_DIR ? resolve(env.DATA_DIR) : null
+
+  return {
+    plugins: [
+      vue(),
+      {
+        name: 'data-server',
+        configureServer(server) {
+          // Intercept /data/* requests and serve them from DATA_DIR
+          server.middlewares.use((req, res, next) => {
+            const url = req.url ?? ''
+            if (!url.startsWith('/data/') && url !== '/data') return next()
+
+            if (!dataDir) {
+              res.writeHead(500, { 'Content-Type': 'text/plain' })
+              res.end('DATA_DIR is not set in .env')
+              return
+            }
+
+            // Strip leading /data prefix to get the relative file path
+            const relativePath = url.replace(/^\/data\/?/, '')
+            const file = join(dataDir, relativePath)
+
+            // Security: ensure the resolved path stays inside dataDir
+            if (!file.startsWith(dataDir)) {
+              res.writeHead(403, { 'Content-Type': 'text/plain' })
+              res.end('Forbidden')
+              return
+            }
+
+            if (!existsSync(file) || !statSync(file).isFile()) {
+              res.writeHead(404, { 'Content-Type': 'text/plain' })
+              res.end(`Not found: ${file}`)
+              return
+            }
+
+            res.setHeader('Content-Type', 'application/json; charset=utf-8')
+            createReadStream(file).pipe(res)
+          })
+        },
+      },
+    ],
+  }
+})


### PR DESCRIPTION
## Summary

Adds two new developer tools under `scripts/`:

### `scripts/exporter` — Static JSON exporter

A Node.js/TypeScript ESM CLI that reads the inventory database and writes a set of denormalized JSON files for consumption by frontend applications (e.g. the new Discover Islamic Art website).

- Accepts a subdirectory name and one or more legacy project keys (e.g. `ISL`)
- Resolves project UUIDs via `backward_compatibility` (format: `mwnf3:projects:ISL`)
- Writes to a gitignored `output/` directory; fails if it already exists unless `--force` is passed
- Exports: manifest, languages, countries, dynasties, partners, items, collections, glossary
- Item images are sourced exclusively from child items of `type = 'picture'`, which carry per-language captions and `extra` JSON (photographer / copyright)
- Collection scoping uses `context_id` from the project row, correctly capturing empty exhibitions and the root collection
- Partners are discovered via `items.partner_id`; both `partner_images` and `partner_logos` are exported
- Author names are resolved via JOIN to the `authors` table
- Image base URL defaults to `./images` (relative); override with `BASE_URL` env var or `--base-url` flag

Same stack as `scripts/importer`: TypeScript ESM, mysql2, commander, chalk, dotenv.

### `scripts/viewer` — Local Vue 3 SPA

A minimal Vite + Vue 3.5 JavaScript app for inspecting exported data locally.

- Root view: list of all items with thumbnail, name, and type
- Click an item: detail view with images, all English translation fields, period / country / reference
- Data path configured via `.env`: `DATA_DIR` (filesystem path served by the Vite dev server at `/data`) and `VITE_DATA_PATH` (browser fetch prefix, defaults to `/data`)

## Usage

```bash
# Export
cd scripts/exporter
cp .env.example .env   # fill in DB credentials
npm install
npm run export -- islamicart ISL

# View
cd scripts/viewer
cp .env.example .env   # DATA_DIR=../exporter/output/islamicart
npm install
npm run dev
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)