### PR TITLE
feat(exporter+viewer): add item-item links, dynasty display, and security fix

### DIFF
--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -65,6 +65,11 @@ interface ItemDynastyRow {
   dynasty_id: string
 }
 
+interface ItemItemLinkRow {
+  source_id: string
+  target_id: string
+}
+
 interface ItemTagRow {
   item_id: string
   tag: string
@@ -152,8 +157,8 @@ export class ItemExporter extends BaseExporter {
       )
     }
 
-    // ── 3. Dynasty and tag links ─────────────────────────────────────────────
-    const [dynastyLinks, tagLinks] = await Promise.all([
+    // ── 3. Dynasty, tag, and item-item links ────────────────────────────────
+    const [dynastyLinks, tagLinks, itemItemLinks] = await Promise.all([
       this.db.query<ItemDynastyRow>(
         `SELECT item_id, dynasty_id FROM item_dynasty WHERE item_id IN (${itemPh})`,
         itemIds
@@ -164,6 +169,11 @@ export class ItemExporter extends BaseExporter {
          JOIN tags t ON t.id = it2.tag_id
          WHERE it2.item_id IN (${itemPh})`,
         itemIds
+      ),
+      this.db.query<ItemItemLinkRow>(
+        `SELECT source_id, target_id FROM item_item_links
+         WHERE source_id IN (${itemPh}) OR target_id IN (${itemPh})`,
+        [...itemIds, ...itemIds]
       ),
     ])
 
@@ -267,6 +277,18 @@ export class ItemExporter extends BaseExporter {
       tagMap.get(link.item_id)!.push(link.tag)
     }
 
+    // item_id -> related_item_ids[] (bidirectional; only items present in this export)
+    const itemIdSet = new Set(itemIds)
+    const relatedMap = new Map<string, string[]>()
+    for (const link of itemItemLinks) {
+      if (itemIdSet.has(link.source_id) && itemIdSet.has(link.target_id)) {
+        if (!relatedMap.has(link.source_id)) relatedMap.set(link.source_id, [])
+        relatedMap.get(link.source_id)!.push(link.target_id)
+        if (!relatedMap.has(link.target_id)) relatedMap.set(link.target_id, [])
+        relatedMap.get(link.target_id)!.push(link.source_id)
+      }
+    }
+
     const output = items.map(item => ({
       id: item.id,
       type: item.type,
@@ -283,6 +305,7 @@ export class ItemExporter extends BaseExporter {
       longitude: item.longitude !== null ? parseFloat(item.longitude) : null,
       images: imageMap.get(item.id) ?? [],
       dynasty_ids: dynastyMap.get(item.id) ?? [],
+      related_item_ids: relatedMap.get(item.id) ?? [],
       tags: tagMap.get(item.id) ?? [],
     }))
 

--- a/scripts/viewer/package-lock.json
+++ b/scripts/viewer/package-lock.json
@@ -103,9 +103,9 @@
       "license": "MIT"
     },
     "node_modules/@metanull/islamicart-data": {
-      "version": "1.0.4",
-      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.4/8be99a7c7708d8d1d7d94adf77c89ff17459b279",
-      "integrity": "sha512-8C2sJq0QXxHOikMOITOg5BAUSGr9IcoOpTEIWtMMDWO0xIsO5WLrvvc2SdX2Q0/ehcdhWbPEu9Bk+/6rztoecw==",
+      "version": "1.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.5/16184b0ed8d309cdc478b3a0982a898bf0eb8023",
+      "integrity": "sha512-/KeI14lJlGeWCiPa4Lt1sb+ioDP9Jzrr1FJsnsVkFZ2w6uwKwHQx7bRkASrzz11xyrM/eTdrtUn7wjk9PuNjiA==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=16.0.0",

--- a/scripts/viewer/src/App.vue
+++ b/scripts/viewer/src/App.vue
@@ -2,8 +2,10 @@
 import { ref, computed, watch } from 'vue'
 import manifestData from '@inventory-data/manifest.json'
 import itemsData from '@inventory-data/items.json'
+import dynastiesData from '@inventory-data/dynasties.json'
 
 const items = ref(itemsData)
+const dynasties = ref(dynastiesData)
 const availableLangs = ref(manifestData.languages ?? [])
 const activeLang = ref(
   (manifestData.languages ?? []).includes('en')
@@ -12,6 +14,8 @@ const activeLang = ref(
 )
 // { [langCode]: { [itemId]: { name, description, ... } } }
 const translationsCache = ref({})
+// { [langCode]: { [dynastyId]: { name, history, ... } } }
+const dynastyTranslationsCache = ref({})
 const selected = ref(null)
 
 async function loadTranslations(lang) {
@@ -24,11 +28,23 @@ async function loadTranslations(lang) {
   }
 }
 
+async function loadDynastyTranslations(lang) {
+  if (dynastyTranslationsCache.value[lang]) return
+  try {
+    const module = await import(`@inventory-data/translations/dynasties.${lang}.json`)
+    dynastyTranslationsCache.value = { ...dynastyTranslationsCache.value, [lang]: module.default }
+  } catch {
+    // no dynasty translations for this language
+  }
+}
+
 // Load initial language translations
 loadTranslations(activeLang.value)
+loadDynastyTranslations(activeLang.value)
 
 watch(activeLang, (lang) => {
   loadTranslations(lang)
+  loadDynastyTranslations(lang)
 })
 
 function t(item) {
@@ -73,6 +89,42 @@ const detailFields = computed(() => {
     .map(([key, label]) => ({ label, value: fields[key] }))
     .filter(f => f.value)
 })
+
+// Build an id→item lookup once for fast related-item resolution
+const itemById = computed(() => {
+  const map = {}
+  for (const item of items.value) map[item.id] = item
+  return map
+})
+
+const relatedItems = computed(() => {
+  if (!selected.value?.related_item_ids?.length) return []
+  return selected.value.related_item_ids
+    .map(id => itemById.value[id])
+    .filter(Boolean)
+})
+
+const dynastyById = computed(() => {
+  const map = {}
+  for (const d of dynasties.value) map[d.id] = d
+  return map
+})
+
+function tDynasty(dynastyId) {
+  return dynastyTranslationsCache.value[activeLang.value]?.[dynastyId] ?? {}
+}
+
+const selectedDynasties = computed(() => {
+  if (!selected.value?.dynasty_ids?.length) return []
+  return selected.value.dynasty_ids
+    .map(id => {
+      const d = dynastyById.value[id]
+      if (!d) return null
+      const tr = tDynasty(id)
+      return { ...d, ...tr }
+    })
+    .filter(Boolean)
+})
 </script>
 
 <template>
@@ -114,6 +166,42 @@ const detailFields = computed(() => {
               <dd>{{ f.value }}</dd>
             </template>
           </dl>
+
+          <div v-if="selectedDynasties.length" class="dynasties">
+            <h2 class="section-title">{{ selectedDynasties.length === 1 ? 'Dynasty' : 'Dynasties' }}</h2>
+            <div v-for="d in selectedDynasties" :key="d.id" class="dynasty-card">
+              <div class="dynasty-header">
+                <span class="dynasty-name">{{ d.name ?? '—' }}</span>
+                <span v-if="d.also_known_as" class="dynasty-aka">also known as {{ d.also_known_as }}</span>
+                <span v-if="d.from_ad || d.to_ad" class="dynasty-dates">
+                  {{ d.date_description_ad ?? (d.from_ad + (d.to_ad ? ' – ' + d.to_ad : '')) }}
+                </span>
+              </div>
+              <p v-if="d.history" class="dynasty-history">{{ d.history }}</p>
+              <p v-if="d.area" class="dynasty-area">Area: {{ d.area }}</p>
+            </div>
+          </div>
+
+          <div v-if="relatedItems.length" class="related">
+            <h2 class="section-title">Related items</h2>
+            <ul class="related-list">
+              <li
+                v-for="rel in relatedItems"
+                :key="rel.id"
+                class="related-item"
+                @click="selectItem(rel)"
+              >
+                <div class="related-thumb">
+                  <img v-if="rel.images?.length" :src="rel.images[0].url" :alt="label(rel)" loading="lazy" />
+                  <div v-else class="related-thumb-placeholder"></div>
+                </div>
+                <div class="related-info">
+                  <span class="related-name">{{ label(rel) }}</span>
+                  <span class="related-type">{{ rel.type }}</span>
+                </div>
+              </li>
+            </ul>
+          </div>
 
           <div class="meta">
             <span v-if="selected.country_id">Country: {{ selected.country_id }}</span>
@@ -218,4 +306,31 @@ dt { font-weight: 600; font-size: .85rem; color: #555; white-space: nowrap; }
 dd { font-size: .9rem; line-height: 1.5; }
 
 .meta { display: flex; flex-wrap: wrap; gap: .5rem 1.5rem; font-size: .8rem; color: #888; border-top: 1px solid #eee; padding-top: 1rem; }
+
+.section-title { font-size: .9rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; color: #555; margin-bottom: .75rem; }
+
+.dynasties { margin-bottom: 1.25rem; border-top: 1px solid #eee; padding-top: 1.25rem; }
+.dynasty-card { background: #f7f5ee; border-left: 3px solid #b5953a; border-radius: 4px; padding: .75rem 1rem; margin-bottom: .6rem; }
+.dynasty-header { display: flex; flex-wrap: wrap; align-items: baseline; gap: .4rem 1rem; margin-bottom: .4rem; }
+.dynasty-name { font-weight: 700; font-size: 1rem; }
+.dynasty-aka { font-size: .82rem; color: #777; font-style: italic; }
+.dynasty-dates { font-size: .82rem; color: #888; margin-left: auto; }
+.dynasty-history { font-size: .88rem; line-height: 1.6; color: #333; margin: 0 0 .35rem; }
+.dynasty-area { font-size: .8rem; color: #777; margin: 0; }
+
+.related { margin-bottom: 1.25rem; border-top: 1px solid #eee; padding-top: 1.25rem; }
+.related-list { list-style: none; display: flex; flex-direction: column; gap: .4rem; }
+.related-item {
+  display: flex; align-items: center; gap: .75rem;
+  padding: .5rem .75rem;
+  background: #f7f7f9; border-radius: 6px;
+  cursor: pointer; transition: background .15s;
+}
+.related-item:hover { background: #eeeef6; }
+.related-thumb { width: 44px; height: 44px; flex-shrink: 0; border-radius: 4px; overflow: hidden; background: #ddd; }
+.related-thumb img { width: 100%; height: 100%; object-fit: cover; }
+.related-thumb-placeholder { width: 100%; height: 100%; }
+.related-info { display: flex; flex-direction: column; gap: .15rem; min-width: 0; }
+.related-name { font-size: .88rem; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.related-type { font-size: .72rem; color: #888; text-transform: uppercase; letter-spacing: .05em; }
 </style>

--- a/scripts/viewer/vite.config.js
+++ b/scripts/viewer/vite.config.js
@@ -1,11 +1,10 @@
-import { defineConfig, loadEnv } from 'vite'
+import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { createRequire } from 'module'
 import { dirname } from 'path'
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
-  const dataPackage = env.DATA_PACKAGE || '@metanull/islamicart-data'
+export default defineConfig(() => {
+  const dataPackage = process.env.DATA_PACKAGE || '@metanull/islamicart-data'
 
   const require = createRequire(import.meta.url)
   let dataPackageDir


### PR DESCRIPTION
## Summary

- **Item-item links**: exporter now queries and exports `related_item_ids` for each item (bidirectional, scoped to items present in the export); viewer renders a "Related items" panel with thumbnail and click-to-navigate
- **Dynasty display**: viewer loads dynasty data and dynasty translations, and renders a styled "Dynasty / Dynasties" section on the item detail panel
- **Security fix**: removes `loadEnv` misconfiguration in `vite.config.js` that was loading all environment variables with an empty prefix filter — switched to `process.env.DATA_PACKAGE` directly, which is a build-time-only value that never enters the client bundle

## Test plan

- [ ] Run exporter against a dataset with `item_item_links` rows and verify `related_item_ids` appears in the output JSON
- [ ] Open viewer, select an item with related items — confirm "Related items" panel appears and clicking navigates to that item
- [ ] Select an item with dynasty associations — confirm dynasty card(s) render with name, dates, and history
- [ ] Verify `vite.config.js` builds correctly when `DATA_PACKAGE` is set in the shell environment
- [ ] Inspect built JS bundle — confirm no CI/CD secrets or unexpected env vars are embedded

🤖 Generated with [Claude Code](https://claude.com/claude-code)