### PR TITLE
feat(exporter+viewer): monument fields, backward_compatibility, markdown prose

### DIFF
--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -39,6 +39,7 @@ interface ItemTranslationRow {
   provenance: string | null
   obtention: string | null
   bibliography: string | null
+  extra: string | null
   author_name: string | null
   copy_editor_name: string | null
   translator_name: string | null
@@ -115,7 +116,7 @@ export class ItemExporter extends BaseExporter {
               it.type, it.holder, it.owner, it.initial_owner, it.dates,
               it.location, it.dimensions, it.place_of_production,
               it.method_for_datation, it.method_for_provenance,
-              it.provenance, it.obtention, it.bibliography,
+              it.provenance, it.obtention, it.bibliography, it.extra,
               a1.name AS author_name,
               a2.name AS copy_editor_name,
               a3.name AS translator_name,
@@ -179,12 +180,26 @@ export class ItemExporter extends BaseExporter {
 
     // ── Build maps ───────────────────────────────────────────────────────────
 
+    // item_id -> type (needed to conditionally surface monument-specific extra fields)
+    const itemTypeMap = new Map<string, string>(items.map(i => [i.id, i.type]))
+
     // item_id -> lang_code -> translation fields
     const translationMap = new Map<string, Record<string, Record<string, unknown>>>()
     for (const t of translations) {
       if (!translationMap.has(t.item_id)) translationMap.set(t.item_id, {})
       const code = langCodeMap.get(t.language_id)
       if (!code) continue
+
+      // For monuments, surface history and patrons stored in item_translations.extra.
+      // These fields are distinct from objects' obtention and initial_owner.
+      let history: string | null = null
+      let patrons: string | null = null
+      if (itemTypeMap.get(t.item_id) === 'monument' && t.extra) {
+        const extra = parseJson(t.extra) as Record<string, string> | null
+        history = extra?.history ?? null
+        patrons = extra?.patrons ?? null
+      }
+
       translationMap.get(t.item_id)![code] = {
         name: t.name,
         alternate_name: t.alternate_name,
@@ -202,6 +217,8 @@ export class ItemExporter extends BaseExporter {
         provenance: t.provenance,
         obtention: t.obtention,
         bibliography: t.bibliography,
+        history,
+        patrons,
         author: t.author_name,
         copy_editor: t.copy_editor_name,
         translator: t.translator_name,
@@ -293,6 +310,7 @@ export class ItemExporter extends BaseExporter {
       id: item.id,
       type: item.type,
       internal_name: item.internal_name,
+      backward_compatibility: item.backward_compatibility,
       parent_id: item.parent_id,
       partner_id: item.partner_id,
       country_id: item.country_id,

--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -155,6 +155,7 @@ export class PartnerExporter extends BaseExporter {
     const output = partners.map(p => ({
       id: p.id,
       type: p.type,
+      backward_compatibility: p.backward_compatibility,
       country_id: p.country_id,
       latitude: p.latitude !== null ? parseFloat(p.latitude) : null,
       longitude: p.longitude !== null ? parseFloat(p.longitude) : null,

--- a/scripts/viewer/package-lock.json
+++ b/scripts/viewer/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@metanull/islamicart-data": "^1.0.4",
+        "marked": "^18.0.5",
         "vue": "^3.5.39"
       },
       "devDependencies": {
@@ -868,6 +869,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/nanoid": {

--- a/scripts/viewer/package.json
+++ b/scripts/viewer/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@metanull/islamicart-data": "^1.0.4",
+    "marked": "^18.0.5",
     "vue": "^3.5.39"
   },
   "devDependencies": {

--- a/scripts/viewer/src/App.vue
+++ b/scripts/viewer/src/App.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
+import { marked } from 'marked'
 import manifestData from '@inventory-data/manifest.json'
 import itemsData from '@inventory-data/items.json'
 import dynastiesData from '@inventory-data/dynasties.json'
@@ -12,9 +13,7 @@ const activeLang = ref(
     ? 'en'
     : (manifestData.languages?.[0] ?? 'en')
 )
-// { [langCode]: { [itemId]: { name, description, ... } } }
 const translationsCache = ref({})
-// { [langCode]: { [dynastyId]: { name, history, ... } } }
 const dynastyTranslationsCache = ref({})
 const selected = ref(null)
 
@@ -33,12 +32,9 @@ async function loadDynastyTranslations(lang) {
   try {
     const module = await import(`@inventory-data/translations/dynasties.${lang}.json`)
     dynastyTranslationsCache.value = { ...dynastyTranslationsCache.value, [lang]: module.default }
-  } catch {
-    // no dynasty translations for this language
-  }
+  } catch {}
 }
 
-// Load initial language translations
 loadTranslations(activeLang.value)
 loadDynastyTranslations(activeLang.value)
 
@@ -64,33 +60,11 @@ function back() {
   selected.value = null
 }
 
-const DETAIL_FIELDS = [
-  ['type', 'Type'],
-  ['alternate_name', 'Alternate name'],
-  ['description', 'Description'],
-  ['dates', 'Dates'],
-  ['location', 'Location'],
-  ['holder', 'Holder'],
-  ['owner', 'Owner'],
-  ['initial_owner', 'Initial owner'],
-  ['dimensions', 'Dimensions'],
-  ['place_of_production', 'Place of production'],
-  ['method_for_datation', 'Method for datation'],
-  ['method_for_provenance', 'Method for provenance'],
-  ['provenance', 'Provenance'],
-  ['obtention', 'Obtention'],
-  ['bibliography', 'Bibliography'],
-]
+function md(text) {
+  if (!text) return ''
+  return marked.parse(text, { breaks: true })
+}
 
-const detailFields = computed(() => {
-  if (!selected.value) return []
-  const fields = t(selected.value)
-  return DETAIL_FIELDS
-    .map(([key, label]) => ({ label, value: fields[key] }))
-    .filter(f => f.value)
-})
-
-// Build an id→item lookup once for fast related-item resolution
 const itemById = computed(() => {
   const map = {}
   for (const item of items.value) map[item.id] = item
@@ -99,9 +73,15 @@ const itemById = computed(() => {
 
 const relatedItems = computed(() => {
   if (!selected.value?.related_item_ids?.length) return []
+  // deduplicate
+  const seen = new Set()
   return selected.value.related_item_ids
     .map(id => itemById.value[id])
-    .filter(Boolean)
+    .filter(item => {
+      if (!item || seen.has(item.id)) return false
+      seen.add(item.id)
+      return true
+    })
 })
 
 const dynastyById = computed(() => {
@@ -125,6 +105,85 @@ const selectedDynasties = computed(() => {
     })
     .filter(Boolean)
 })
+
+const isMonument = computed(() => selected.value?.type === 'monument')
+
+// Key facts: metadata rows in the info table, matching legacy page field order
+const keyFacts = computed(() => {
+  if (!selected.value) return []
+  const item = selected.value
+  const tr = t(item)
+  const dynastyNames = selectedDynasties.value.map(d => d.name).filter(Boolean).join(', ')
+  const facts = []
+
+  if (isMonument.value) {
+    // Monument field order from legacy: Also known as, Location, Date, Period/Dynasty, Patron(s)
+    if (tr.alternate_name)              facts.push({ label: 'Also known as', value: tr.alternate_name })
+    if (tr.location)                    facts.push({ label: 'Location', value: tr.location })
+    if (tr.dates)                       facts.push({ label: 'Date of Monument', value: tr.dates })
+    if (dynastyNames)                   facts.push({ label: 'Period / Dynasty', value: dynastyNames })
+    // patrons comes from extra.patrons (monument-specific); fall back to initial_owner if absent
+    const patronValue = tr.patrons ?? tr.initial_owner
+    if (patronValue)                    facts.push({ label: 'Patron(s)', value: patronValue })
+  } else {
+    // Object field order from legacy: Location, Holding Museum, Inventory No, Date, Period/Dynasty, Provenance, Material/Technique, Dimensions
+    if (tr.location)            facts.push({ label: 'Location', value: tr.location })
+    if (tr.holder)              facts.push({ label: 'Holding Museum', value: tr.holder })
+    if (item.owner_reference)   facts.push({ label: 'Museum Inventory Number', value: item.owner_reference })
+    if (tr.dates)               facts.push({ label: 'Date of Object', value: tr.dates })
+    if (dynastyNames)           facts.push({ label: 'Period / Dynasty', value: dynastyNames })
+    if (tr.provenance)          facts.push({ label: 'Provenance', value: tr.provenance })
+    if (tr.type)                facts.push({ label: 'Material(s) / Technique(s)', value: tr.type })
+    if (tr.dimensions)          facts.push({ label: 'Dimensions', value: tr.dimensions })
+    if (tr.owner)               facts.push({ label: 'Owner', value: tr.owner })
+    if (tr.initial_owner)       facts.push({ label: 'Initial Owner', value: tr.initial_owner })
+    if (tr.place_of_production) facts.push({ label: 'Place of Production', value: tr.place_of_production })
+  }
+
+  return facts
+})
+
+// Content sections: named text blocks rendered as markdown, matching legacy section order
+const contentSections = computed(() => {
+  if (!selected.value) return []
+  const tr = t(selected.value)
+  const monument = isMonument.value
+  const sections = []
+
+  if (monument) {
+    // Monument order: History, Description, How Monument Was Dated
+    // history comes from extra.history (monument-specific brief history of construction/restoration)
+    if (tr.history)               sections.push({ heading: 'History', value: tr.history })
+    if (tr.description)           sections.push({ heading: 'Description', value: tr.description })
+  } else {
+    // Object order: Description, History/Acquisition, How Object Was Dated, Provenance method
+    if (tr.description)           sections.push({ heading: 'Description', value: tr.description })
+    if (tr.obtention)             sections.push({ heading: 'History / Acquisition', value: tr.obtention })
+  }
+
+  if (tr.method_for_datation)
+    sections.push({ heading: monument ? 'How Monument Was Dated' : 'How Object Was Dated', value: tr.method_for_datation })
+
+  if (tr.method_for_provenance)
+    sections.push({ heading: monument ? 'How Monument Provenance Was Determined' : 'How Object Provenance Was Determined', value: tr.method_for_provenance })
+
+  if (tr.bibliography)
+    sections.push({ heading: 'Bibliography', value: tr.bibliography })
+
+  return sections
+})
+
+// Credits block: separated from content, matching legacy credits section labels
+const credits = computed(() => {
+  if (!selected.value) return []
+  const tr = t(selected.value)
+  const c = []
+  if (tr.author)                   c.push({ label: 'Prepared by', value: tr.author })
+  if (tr.copy_editor)              c.push({ label: 'Copyedited by', value: tr.copy_editor })
+  if (tr.translator)               c.push({ label: 'Translation by', value: tr.translator })
+  if (tr.translation_copy_editor)  c.push({ label: 'Translation copyedited by', value: tr.translation_copy_editor })
+  return c
+})
 </script>
 
 <template>
@@ -142,7 +201,7 @@ const selectedDynasties = computed(() => {
     </header>
 
     <main>
-      <!-- Detail -->
+      <!-- ── Detail view ── -->
       <template v-if="selected">
         <a class="back" href="#" @click.prevent="back">← Back to list</a>
 
@@ -150,23 +209,52 @@ const selectedDynasties = computed(() => {
           <div class="detail-type">{{ selected.type }}</div>
           <h1>{{ label(selected) }}</h1>
 
+          <!-- Images -->
           <div v-if="selected.images?.length" class="images">
             <figure v-for="(img, i) in selected.images" :key="i">
               <img :src="img.url" :alt="img.captions?.[activeLang] ?? ''" loading="lazy" />
               <figcaption v-if="img.captions?.[activeLang] || img.photographer">
                 <span v-if="img.captions?.[activeLang]">{{ img.captions[activeLang] }}</span>
-                <span v-if="img.photographer" class="credit">© {{ img.photographer }}</span>
+                <span v-if="img.photographer" class="photo-credit">© {{ img.photographer }}</span>
               </figcaption>
             </figure>
           </div>
 
-          <dl v-if="detailFields.length">
-            <template v-for="f in detailFields" :key="f.label">
-              <dt>{{ f.label }}</dt>
-              <dd>{{ f.value }}</dd>
-            </template>
-          </dl>
+          <!-- Key facts table (metadata, type-conditional labels & order) -->
+          <table v-if="keyFacts.length" class="key-facts">
+            <tbody>
+              <tr v-for="fact in keyFacts" :key="fact.label">
+                <th>{{ fact.label }}</th>
+                <td>{{ fact.value }}</td>
+              </tr>
+            </tbody>
+          </table>
 
+          <!-- Content sections (named sections with markdown body) -->
+          <section
+            v-for="section in contentSections"
+            :key="section.heading"
+            class="content-section"
+          >
+            <h2>{{ section.heading }}</h2>
+            <div v-html="md(section.value)" class="prose"></div>
+          </section>
+
+          <!-- Credits block -->
+          <div v-if="credits.length" class="credits">
+            <h2 class="credits-heading">Credits</h2>
+            <dl class="credits-list">
+              <template v-for="c in credits" :key="c.label">
+                <dt>{{ c.label }}</dt>
+                <dd>{{ c.value }}</dd>
+              </template>
+            </dl>
+            <p v-if="selected.mwnf_reference" class="mwnf-ref">
+              MWNF Working Number: <strong>{{ selected.mwnf_reference }}</strong>
+            </p>
+          </div>
+
+          <!-- Dynasty detail cards (historical context) -->
           <div v-if="selectedDynasties.length" class="dynasties">
             <h2 class="section-title">{{ selectedDynasties.length === 1 ? 'Dynasty' : 'Dynasties' }}</h2>
             <div v-for="d in selectedDynasties" :key="d.id" class="dynasty-card">
@@ -182,6 +270,7 @@ const selectedDynasties = computed(() => {
             </div>
           </div>
 
+          <!-- Related items -->
           <div v-if="relatedItems.length" class="related">
             <h2 class="section-title">Related items</h2>
             <ul class="related-list">
@@ -202,18 +291,10 @@ const selectedDynasties = computed(() => {
               </li>
             </ul>
           </div>
-
-          <div class="meta">
-            <span v-if="selected.country_id">Country: {{ selected.country_id }}</span>
-            <span v-if="selected.start_date">
-              Period: {{ selected.start_date }}{{ selected.end_date ? ' – ' + selected.end_date : '' }}
-            </span>
-            <span v-if="selected.mwnf_reference">Ref: {{ selected.mwnf_reference }}</span>
-          </div>
         </div>
       </template>
 
-      <!-- List -->
+      <!-- ── List view ── -->
       <template v-else>
         <ul class="list">
           <li
@@ -251,18 +332,14 @@ header {
 
 .lang-select {
   margin-left: auto;
-  background: #2a2a4e;
-  color: #fff;
-  border: 1px solid #4a4a7e;
-  border-radius: 4px;
-  padding: .25rem .5rem;
-  font-size: .8rem;
-  cursor: pointer;
+  background: #2a2a4e; color: #fff;
+  border: 1px solid #4a4a7e; border-radius: 4px;
+  padding: .25rem .5rem; font-size: .8rem; cursor: pointer;
 }
 
 main { flex: 1; max-width: 900px; width: 100%; margin: 0 auto; padding: 1.5rem; }
 
-/* List */
+/* ── List ── */
 .list { list-style: none; display: flex; flex-direction: column; gap: .5rem; }
 
 .list-item {
@@ -281,44 +358,116 @@ main { flex: 1; max-width: 900px; width: 100%; margin: 0 auto; padding: 1.5rem; 
 .item-name { font-weight: 600; font-size: .95rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .item-type { font-size: .75rem; color: #888; text-transform: uppercase; letter-spacing: .05em; }
 
-/* Detail */
+/* ── Detail ── */
 .back {
   display: inline-block; margin-bottom: 1.25rem;
   color: #1a1a2e; font-size: .9rem; text-decoration: none;
 }
 .back:hover { text-decoration: underline; }
 
-.detail { background: #fff; border-radius: 8px; padding: 1.5rem; }
-.detail-type { font-size: .75rem; text-transform: uppercase; letter-spacing: .08em; color: #888; margin-bottom: .5rem; }
-.detail h1 { font-size: 1.5rem; margin-bottom: 1.25rem; }
+.detail { background: #fff; border-radius: 8px; padding: 2rem; }
+.detail-type {
+  display: inline-block;
+  font-size: .7rem; text-transform: uppercase; letter-spacing: .1em;
+  color: #fff; background: #1a1a2e;
+  padding: .2rem .6rem; border-radius: 3px; margin-bottom: .75rem;
+}
+.detail h1 { font-size: 1.6rem; margin: 0 0 1.5rem; line-height: 1.3; }
 
+/* Images */
 .images {
   display: flex; gap: 1rem; flex-wrap: wrap;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.75rem;
 }
 .images figure { width: 180px; }
 .images img { width: 100%; height: 130px; object-fit: cover; border-radius: 4px; }
-.images figcaption { font-size: .75rem; color: #666; margin-top: .3rem; }
-.images .credit { display: block; }
+.images figcaption { font-size: .72rem; color: #666; margin-top: .3rem; }
+.photo-credit { display: block; }
 
-dl { display: grid; grid-template-columns: max-content 1fr; gap: .4rem 1rem; margin-bottom: 1.25rem; }
-dt { font-weight: 600; font-size: .85rem; color: #555; white-space: nowrap; }
-dd { font-size: .9rem; line-height: 1.5; }
+/* Key facts table */
+.key-facts {
+  width: 100%; border-collapse: collapse;
+  margin-bottom: 2rem;
+  font-size: .9rem;
+}
+.key-facts th, .key-facts td {
+  padding: .5rem .75rem;
+  border-bottom: 1px solid #eee;
+  text-align: left;
+  vertical-align: top;
+}
+.key-facts th {
+  width: 36%; font-weight: 600; color: #444;
+  background: #f8f7f4;
+  white-space: nowrap;
+}
+.key-facts td { color: #222; }
+.key-facts tr:last-child th,
+.key-facts tr:last-child td { border-bottom: none; }
 
-.meta { display: flex; flex-wrap: wrap; gap: .5rem 1.5rem; font-size: .8rem; color: #888; border-top: 1px solid #eee; padding-top: 1rem; }
+/* Content sections */
+.content-section {
+  margin-bottom: 1.75rem;
+  border-top: 1px solid #eee;
+  padding-top: 1.5rem;
+}
+.content-section h2 {
+  font-size: 1rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .06em;
+  color: #1a1a2e; margin: 0 0 .9rem;
+}
 
-.section-title { font-size: .9rem; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; color: #555; margin-bottom: .75rem; }
+/* Prose (markdown output) */
+.prose { font-size: .93rem; line-height: 1.7; color: #222; }
+.prose :deep(p) { margin: 0 0 .75em; }
+.prose :deep(p:last-child) { margin-bottom: 0; }
+.prose :deep(em) { font-style: italic; }
+.prose :deep(strong) { font-weight: 700; }
+.prose :deep(ul), .prose :deep(ol) { padding-left: 1.5em; margin: 0 0 .75em; }
+.prose :deep(li) { margin-bottom: .25em; }
+.prose :deep(a) { color: #1a1a2e; text-decoration: underline; }
 
-.dynasties { margin-bottom: 1.25rem; border-top: 1px solid #eee; padding-top: 1.25rem; }
-.dynasty-card { background: #f7f5ee; border-left: 3px solid #b5953a; border-radius: 4px; padding: .75rem 1rem; margin-bottom: .6rem; }
-.dynasty-header { display: flex; flex-wrap: wrap; align-items: baseline; gap: .4rem 1rem; margin-bottom: .4rem; }
+/* Credits */
+.credits {
+  margin-top: 1.75rem; border-top: 2px solid #1a1a2e;
+  padding-top: 1.25rem;
+}
+.credits-heading {
+  font-size: .8rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .08em;
+  color: #1a1a2e; margin: 0 0 .75rem;
+}
+.credits-list {
+  display: grid; grid-template-columns: max-content 1fr;
+  gap: .3rem 1rem; font-size: .85rem; margin-bottom: .75rem;
+}
+.credits-list dt { font-weight: 600; color: #555; white-space: nowrap; }
+.credits-list dd { color: #222; }
+
+.mwnf-ref { font-size: .8rem; color: #888; margin-top: .5rem; }
+
+/* Dynasty cards */
+.section-title {
+  font-size: .9rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .06em; color: #555; margin-bottom: .75rem;
+}
+.dynasties { margin-top: 1.75rem; border-top: 1px solid #eee; padding-top: 1.5rem; }
+.dynasty-card {
+  background: #f7f5ee; border-left: 3px solid #b5953a;
+  border-radius: 4px; padding: .75rem 1rem; margin-bottom: .6rem;
+}
+.dynasty-header {
+  display: flex; flex-wrap: wrap; align-items: baseline;
+  gap: .4rem 1rem; margin-bottom: .4rem;
+}
 .dynasty-name { font-weight: 700; font-size: 1rem; }
 .dynasty-aka { font-size: .82rem; color: #777; font-style: italic; }
 .dynasty-dates { font-size: .82rem; color: #888; margin-left: auto; }
 .dynasty-history { font-size: .88rem; line-height: 1.6; color: #333; margin: 0 0 .35rem; }
 .dynasty-area { font-size: .8rem; color: #777; margin: 0; }
 
-.related { margin-bottom: 1.25rem; border-top: 1px solid #eee; padding-top: 1.25rem; }
+/* Related items */
+.related { margin-top: 1.75rem; border-top: 1px solid #eee; padding-top: 1.5rem; }
 .related-list { list-style: none; display: flex; flex-direction: column; gap: .4rem; }
 .related-item {
   display: flex; align-items: center; gap: .75rem;
@@ -327,7 +476,10 @@ dd { font-size: .9rem; line-height: 1.5; }
   cursor: pointer; transition: background .15s;
 }
 .related-item:hover { background: #eeeef6; }
-.related-thumb { width: 44px; height: 44px; flex-shrink: 0; border-radius: 4px; overflow: hidden; background: #ddd; }
+.related-thumb {
+  width: 44px; height: 44px; flex-shrink: 0;
+  border-radius: 4px; overflow: hidden; background: #ddd;
+}
 .related-thumb img { width: 100%; height: 100%; object-fit: cover; }
 .related-thumb-placeholder { width: 100%; height: 100%; }
 .related-info { display: flex; flex-direction: column; gap: .15rem; min-width: 0; }


### PR DESCRIPTION
## Summary

- **Exporter — monument-specific fields**: For items of type `monument`, the exporter now reads `history` and `patrons` from `item_translations.extra` (stored as JSON) and surfaces them as top-level translation fields alongside the existing shared fields.
- **Exporter — `backward_compatibility`**: Added `backward_compatibility` to both the item and partner export outputs so downstream consumers can access the legacy reference mapping.
- **Viewer — type-conditional display**: Replaced the flat `DETAIL_FIELDS` list with two computed blocks:
  - `keyFacts` — metadata table rows rendered in legacy field order, with monument-specific labels (e.g. *Patron(s)*, *Date of Monument*) vs object labels (e.g. *Holding Museum*, *Museum Inventory Number*).
  - `contentSections` — named prose sections (Description, History, Bibliography, etc.) rendered as markdown via the `marked` library, in the correct legacy section order per type.
  - `credits` — separated credits block (Prepared by, Copyedited by, …) with MWNF reference number.
- **Viewer — related-item deduplication**: Related items are now deduplicated before rendering.
- **Viewer — markdown rendering**: Added `marked` dependency; prose fields are rendered as HTML via `v-html` with scoped `:deep()` prose styles.

## Test plan

- [ ] Run the exporter against a dataset containing monuments and verify `history` / `patrons` appear in the translation output for monuments and are absent for objects.
- [ ] Verify `backward_compatibility` appears in both item and partner JSON exports.
- [ ] Load the viewer with a monument item — confirm key facts show monument labels and the History section renders above Description.
- [ ] Load the viewer with an object item — confirm object labels (Holding Museum, Provenance, etc.) and section order (Description, History/Acquisition, …).
- [ ] Confirm markdown in description/bibliography fields renders correctly (bold, italic, lists, links).
- [ ] Confirm related items with duplicate IDs are shown only once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)