### PR TITLE
Fix(/pub): simplify public image distribution

### DIFF
--- a/app/Http/Controllers/Pub/PictureController.php
+++ b/app/Http/Controllers/Pub/PictureController.php
@@ -2,68 +2,31 @@
 
 namespace App\Http\Controllers\Pub;
 
-use App\Contracts\StreamableImageFile;
 use App\Http\Controllers\Controller;
-use App\Models\CollectionImage;
-use App\Models\ContributorImage;
-use App\Models\ItemImage;
-use App\Models\PartnerImage;
-use App\Models\PartnerLogo;
-use App\Models\PartnerTranslationImage;
-use App\Models\TimelineEventImage;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class PictureController extends Controller
 {
     /**
-     * Maps URL type segment to the Eloquent model class that owns the image.
+     * Serve a picture from the public pictures storage.
      *
-     * @var array<string, class-string<Model&StreamableImageFile>>
+     * Route: GET /pub/{filename}  (filename constrained to {uuid}.jpg)
+     * No model lookup — the UUID is the bare filename on disk.
      */
-    private const MODEL_MAP = [
-        'item-picture' => ItemImage::class,
-        'collection-picture' => CollectionImage::class,
-        'partner-picture' => PartnerImage::class,
-        'partner-translation-picture' => PartnerTranslationImage::class,
-        'contributor-picture' => ContributorImage::class,
-        'timeline-event-picture' => TimelineEventImage::class,
-        'partner-logo' => PartnerLogo::class,
-    ];
-
-    /**
-     * Serve a public picture by model type and UUID.
-     *
-     * Route: GET /pub/{type}/{filename}
-     * where {filename} is constrained to {uuid}.jpg by the route definition.
-     */
-    public function show(Request $request, string $type, string $filename): BinaryFileResponse|Response
+    public function show(Request $request, string $filename): BinaryFileResponse|Response
     {
         // Reject query string parameters — public image URLs must be clean
         if ($request->query->count() > 0) {
             abort(400, 'Query parameters are not accepted.');
         }
 
-        // Resolve model class from the URL type segment
-        $modelClass = self::MODEL_MAP[$type] ?? null;
-        if ($modelClass === null) {
-            abort(404);
-        }
-
-        // Strip the .jpg suffix to obtain the UUID primary key
-        $id = substr($filename, 0, -4);
-
-        /** @var (Model&StreamableImageFile)|null $image */
-        $image = $modelClass::find($id);
-        if ($image === null) {
-            abort(404);
-        }
-
-        $disk = $image->imageDisk();
-        $storagePath = $image->imageStoragePath();
+        $disk = Config::string('localstorage.pictures.disk');
+        $directory = trim(Config::string('localstorage.pictures.directory'), '/');
+        $storagePath = $directory.'/'.$filename;
 
         if (! Storage::disk($disk)->exists($storagePath)) {
             abort(404);
@@ -71,7 +34,7 @@ class PictureController extends Controller
 
         $fullPath = Storage::disk($disk)->path($storagePath);
         $lastModifiedTimestamp = Storage::disk($disk)->lastModified($storagePath);
-        $etag = '"'.md5($id.':'.$lastModifiedTimestamp).'"';
+        $etag = '"'.md5($filename.':'.$lastModifiedTimestamp).'"';
         $lastModifiedHttp = gmdate('D, d M Y H:i:s', $lastModifiedTimestamp).' GMT';
 
         // Honour conditional GET requests so clients can revalidate cheaply

--- a/routes/web.php
+++ b/routes/web.php
@@ -231,15 +231,12 @@ Route::prefix('web')->group(function () {
 // See app/Providers/FortifyServiceProvider.php for middleware configuration
 
 // Public picture viewer — no authentication, rate-limited
-// Serves: /pub/{type}/{uuid}.jpg
-// Supported types: item-picture, collection-picture, partner-picture,
-//   partner-translation-picture, contributor-picture, timeline-event-picture, partner-logo
+// Serves any picture from the shared pictures storage by bare UUID filename.
 Route::middleware(['throttle:pub-pictures'])
     ->prefix('pub')
     ->name('pub.')
     ->group(function () {
-        Route::get('/{type}/{filename}', [PictureController::class, 'show'])
-            ->where('type', '[a-z][a-z-]*')
+        Route::get('/{filename}', [PictureController::class, 'show'])
             ->where('filename', '[0-9a-f-]+\.jpg')
             ->name('picture');
     });

--- a/scripts/Invoke-Pest.local.ps1
+++ b/scripts/Invoke-Pest.local.ps1
@@ -1,4 +1,5 @@
 $AppRoot = Split-Path -Parent -Path $PSScriptRoot
+Set-Location $AppRoot
 $TestSuites = @(                                                                                                                 
     'Unit'                                   
     'Api'
@@ -11,7 +12,7 @@ $TestSuites = @(
 )
 $TestSuites | Foreach-Object {
     $TestSuite = $_
-    $LogFile = Join-Path $AppRoot "temp_PHPTEST_$($TestSuite).xml"
+    $LogFile = "temp_PHPTEST_$($TestSuite).xml"
     Clear-Content $LogFile -ErrorAction Continue
     docker compose run --rm app php -d memory_limit=-1 artisan test --compact --log-junit=$LogFile --no-coverage --testsuite $TestSuite
     Write-Warning "Test suite '$TestSuite' completed. Log file: $(Resolve-Path $LogFile)"

--- a/scripts/exporter/src/exporters/base-exporter.ts
+++ b/scripts/exporter/src/exporters/base-exporter.ts
@@ -87,13 +87,8 @@ export abstract class BaseExporter {
     return Array.from({ length: count }, () => '?').join(', ')
   }
 
-  /**
-   * Build the public picture URL for a given image path and model type segment.
-   * path is the bare filename stored in the DB (e.g. "uuid.jpg").
-   * modelSegment is the kebab-case type used in the /pub/ URL
-   * (e.g. "item-picture", "collection-picture", "partner-logo").
-   */
-  protected imageUrl(path: string, modelSegment: string): string {
-    return `${this.baseUrl}/pub/${modelSegment}/${path}`
+  /** Build the public picture URL for a bare filename stored in the DB (e.g. "uuid.jpg"). */
+  protected imageUrl(path: string): string {
+    return `${this.baseUrl}/pub/${path}`
   }
 }

--- a/scripts/exporter/src/exporters/collection-exporter.ts
+++ b/scripts/exporter/src/exporters/collection-exporter.ts
@@ -130,7 +130,7 @@ export class CollectionExporter extends BaseExporter {
     for (const img of images) {
       if (!imageMap.has(img.collection_id)) imageMap.set(img.collection_id, [])
       imageMap.get(img.collection_id)!.push({
-        url: this.imageUrl(img.path, 'collection-picture'),
+        url: this.imageUrl(img.path),
         alt_text: img.alt_text,
         display_order: img.display_order,
       })

--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -245,7 +245,7 @@ export class ItemExporter extends BaseExporter {
       }
 
       imageMap.get(pic.item_id)!.push({
-        url: this.imageUrl(pic.path, 'item-picture'),
+        url: this.imageUrl(pic.path),
         display_order: pic.display_order,
         captions,
         photographer: firstLang?.photographer ?? null,

--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -131,7 +131,7 @@ export class PartnerExporter extends BaseExporter {
     for (const img of images) {
       if (!imageMap.has(img.partner_id)) imageMap.set(img.partner_id, [])
       imageMap.get(img.partner_id)!.push({
-        url: this.imageUrl(img.path, 'partner-picture'),
+        url: this.imageUrl(img.path),
         alt_text: img.alt_text,
         display_order: img.display_order,
       })
@@ -145,7 +145,7 @@ export class PartnerExporter extends BaseExporter {
     for (const logo of logos) {
       if (!logoMap.has(logo.partner_id)) logoMap.set(logo.partner_id, [])
       logoMap.get(logo.partner_id)!.push({
-        url: this.imageUrl(logo.path, 'partner-logo'),
+        url: this.imageUrl(logo.path),
         logo_type: logo.logo_type,
         alt_text: logo.alt_text,
         display_order: logo.display_order,

--- a/tests/Pub/PictureControllerTest.php
+++ b/tests/Pub/PictureControllerTest.php
@@ -2,12 +2,9 @@
 
 namespace Tests\Pub;
 
-use App\Models\CollectionImage;
-use App\Models\Item;
-use App\Models\ItemImage;
-use App\Models\PartnerImage;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class PictureControllerTest extends TestCase
@@ -20,7 +17,6 @@ class PictureControllerTest extends TestCase
     {
         parent::setUp();
 
-        Storage::fake('local');
         Storage::fake('public');
 
         config([
@@ -37,22 +33,19 @@ class PictureControllerTest extends TestCase
         );
     }
 
+    private function uuid(): string
+    {
+        return (string) Str::uuid();
+    }
+
     // ── Happy path ────────────────────────────────────────────────────────────
 
     public function test_serves_jpeg_with_caching_headers(): void
     {
-        $item = Item::factory()->create();
-        $image = ItemImage::factory()->create([
-            'item_id' => $item->id,
-            'path' => $item->id.'.jpg',
-            'mime_type' => 'image/jpeg',
-        ]);
-        $this->putTestImage($image->path);
+        $filename = $this->uuid().'.jpg';
+        $this->putTestImage($filename);
 
-        $response = $this->get(route('pub.picture', [
-            'type' => 'item-picture',
-            'filename' => $image->id.'.jpg',
-        ]));
+        $response = $this->get(route('pub.picture', ['filename' => $filename]));
 
         $response->assertOk();
         $response->assertHeader('Content-Type', 'image/jpeg');
@@ -65,27 +58,14 @@ class PictureControllerTest extends TestCase
 
     public function test_returns_304_when_etag_matches(): void
     {
-        $item = Item::factory()->create();
-        $image = ItemImage::factory()->create([
-            'item_id' => $item->id,
-            'path' => $item->id.'.jpg',
-            'mime_type' => 'image/jpeg',
-        ]);
-        $this->putTestImage($image->path);
+        $filename = $this->uuid().'.jpg';
+        $this->putTestImage($filename);
 
-        // First request to obtain the ETag
-        $first = $this->get(route('pub.picture', [
-            'type' => 'item-picture',
-            'filename' => $image->id.'.jpg',
-        ]));
+        $first = $this->get(route('pub.picture', ['filename' => $filename]));
         $etag = $first->headers->get('ETag');
 
-        // Conditional request with matching ETag
         $response = $this->withHeaders(['If-None-Match' => $etag])
-            ->get(route('pub.picture', [
-                'type' => 'item-picture',
-                'filename' => $image->id.'.jpg',
-            ]));
+            ->get(route('pub.picture', ['filename' => $filename]));
 
         $response->assertStatus(304);
     }
@@ -94,58 +74,23 @@ class PictureControllerTest extends TestCase
 
     public function test_returns_304_when_not_modified_since(): void
     {
-        $item = Item::factory()->create();
-        $image = ItemImage::factory()->create([
-            'item_id' => $item->id,
-            'path' => $item->id.'.jpg',
-            'mime_type' => 'image/jpeg',
-        ]);
-        $this->putTestImage($image->path);
+        $filename = $this->uuid().'.jpg';
+        $this->putTestImage($filename);
 
-        $first = $this->get(route('pub.picture', [
-            'type' => 'item-picture',
-            'filename' => $image->id.'.jpg',
-        ]));
+        $first = $this->get(route('pub.picture', ['filename' => $filename]));
         $lastModified = $first->headers->get('Last-Modified');
 
         $response = $this->withHeaders(['If-Modified-Since' => $lastModified])
-            ->get(route('pub.picture', [
-                'type' => 'item-picture',
-                'filename' => $image->id.'.jpg',
-            ]));
+            ->get(route('pub.picture', ['filename' => $filename]));
 
         $response->assertStatus(304);
     }
 
     // ── 404 paths ─────────────────────────────────────────────────────────────
 
-    public function test_returns_404_for_unknown_id(): void
+    public function test_returns_404_for_unknown_file(): void
     {
-        $response = $this->get('/pub/item-picture/00000000-0000-0000-0000-000000000000.jpg');
-
-        $response->assertNotFound();
-    }
-
-    public function test_returns_404_for_unknown_model_type(): void
-    {
-        $response = $this->get('/pub/unknown-type/00000000-0000-0000-0000-000000000000.jpg');
-
-        $response->assertNotFound();
-    }
-
-    public function test_returns_404_when_file_missing_from_disk(): void
-    {
-        $item = Item::factory()->create();
-        $image = ItemImage::factory()->create([
-            'item_id' => $item->id,
-            'path' => 'missing-file.jpg',
-        ]);
-        // intentionally not putting the file in storage
-
-        $response = $this->get(route('pub.picture', [
-            'type' => 'item-picture',
-            'filename' => $image->id.'.jpg',
-        ]));
+        $response = $this->get('/pub/00000000-0000-0000-0000-000000000000.jpg');
 
         $response->assertNotFound();
     }
@@ -154,64 +99,20 @@ class PictureControllerTest extends TestCase
 
     public function test_returns_400_when_query_string_is_present(): void
     {
-        $item = Item::factory()->create();
-        $image = ItemImage::factory()->create([
-            'item_id' => $item->id,
-            'path' => $item->id.'.jpg',
-            'mime_type' => 'image/jpeg',
-        ]);
-        $this->putTestImage($image->path);
+        $filename = $this->uuid().'.jpg';
+        $this->putTestImage($filename);
 
-        $response = $this->get(route('pub.picture', [
-            'type' => 'item-picture',
-            'filename' => $image->id.'.jpg',
-        ]).'?w=200');
+        $response = $this->get(route('pub.picture', ['filename' => $filename]).'?w=200');
 
         $response->assertStatus(400);
     }
 
-    // ── Non-JPEG filename is rejected by the route (no match → 404) ───────────
+    // ── Non-JPEG filename does not match the route ────────────────────────────
 
     public function test_non_jpg_extension_does_not_match_route(): void
     {
-        $response = $this->get('/pub/item-picture/00000000-0000-0000-0000-000000000000.png');
+        $response = $this->get('/pub/00000000-0000-0000-0000-000000000000.png');
 
         $response->assertNotFound();
-    }
-
-    // ── Different model types resolve correctly ───────────────────────────────
-
-    public function test_serves_collection_picture(): void
-    {
-        $image = CollectionImage::factory()->create([
-            'path' => 'col-test.jpg',
-            'mime_type' => 'image/jpeg',
-        ]);
-        $this->putTestImage($image->path);
-
-        $response = $this->get(route('pub.picture', [
-            'type' => 'collection-picture',
-            'filename' => $image->id.'.jpg',
-        ]));
-
-        $response->assertOk();
-        $response->assertHeader('Content-Type', 'image/jpeg');
-    }
-
-    public function test_serves_partner_picture(): void
-    {
-        $image = PartnerImage::factory()->create([
-            'path' => 'partner-test.jpg',
-            'mime_type' => 'image/jpeg',
-        ]);
-        $this->putTestImage($image->path);
-
-        $response = $this->get(route('pub.picture', [
-            'type' => 'partner-picture',
-            'filename' => $image->id.'.jpg',
-        ]));
-
-        $response->assertOk();
-        $response->assertHeader('Content-Type', 'image/jpeg');
     }
 }


### PR DESCRIPTION
**`PictureController`** — dropped the `MODEL_MAP` and all model imports entirely. Now reads straight from `localstorage.pictures.disk` / `localstorage.pictures.directory` using the UUID filename from the URL. ~half the code.

**Route** — `/pub/{type}/{filename}` → `/pub/{filename}` (one segment, same `.jpg` constraint).

**Exporter** — `imageUrl(path, modelSegment)` reverted to `imageUrl(path)`, producing `{base}/pub/{uuid}.jpg`. All four call sites (item pictures, collection images, partner images, partner logos) updated.

**Tests** — no factories needed; tests just write a file to fake storage and request `/pub/{uuid}.jpg` directly.