### PR TITLE
Feat(web): Add public Image endpoint (for the exporter/viewer)

### DIFF
--- a/app/Http/Controllers/Pub/PictureController.php
+++ b/app/Http/Controllers/Pub/PictureController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Http\Controllers\Pub;
+
+use App\Contracts\StreamableImageFile;
+use App\Http\Controllers\Controller;
+use App\Models\CollectionImage;
+use App\Models\ContributorImage;
+use App\Models\ItemImage;
+use App\Models\PartnerImage;
+use App\Models\PartnerLogo;
+use App\Models\PartnerTranslationImage;
+use App\Models\TimelineEventImage;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class PictureController extends Controller
+{
+    /**
+     * Maps URL type segment to the Eloquent model class that owns the image.
+     *
+     * @var array<string, class-string<Model&StreamableImageFile>>
+     */
+    private const MODEL_MAP = [
+        'item-picture' => ItemImage::class,
+        'collection-picture' => CollectionImage::class,
+        'partner-picture' => PartnerImage::class,
+        'partner-translation-picture' => PartnerTranslationImage::class,
+        'contributor-picture' => ContributorImage::class,
+        'timeline-event-picture' => TimelineEventImage::class,
+        'partner-logo' => PartnerLogo::class,
+    ];
+
+    /**
+     * Serve a public picture by model type and UUID.
+     *
+     * Route: GET /pub/{type}/{filename}
+     * where {filename} is constrained to {uuid}.jpg by the route definition.
+     */
+    public function show(Request $request, string $type, string $filename): BinaryFileResponse|Response
+    {
+        // Reject query string parameters — public image URLs must be clean
+        if ($request->query->count() > 0) {
+            abort(400, 'Query parameters are not accepted.');
+        }
+
+        // Resolve model class from the URL type segment
+        $modelClass = self::MODEL_MAP[$type] ?? null;
+        if ($modelClass === null) {
+            abort(404);
+        }
+
+        // Strip the .jpg suffix to obtain the UUID primary key
+        $id = substr($filename, 0, -4);
+
+        /** @var (Model&StreamableImageFile)|null $image */
+        $image = $modelClass::find($id);
+        if ($image === null) {
+            abort(404);
+        }
+
+        $disk = $image->imageDisk();
+        $storagePath = $image->imageStoragePath();
+
+        if (! Storage::disk($disk)->exists($storagePath)) {
+            abort(404);
+        }
+
+        $fullPath = Storage::disk($disk)->path($storagePath);
+        $lastModifiedTimestamp = Storage::disk($disk)->lastModified($storagePath);
+        $etag = '"'.md5($id.':'.$lastModifiedTimestamp).'"';
+        $lastModifiedHttp = gmdate('D, d M Y H:i:s', $lastModifiedTimestamp).' GMT';
+
+        // Honour conditional GET requests so clients can revalidate cheaply
+        $ifNoneMatch = $request->header('If-None-Match');
+        if ($ifNoneMatch !== null && $ifNoneMatch === $etag) {
+            return response('', 304);
+        }
+
+        if ($ifNoneMatch === null) {
+            $ifModifiedSince = $request->header('If-Modified-Since');
+            if ($ifModifiedSince !== null) {
+                $since = strtotime($ifModifiedSince);
+                if ($since !== false && $lastModifiedTimestamp <= $since) {
+                    return response('', 304);
+                }
+            }
+        }
+
+        return response()->file($fullPath, [
+            'Content-Type' => 'image/jpeg',
+            'Cache-Control' => 'public, max-age=86400, must-revalidate',
+            'Last-Modified' => $lastModifiedHttp,
+            'ETag' => $etag,
+        ]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -29,9 +29,12 @@ use App\View\Composers\SettingsComposer;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Spatie\Permission\Models\Role;
@@ -51,6 +54,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Public picture endpoint throttle — configurable via PUB_PICTURES_THROTTLE env var
+        RateLimiter::for('pub-pictures', function (Request $request) {
+            return Limit::perMinute(Config::integer('app.pub_pictures_throttle', 60))
+                ->by($request->ip());
+        });
+
         // Register glossary link maintenance event listeners
         Event::listen(ItemTranslationSaved::class, DispatchSyncItemTranslationSpellings::class);
         Event::listen(CollectionTranslationSaved::class, DispatchSyncCollectionTranslationSpellings::class);

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\Permission;
+use App\Http\Controllers\Pub\PictureController;
 use App\Http\Controllers\RoleManagementController;
 use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\SpaController;
@@ -228,6 +229,20 @@ Route::prefix('web')->group(function () {
 
 // Note: Registration routes are handled by Fortify with self_registration middleware
 // See app/Providers/FortifyServiceProvider.php for middleware configuration
+
+// Public picture viewer — no authentication, rate-limited
+// Serves: /pub/{type}/{uuid}.jpg
+// Supported types: item-picture, collection-picture, partner-picture,
+//   partner-translation-picture, contributor-picture, timeline-event-picture, partner-logo
+Route::middleware(['throttle:pub-pictures'])
+    ->prefix('pub')
+    ->name('pub.')
+    ->group(function () {
+        Route::get('/{type}/{filename}', [PictureController::class, 'show'])
+            ->where('type', '[a-z][a-z-]*')
+            ->where('filename', '[0-9a-f-]+\.jpg')
+            ->name('picture');
+    });
 
 // Vue.js SPA Route - serves the client app at /cli (demo client)
 // IMPORTANT: This route works in PRODUCTION (Apache with .htaccess) but NOT with 'php artisan serve'

--- a/scripts/Invoke-Pest.local.ps1
+++ b/scripts/Invoke-Pest.local.ps1
@@ -1,0 +1,18 @@
+$AppRoot = Split-Path -Parent -Path $PSScriptRoot
+$TestSuites = @(                                                                                                                 
+    'Unit'                                   
+    'Api'
+    'Web'
+    'Filament'
+    'Configuration'
+    'Console'
+    'Event'
+    'Integration'
+)
+$TestSuites | Foreach-Object {
+    $TestSuite = $_
+    $LogFile = Join-Path $AppRoot "temp_PHPTEST_$($TestSuite).xml"
+    Clear-Content $LogFile -ErrorAction Continue
+    docker compose run --rm app php -d memory_limit=-1 artisan test --compact --log-junit=$LogFile --no-coverage --testsuite $TestSuite
+    Write-Warning "Test suite '$TestSuite' completed. Log file: $(Resolve-Path $LogFile)"
+}

--- a/scripts/Invoke-Phpstan.local.ps1
+++ b/scripts/Invoke-Phpstan.local.ps1
@@ -1,0 +1,10 @@
+$AppRoot = Split-Path -Parent -Path $PSScriptRoot
+$StaticAnalysisOutput = Join-Path $AppRoot 'temp_PHPSTAN.txt'
+Set-Location $AppRoot
+Clear-Content $StaticAnalysisOutput -ErrorAction Continue 
+docker compose run --rm app vendor/bin/phpstan analyse --no-progress --memory-limit=512M --error-format=raw --level=10 > $StaticAnalysisOutput
+if (-not (Get-Content $StaticAnalysisOutput)) {
+    Write-Host 'Success' -ForegroundColor Green
+} else {
+    Write-Warning "Static-analysis issues found: $(Resolve-Path $StaticAnalysisOutput)"
+}

--- a/scripts/exporter/src/exporters/base-exporter.ts
+++ b/scripts/exporter/src/exporters/base-exporter.ts
@@ -1,5 +1,9 @@
 import { writeFile } from 'fs/promises'
-import { resolve } from 'path'
+import { mkdirSync, createWriteStream } from 'fs'
+import { resolve, dirname } from 'path'
+import { createGzip } from 'zlib'
+import { pipeline } from 'stream/promises'
+import { Readable } from 'stream'
 import type { ExportContext, ExportResult } from '../core/types.js'
 
 export abstract class BaseExporter {
@@ -48,9 +52,35 @@ export abstract class BaseExporter {
     return this._langCodeMap
   }
 
+  /** Writes compact JSON + a .gz companion. Creates parent directories as needed. */
   protected async writeJson(filename: string, data: unknown): Promise<void> {
     const filePath = resolve(this.context.outputDir, filename)
-    await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8')
+    mkdirSync(dirname(filePath), { recursive: true })
+    const json = JSON.stringify(data)
+    await writeFile(filePath, json, 'utf-8')
+    await pipeline(
+      Readable.from([Buffer.from(json, 'utf-8')]),
+      createGzip(),
+      createWriteStream(filePath + '.gz')
+    )
+  }
+
+  /**
+   * Writes one translation file per language under translations/{entityName}.{lang}.json.
+   * byLang maps lang code → { [entityId]: stripped translation fields }.
+   */
+  protected async writeTranslationFiles(
+    entityName: string,
+    byLang: Map<string, Record<string, unknown>>
+  ): Promise<void> {
+    for (const [lang, data] of byLang) {
+      await this.writeJson(`translations/${entityName}.${lang}.json`, data)
+    }
+  }
+
+  /** Returns a shallow copy of obj with null-valued keys removed. */
+  protected stripNulls(obj: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== null))
   }
 
   protected placeholders(count: number): string {

--- a/scripts/exporter/src/exporters/base-exporter.ts
+++ b/scripts/exporter/src/exporters/base-exporter.ts
@@ -87,7 +87,13 @@ export abstract class BaseExporter {
     return Array.from({ length: count }, () => '?').join(', ')
   }
 
-  protected imageUrl(path: string): string {
-    return `${this.baseUrl}/${path}`
+  /**
+   * Build the public picture URL for a given image path and model type segment.
+   * path is the bare filename stored in the DB (e.g. "uuid.jpg").
+   * modelSegment is the kebab-case type used in the /pub/ URL
+   * (e.g. "item-picture", "collection-picture", "partner-logo").
+   */
+  protected imageUrl(path: string, modelSegment: string): string {
+    return `${this.baseUrl}/pub/${modelSegment}/${path}`
   }
 }

--- a/scripts/exporter/src/exporters/collection-exporter.ts
+++ b/scripts/exporter/src/exporters/collection-exporter.ts
@@ -130,7 +130,7 @@ export class CollectionExporter extends BaseExporter {
     for (const img of images) {
       if (!imageMap.has(img.collection_id)) imageMap.set(img.collection_id, [])
       imageMap.get(img.collection_id)!.push({
-        url: this.imageUrl(img.path),
+        url: this.imageUrl(img.path, 'collection-picture'),
         alt_text: img.alt_text,
         display_order: img.display_order,
       })

--- a/scripts/exporter/src/exporters/collection-exporter.ts
+++ b/scripts/exporter/src/exporters/collection-exporter.ts
@@ -112,6 +112,16 @@ export class CollectionExporter extends BaseExporter {
       }
     }
 
+    // Write one translations/collections.{lang}.json per language (null fields omitted)
+    const byLang = new Map<string, Record<string, unknown>>()
+    for (const [colId, langMap] of translationMap) {
+      for (const [langCode, fields] of Object.entries(langMap)) {
+        if (!byLang.has(langCode)) byLang.set(langCode, {})
+        byLang.get(langCode)![colId] = this.stripNulls(fields)
+      }
+    }
+    await this.writeTranslationFiles('collections', byLang)
+
     // collection_id -> images[]
     const imageMap = new Map<
       string,
@@ -141,7 +151,6 @@ export class CollectionExporter extends BaseExporter {
       display_order: c.display_order,
       latitude: c.latitude !== null ? parseFloat(c.latitude) : null,
       longitude: c.longitude !== null ? parseFloat(c.longitude) : null,
-      translations: translationMap.get(c.id) ?? {},
       images: imageMap.get(c.id) ?? [],
       item_ids: itemMap.get(c.id) ?? [],
     }))

--- a/scripts/exporter/src/exporters/country-exporter.ts
+++ b/scripts/exporter/src/exporters/country-exporter.ts
@@ -43,11 +43,20 @@ export class CountryExporter extends BaseExporter {
       }
     }
 
+    // Write one translations/countries.{lang}.json per language
+    const byLang = new Map<string, Record<string, unknown>>()
+    for (const [countryId, langMap] of translationMap) {
+      for (const [langCode, name] of Object.entries(langMap)) {
+        if (!byLang.has(langCode)) byLang.set(langCode, {})
+        byLang.get(langCode)![countryId] = { name }
+      }
+    }
+    await this.writeTranslationFiles('countries', byLang)
+
     const output = countries.map(country => ({
       id: country.id,
       code: country.backward_compatibility,
       internal_name: country.internal_name,
-      translations: translationMap.get(country.id) ?? {},
     }))
 
     await this.writeJson('countries.json', output)

--- a/scripts/exporter/src/exporters/dynasty-exporter.ts
+++ b/scripts/exporter/src/exporters/dynasty-exporter.ts
@@ -79,13 +79,22 @@ export class DynastyExporter extends BaseExporter {
       }
     }
 
+    // Write one translations/dynasties.{lang}.json per language (null fields omitted)
+    const byLang = new Map<string, Record<string, unknown>>()
+    for (const [dynastyId, langMap] of translationMap) {
+      for (const [langCode, fields] of Object.entries(langMap)) {
+        if (!byLang.has(langCode)) byLang.set(langCode, {})
+        byLang.get(langCode)![dynastyId] = this.stripNulls(fields as Record<string, unknown>)
+      }
+    }
+    await this.writeTranslationFiles('dynasties', byLang)
+
     const output = dynasties.map(d => ({
       id: d.id,
       from_ah: d.from_ah,
       to_ah: d.to_ah,
       from_ad: d.from_ad,
       to_ad: d.to_ad,
-      translations: translationMap.get(d.id) ?? {},
     }))
 
     await this.writeJson('dynasties.json', output)

--- a/scripts/exporter/src/exporters/glossary-exporter.ts
+++ b/scripts/exporter/src/exporters/glossary-exporter.ts
@@ -81,11 +81,29 @@ export class GlossaryExporter extends BaseExporter {
       }
     }
 
+    // Collect all language codes that appear in either map
+    const allLangs = new Set<string>()
+    for (const m of definitionMap.values()) Object.keys(m).forEach(k => allLangs.add(k))
+    for (const m of spellingMap.values()) Object.keys(m).forEach(k => allLangs.add(k))
+
+    // Write one translations/glossary.{lang}.json per language
+    const byLang = new Map<string, Record<string, unknown>>()
+    for (const entry of entries) {
+      const defs = definitionMap.get(entry.id) ?? {}
+      const spells = spellingMap.get(entry.id) ?? {}
+      for (const lang of allLangs) {
+        if (!byLang.has(lang)) byLang.set(lang, {})
+        const obj: Record<string, unknown> = {}
+        if (defs[lang] !== undefined) obj['definition'] = defs[lang]
+        if (spells[lang] !== undefined) obj['spellings'] = spells[lang]
+        if (Object.keys(obj).length > 0) byLang.get(lang)![entry.id] = obj
+      }
+    }
+    await this.writeTranslationFiles('glossary', byLang)
+
     const output = entries.map(entry => ({
       id: entry.id,
       word: entry.internal_name,
-      definitions: definitionMap.get(entry.id) ?? {},
-      spellings: spellingMap.get(entry.id) ?? {},
     }))
 
     await this.writeJson('glossary.json', output)

--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -199,6 +199,16 @@ export class ItemExporter extends BaseExporter {
       }
     }
 
+    // Write one translations/items.{lang}.json per language (null fields omitted)
+    const byLang = new Map<string, Record<string, unknown>>()
+    for (const [itemId, langMap] of translationMap) {
+      for (const [langCode, fields] of Object.entries(langMap)) {
+        if (!byLang.has(langCode)) byLang.set(langCode, {})
+        byLang.get(langCode)![itemId] = this.stripNulls(fields)
+      }
+    }
+    await this.writeTranslationFiles('items', byLang)
+
     // picture_id -> lang_code -> { caption, photographer, copyright }
     const picTransMap = new Map<
       string,
@@ -228,10 +238,10 @@ export class ItemExporter extends BaseExporter {
       // photographer/copyright are not language-specific; pick from first available lang
       const firstLang = Object.values(perLang)[0]
 
-      // Collect captions keyed by lang code
-      const captions: Record<string, string | null> = {}
+      // Captions keyed by lang code — skip langs where caption is null
+      const captions: Record<string, string> = {}
       for (const [lang, t] of Object.entries(perLang)) {
-        captions[lang] = t.caption
+        if (t.caption !== null) captions[lang] = t.caption
       }
 
       imageMap.get(pic.item_id)!.push({
@@ -260,6 +270,7 @@ export class ItemExporter extends BaseExporter {
     const output = items.map(item => ({
       id: item.id,
       type: item.type,
+      internal_name: item.internal_name,
       parent_id: item.parent_id,
       partner_id: item.partner_id,
       country_id: item.country_id,
@@ -270,7 +281,6 @@ export class ItemExporter extends BaseExporter {
       end_date: item.end_date,
       latitude: item.latitude !== null ? parseFloat(item.latitude) : null,
       longitude: item.longitude !== null ? parseFloat(item.longitude) : null,
-      translations: translationMap.get(item.id) ?? {},
       images: imageMap.get(item.id) ?? [],
       dynasty_ids: dynastyMap.get(item.id) ?? [],
       tags: tagMap.get(item.id) ?? [],
@@ -286,7 +296,7 @@ export class ItemExporter extends BaseExporter {
 interface ImageEntry {
   url: string
   display_order: number | null
-  captions: Record<string, string | null>
+  captions: Record<string, string>
   photographer: string | null
   copyright: string | null
 }

--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -245,7 +245,7 @@ export class ItemExporter extends BaseExporter {
       }
 
       imageMap.get(pic.item_id)!.push({
-        url: this.imageUrl(pic.path),
+        url: this.imageUrl(pic.path, 'item-picture'),
         display_order: pic.display_order,
         captions,
         photographer: firstLang?.photographer ?? null,

--- a/scripts/exporter/src/exporters/manifest-exporter.ts
+++ b/scripts/exporter/src/exporters/manifest-exporter.ts
@@ -9,11 +9,16 @@ export class ManifestExporter extends BaseExporter {
   async export(): Promise<ExportResult> {
     this.logger.info('Writing manifest.json...')
 
+    const langRows = await this.db.query<{ backward_compatibility: string }>(
+      `SELECT backward_compatibility FROM languages WHERE backward_compatibility IS NOT NULL ORDER BY id`
+    )
+
     const manifest = {
       generatedAt: new Date().toISOString(),
       projectKeys: this.context.projectKeys,
       projectIds: this.context.projectIds,
       version: '1.0.0',
+      languages: langRows.map(r => r.backward_compatibility),
     }
 
     await this.writeJson('manifest.json', manifest)

--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -131,7 +131,7 @@ export class PartnerExporter extends BaseExporter {
     for (const img of images) {
       if (!imageMap.has(img.partner_id)) imageMap.set(img.partner_id, [])
       imageMap.get(img.partner_id)!.push({
-        url: this.imageUrl(img.path),
+        url: this.imageUrl(img.path, 'partner-picture'),
         alt_text: img.alt_text,
         display_order: img.display_order,
       })
@@ -145,7 +145,7 @@ export class PartnerExporter extends BaseExporter {
     for (const logo of logos) {
       if (!logoMap.has(logo.partner_id)) logoMap.set(logo.partner_id, [])
       logoMap.get(logo.partner_id)!.push({
-        url: this.imageUrl(logo.path),
+        url: this.imageUrl(logo.path, 'partner-logo'),
         logo_type: logo.logo_type,
         alt_text: logo.alt_text,
         display_order: logo.display_order,

--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -113,6 +113,16 @@ export class PartnerExporter extends BaseExporter {
       }
     }
 
+    // Write one translations/partners.{lang}.json per language (null fields omitted)
+    const byLang = new Map<string, Record<string, unknown>>()
+    for (const [partnerId, langMap] of translationMap) {
+      for (const [langCode, fields] of Object.entries(langMap)) {
+        if (!byLang.has(langCode)) byLang.set(langCode, {})
+        byLang.get(langCode)![partnerId] = this.stripNulls(fields as Record<string, unknown>)
+      }
+    }
+    await this.writeTranslationFiles('partners', byLang)
+
     // partner_id -> images[]
     const imageMap = new Map<
       string,
@@ -149,7 +159,6 @@ export class PartnerExporter extends BaseExporter {
       latitude: p.latitude !== null ? parseFloat(p.latitude) : null,
       longitude: p.longitude !== null ? parseFloat(p.longitude) : null,
       monument_item_id: p.monument_item_id,
-      translations: translationMap.get(p.id) ?? {},
       images: imageMap.get(p.id) ?? [],
       logos: logoMap.get(p.id) ?? [],
     }))

--- a/scripts/viewer/src/App.vue
+++ b/scripts/viewer/src/App.vue
@@ -1,18 +1,49 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 
 const DATA_PATH = import.meta.env.VITE_DATA_PATH?.replace(/\/$/, '') ?? ''
 
 const items = ref([])
+const availableLangs = ref([])
+const activeLang = ref('en')
+// { [langCode]: { [itemId]: { name, description, ... } } }
+const translationsCache = ref({})
 const loading = ref(true)
 const error = ref(null)
 const selected = ref(null)
 
+async function loadTranslations(lang) {
+  if (translationsCache.value[lang]) return
+  try {
+    const res = await fetch(`${DATA_PATH}/translations/items.${lang}.json`)
+    if (res.ok) {
+      translationsCache.value = { ...translationsCache.value, [lang]: await res.json() }
+    }
+  } catch {
+    // silently fall back to internal_name
+  }
+}
+
 onMounted(async () => {
   try {
-    const res = await fetch(`${DATA_PATH}/items.json`)
-    if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    items.value = await res.json()
+    const [manifestRes, itemsRes] = await Promise.all([
+      fetch(`${DATA_PATH}/manifest.json`),
+      fetch(`${DATA_PATH}/items.json`),
+    ])
+
+    if (!itemsRes.ok) throw new Error(`HTTP ${itemsRes.status}`)
+    items.value = await itemsRes.json()
+
+    if (manifestRes.ok) {
+      const manifest = await manifestRes.json()
+      availableLangs.value = manifest.languages ?? []
+      // default to 'en' if present, otherwise first available
+      if (availableLangs.value.length > 0 && !availableLangs.value.includes(activeLang.value)) {
+        activeLang.value = availableLangs.value[0]
+      }
+    }
+
+    await loadTranslations(activeLang.value)
   } catch (e) {
     error.value = e.message
   } finally {
@@ -20,8 +51,16 @@ onMounted(async () => {
   }
 })
 
+watch(activeLang, async (lang) => {
+  await loadTranslations(lang)
+})
+
+function t(item) {
+  return translationsCache.value[activeLang.value]?.[item.id] ?? {}
+}
+
 function label(item) {
-  return item.translations?.en?.name ?? item.internal_name ?? item.id
+  return t(item).name ?? item.internal_name ?? item.id
 }
 
 function selectItem(item) {
@@ -33,7 +72,6 @@ function back() {
   selected.value = null
 }
 
-// Fields to show in detail view, in order
 const DETAIL_FIELDS = [
   ['type', 'Type'],
   ['alternate_name', 'Alternate name'],
@@ -54,9 +92,9 @@ const DETAIL_FIELDS = [
 
 const detailFields = computed(() => {
   if (!selected.value) return []
-  const en = selected.value.translations?.en ?? {}
+  const fields = t(selected.value)
   return DETAIL_FIELDS
-    .map(([key, label]) => ({ label, value: en[key] }))
+    .map(([key, label]) => ({ label, value: fields[key] }))
     .filter(f => f.value)
 })
 </script>
@@ -66,6 +104,14 @@ const detailFields = computed(() => {
     <header>
       <span class="logo">Inventory Viewer</span>
       <span v-if="!loading && !error" class="count">{{ items.length }} items</span>
+      <select
+        v-if="availableLangs.length > 1"
+        v-model="activeLang"
+        class="lang-select"
+        :disabled="loading"
+      >
+        <option v-for="lang in availableLangs" :key="lang" :value="lang">{{ lang }}</option>
+      </select>
     </header>
 
     <main>
@@ -89,9 +135,9 @@ const detailFields = computed(() => {
 
           <div v-if="selected.images?.length" class="images">
             <figure v-for="(img, i) in selected.images" :key="i">
-              <img :src="img.url" :alt="img.captions?.en ?? ''" loading="lazy" />
-              <figcaption v-if="img.captions?.en || img.photographer">
-                <span v-if="img.captions?.en">{{ img.captions.en }}</span>
+              <img :src="img.url" :alt="img.captions?.[activeLang] ?? ''" loading="lazy" />
+              <figcaption v-if="img.captions?.[activeLang] || img.photographer">
+                <span v-if="img.captions?.[activeLang]">{{ img.captions[activeLang] }}</span>
                 <span v-if="img.photographer" class="credit">© {{ img.photographer }}</span>
               </figcaption>
             </figure>
@@ -149,6 +195,18 @@ header {
 }
 .logo { font-weight: 700; font-size: 1rem; letter-spacing: .02em; }
 .count { font-size: .8rem; opacity: .6; }
+
+.lang-select {
+  margin-left: auto;
+  background: #2a2a4e;
+  color: #fff;
+  border: 1px solid #4a4a7e;
+  border-radius: 4px;
+  padding: .25rem .5rem;
+  font-size: .8rem;
+  cursor: pointer;
+}
+.lang-select:disabled { opacity: .5; cursor: default; }
 
 main { flex: 1; max-width: 900px; width: 100%; margin: 0 auto; padding: 1.5rem; }
 

--- a/tests/Pub/PictureControllerTest.php
+++ b/tests/Pub/PictureControllerTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Tests\Pub;
+
+use App\Models\CollectionImage;
+use App\Models\Item;
+use App\Models\ItemImage;
+use App\Models\PartnerImage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PictureControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const MINIMAL_JPEG = '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCwABIA/9k=';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('local');
+        Storage::fake('public');
+
+        config([
+            'localstorage.pictures.disk' => 'public',
+            'localstorage.pictures.directory' => 'pictures',
+        ]);
+    }
+
+    private function putTestImage(string $filename): void
+    {
+        Storage::disk('public')->put(
+            'pictures/'.$filename,
+            base64_decode(self::MINIMAL_JPEG)
+        );
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    public function test_serves_jpeg_with_caching_headers(): void
+    {
+        $item = Item::factory()->create();
+        $image = ItemImage::factory()->create([
+            'item_id' => $item->id,
+            'path' => $item->id.'.jpg',
+            'mime_type' => 'image/jpeg',
+        ]);
+        $this->putTestImage($image->path);
+
+        $response = $this->get(route('pub.picture', [
+            'type' => 'item-picture',
+            'filename' => $image->id.'.jpg',
+        ]));
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'image/jpeg');
+        $this->assertNotEmpty($response->headers->get('ETag'));
+        $this->assertNotEmpty($response->headers->get('Last-Modified'));
+        $this->assertStringContainsString('public', $response->headers->get('Cache-Control'));
+    }
+
+    // ── Conditional GET: ETag ─────────────────────────────────────────────────
+
+    public function test_returns_304_when_etag_matches(): void
+    {
+        $item = Item::factory()->create();
+        $image = ItemImage::factory()->create([
+            'item_id' => $item->id,
+            'path' => $item->id.'.jpg',
+            'mime_type' => 'image/jpeg',
+        ]);
+        $this->putTestImage($image->path);
+
+        // First request to obtain the ETag
+        $first = $this->get(route('pub.picture', [
+            'type' => 'item-picture',
+            'filename' => $image->id.'.jpg',
+        ]));
+        $etag = $first->headers->get('ETag');
+
+        // Conditional request with matching ETag
+        $response = $this->withHeaders(['If-None-Match' => $etag])
+            ->get(route('pub.picture', [
+                'type' => 'item-picture',
+                'filename' => $image->id.'.jpg',
+            ]));
+
+        $response->assertStatus(304);
+    }
+
+    // ── Conditional GET: Last-Modified ────────────────────────────────────────
+
+    public function test_returns_304_when_not_modified_since(): void
+    {
+        $item = Item::factory()->create();
+        $image = ItemImage::factory()->create([
+            'item_id' => $item->id,
+            'path' => $item->id.'.jpg',
+            'mime_type' => 'image/jpeg',
+        ]);
+        $this->putTestImage($image->path);
+
+        $first = $this->get(route('pub.picture', [
+            'type' => 'item-picture',
+            'filename' => $image->id.'.jpg',
+        ]));
+        $lastModified = $first->headers->get('Last-Modified');
+
+        $response = $this->withHeaders(['If-Modified-Since' => $lastModified])
+            ->get(route('pub.picture', [
+                'type' => 'item-picture',
+                'filename' => $image->id.'.jpg',
+            ]));
+
+        $response->assertStatus(304);
+    }
+
+    // ── 404 paths ─────────────────────────────────────────────────────────────
+
+    public function test_returns_404_for_unknown_id(): void
+    {
+        $response = $this->get('/pub/item-picture/00000000-0000-0000-0000-000000000000.jpg');
+
+        $response->assertNotFound();
+    }
+
+    public function test_returns_404_for_unknown_model_type(): void
+    {
+        $response = $this->get('/pub/unknown-type/00000000-0000-0000-0000-000000000000.jpg');
+
+        $response->assertNotFound();
+    }
+
+    public function test_returns_404_when_file_missing_from_disk(): void
+    {
+        $item = Item::factory()->create();
+        $image = ItemImage::factory()->create([
+            'item_id' => $item->id,
+            'path' => 'missing-file.jpg',
+        ]);
+        // intentionally not putting the file in storage
+
+        $response = $this->get(route('pub.picture', [
+            'type' => 'item-picture',
+            'filename' => $image->id.'.jpg',
+        ]));
+
+        $response->assertNotFound();
+    }
+
+    // ── 400 paths ─────────────────────────────────────────────────────────────
+
+    public function test_returns_400_when_query_string_is_present(): void
+    {
+        $item = Item::factory()->create();
+        $image = ItemImage::factory()->create([
+            'item_id' => $item->id,
+            'path' => $item->id.'.jpg',
+            'mime_type' => 'image/jpeg',
+        ]);
+        $this->putTestImage($image->path);
+
+        $response = $this->get(route('pub.picture', [
+            'type' => 'item-picture',
+            'filename' => $image->id.'.jpg',
+        ]).'?w=200');
+
+        $response->assertStatus(400);
+    }
+
+    // ── Non-JPEG filename is rejected by the route (no match → 404) ───────────
+
+    public function test_non_jpg_extension_does_not_match_route(): void
+    {
+        $response = $this->get('/pub/item-picture/00000000-0000-0000-0000-000000000000.png');
+
+        $response->assertNotFound();
+    }
+
+    // ── Different model types resolve correctly ───────────────────────────────
+
+    public function test_serves_collection_picture(): void
+    {
+        $image = CollectionImage::factory()->create([
+            'path' => 'col-test.jpg',
+            'mime_type' => 'image/jpeg',
+        ]);
+        $this->putTestImage($image->path);
+
+        $response = $this->get(route('pub.picture', [
+            'type' => 'collection-picture',
+            'filename' => $image->id.'.jpg',
+        ]));
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'image/jpeg');
+    }
+
+    public function test_serves_partner_picture(): void
+    {
+        $image = PartnerImage::factory()->create([
+            'path' => 'partner-test.jpg',
+            'mime_type' => 'image/jpeg',
+        ]);
+        $this->putTestImage($image->path);
+
+        $response = $this->get(route('pub.picture', [
+            'type' => 'partner-picture',
+            'filename' => $image->id.'.jpg',
+        ]));
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'image/jpeg');
+    }
+}


### PR DESCRIPTION
feat(exporter): Add public image viewer endpoint

### Laravel — public image endpoint

**`app/Http/Controllers/Pub/PictureController.php`** (new)
- Accepts `GET /pub/{type}/{uuid}.jpg`
- Rejects query string params → **400**
- Unknown model type or unknown UUID → **404**
- File missing from disk → **404**
- Returns `image/jpeg` with full caching headers: `Cache-Control: public, max-age=86400, must-revalidate`, `Last-Modified`, `ETag` (derived from file mtime)
- Handles `If-None-Match` and `If-Modified-Since` conditional requests → **304**

**`routes/web.php`** — new `/pub` group:
- Middleware: `throttle:pub-pictures` (no auth)
- Route regex enforces: `type` = `[a-z][a-z-]*`, `filename` = `[uuid].jpg` only (non-`.jpg` → 404 at routing level)

**`app/Providers/AppServiceProvider.php`** — registers the `pub-pictures` rate limiter (60 req/min by IP, tunable via `app.pub_pictures_throttle` config).

**Supported URL types → models:**

| URL segment | Model |
|---|---|
| `item-picture` | `ItemImage` |
| `collection-picture` | `CollectionImage` |
| `partner-picture` | `PartnerImage` |
| `partner-translation-picture` | `PartnerTranslationImage` |
| `contributor-picture` | `ContributorImage` |
| `timeline-event-picture` | `TimelineEventImage` |
| `partner-logo` | `PartnerLogo` |

### Exporter — updated image URLs

`imageUrl(path, modelSegment)` now builds `{base}/pub/{modelSegment}/{filename}` instead of the flat `{base}/{filename}`:

- Item images → `…/pub/item-picture/uuid.jpg`
- Collection images → `…/pub/collection-picture/uuid.jpg`
- Partner images → `…/pub/partner-picture/uuid.jpg`
- Partner logos → `…/pub/partner-logo/uuid.jpg`