### PR TITLE
feat(viewer): splash page, Permanent Collection, and Database pages

### DIFF
--- a/scripts/viewer/index.html
+++ b/scripts/viewer/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Inventory Viewer</title>
+    <title>Islamic Art — Museum With No Frontiers</title>
     <style>
       *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-      body { font-family: system-ui, sans-serif; color: #1a1a1a; background: #f5f5f5; }
+      body { font-family: Georgia, 'Times New Roman', serif; color: #1a1a1a; background: #f0e9d8; }
     </style>
   </head>
   <body>

--- a/scripts/viewer/package-lock.json
+++ b/scripts/viewer/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@metanull/islamicart-data": "^1.0.4",
         "marked": "^18.0.5",
-        "vue": "^3.5.39"
+        "vue": "^3.5.39",
+        "vue-router": "^4.6.4"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.7",
@@ -483,6 +484,12 @@
         "@vue/compiler-dom": "3.5.39",
         "@vue/shared": "3.5.39"
       }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.39",
@@ -1113,6 +1120,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     }
   }

--- a/scripts/viewer/package.json
+++ b/scripts/viewer/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@metanull/islamicart-data": "^1.0.4",
     "marked": "^18.0.5",
-    "vue": "^3.5.39"
+    "vue": "^3.5.39",
+    "vue-router": "^4.6.4"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.7",

--- a/scripts/viewer/src/App.vue
+++ b/scripts/viewer/src/App.vue
@@ -1,488 +1,288 @@
 <script setup>
-import { ref, computed, watch } from 'vue'
-import { marked } from 'marked'
-import manifestData from '@inventory-data/manifest.json'
-import itemsData from '@inventory-data/items.json'
-import dynastiesData from '@inventory-data/dynasties.json'
-
-const items = ref(itemsData)
-const dynasties = ref(dynastiesData)
-const availableLangs = ref(manifestData.languages ?? [])
-const activeLang = ref(
-  (manifestData.languages ?? []).includes('en')
-    ? 'en'
-    : (manifestData.languages?.[0] ?? 'en')
-)
-const translationsCache = ref({})
-const dynastyTranslationsCache = ref({})
-const selected = ref(null)
-
-async function loadTranslations(lang) {
-  if (translationsCache.value[lang]) return
-  try {
-    const module = await import(`@inventory-data/translations/items.${lang}.json`)
-    translationsCache.value = { ...translationsCache.value, [lang]: module.default }
-  } catch {
-    // silently fall back to internal_name
-  }
-}
-
-async function loadDynastyTranslations(lang) {
-  if (dynastyTranslationsCache.value[lang]) return
-  try {
-    const module = await import(`@inventory-data/translations/dynasties.${lang}.json`)
-    dynastyTranslationsCache.value = { ...dynastyTranslationsCache.value, [lang]: module.default }
-  } catch {}
-}
-
-loadTranslations(activeLang.value)
-loadDynastyTranslations(activeLang.value)
-
-watch(activeLang, (lang) => {
-  loadTranslations(lang)
-  loadDynastyTranslations(lang)
-})
-
-function t(item) {
-  return translationsCache.value[activeLang.value]?.[item.id] ?? {}
-}
-
-function label(item) {
-  return t(item).name ?? item.internal_name ?? item.id
-}
-
-function selectItem(item) {
-  selected.value = item
-  window.scrollTo(0, 0)
-}
-
-function back() {
-  selected.value = null
-}
-
-function md(text) {
-  if (!text) return ''
-  return marked.parse(text, { breaks: true })
-}
-
-const itemById = computed(() => {
-  const map = {}
-  for (const item of items.value) map[item.id] = item
-  return map
-})
-
-const relatedItems = computed(() => {
-  if (!selected.value?.related_item_ids?.length) return []
-  // deduplicate
-  const seen = new Set()
-  return selected.value.related_item_ids
-    .map(id => itemById.value[id])
-    .filter(item => {
-      if (!item || seen.has(item.id)) return false
-      seen.add(item.id)
-      return true
-    })
-})
-
-const dynastyById = computed(() => {
-  const map = {}
-  for (const d of dynasties.value) map[d.id] = d
-  return map
-})
-
-function tDynasty(dynastyId) {
-  return dynastyTranslationsCache.value[activeLang.value]?.[dynastyId] ?? {}
-}
-
-const selectedDynasties = computed(() => {
-  if (!selected.value?.dynasty_ids?.length) return []
-  return selected.value.dynasty_ids
-    .map(id => {
-      const d = dynastyById.value[id]
-      if (!d) return null
-      const tr = tDynasty(id)
-      return { ...d, ...tr }
-    })
-    .filter(Boolean)
-})
-
-const isMonument = computed(() => selected.value?.type === 'monument')
-
-// Key facts: metadata rows in the info table, matching legacy page field order
-const keyFacts = computed(() => {
-  if (!selected.value) return []
-  const item = selected.value
-  const tr = t(item)
-  const dynastyNames = selectedDynasties.value.map(d => d.name).filter(Boolean).join(', ')
-  const facts = []
-
-  if (isMonument.value) {
-    // Monument field order from legacy: Also known as, Location, Date, Period/Dynasty, Patron(s)
-    if (tr.alternate_name)              facts.push({ label: 'Also known as', value: tr.alternate_name })
-    if (tr.location)                    facts.push({ label: 'Location', value: tr.location })
-    if (tr.dates)                       facts.push({ label: 'Date of Monument', value: tr.dates })
-    if (dynastyNames)                   facts.push({ label: 'Period / Dynasty', value: dynastyNames })
-    // patrons comes from extra.patrons (monument-specific); fall back to initial_owner if absent
-    const patronValue = tr.patrons ?? tr.initial_owner
-    if (patronValue)                    facts.push({ label: 'Patron(s)', value: patronValue })
-  } else {
-    // Object field order from legacy: Location, Holding Museum, Inventory No, Date, Period/Dynasty, Provenance, Material/Technique, Dimensions
-    if (tr.location)            facts.push({ label: 'Location', value: tr.location })
-    if (tr.holder)              facts.push({ label: 'Holding Museum', value: tr.holder })
-    if (item.owner_reference)   facts.push({ label: 'Museum Inventory Number', value: item.owner_reference })
-    if (tr.dates)               facts.push({ label: 'Date of Object', value: tr.dates })
-    if (dynastyNames)           facts.push({ label: 'Period / Dynasty', value: dynastyNames })
-    if (tr.provenance)          facts.push({ label: 'Provenance', value: tr.provenance })
-    if (tr.type)                facts.push({ label: 'Material(s) / Technique(s)', value: tr.type })
-    if (tr.dimensions)          facts.push({ label: 'Dimensions', value: tr.dimensions })
-    if (tr.owner)               facts.push({ label: 'Owner', value: tr.owner })
-    if (tr.initial_owner)       facts.push({ label: 'Initial Owner', value: tr.initial_owner })
-    if (tr.place_of_production) facts.push({ label: 'Place of Production', value: tr.place_of_production })
-  }
-
-  return facts
-})
-
-// Content sections: named text blocks rendered as markdown, matching legacy section order
-const contentSections = computed(() => {
-  if (!selected.value) return []
-  const tr = t(selected.value)
-  const monument = isMonument.value
-  const sections = []
-
-  if (monument) {
-    // Monument order: History, Description, How Monument Was Dated
-    // history comes from extra.history (monument-specific brief history of construction/restoration)
-    if (tr.history)               sections.push({ heading: 'History', value: tr.history })
-    if (tr.description)           sections.push({ heading: 'Description', value: tr.description })
-  } else {
-    // Object order: Description, History/Acquisition, How Object Was Dated, Provenance method
-    if (tr.description)           sections.push({ heading: 'Description', value: tr.description })
-    if (tr.obtention)             sections.push({ heading: 'History / Acquisition', value: tr.obtention })
-  }
-
-  if (tr.method_for_datation)
-    sections.push({ heading: monument ? 'How Monument Was Dated' : 'How Object Was Dated', value: tr.method_for_datation })
-
-  if (tr.method_for_provenance)
-    sections.push({ heading: monument ? 'How Monument Provenance Was Determined' : 'How Object Provenance Was Determined', value: tr.method_for_provenance })
-
-  if (tr.bibliography)
-    sections.push({ heading: 'Bibliography', value: tr.bibliography })
-
-  return sections
-})
-
-// Credits block: separated from content, matching legacy credits section labels
-const credits = computed(() => {
-  if (!selected.value) return []
-  const tr = t(selected.value)
-  const c = []
-  if (tr.author)                   c.push({ label: 'Prepared by', value: tr.author })
-  if (tr.copy_editor)              c.push({ label: 'Copyedited by', value: tr.copy_editor })
-  if (tr.translator)               c.push({ label: 'Translation by', value: tr.translator })
-  if (tr.translation_copy_editor)  c.push({ label: 'Translation copyedited by', value: tr.translation_copy_editor })
-  return c
-})
+import { RouterView, RouterLink } from 'vue-router'
 </script>
 
 <template>
-  <div class="shell">
-    <header>
-      <span class="logo">Inventory Viewer</span>
-      <span class="count">{{ items.length }} items</span>
-      <select
-        v-if="availableLangs.length > 1"
-        v-model="activeLang"
-        class="lang-select"
-      >
-        <option v-for="lang in availableLangs" :key="lang" :value="lang">{{ lang }}</option>
-      </select>
+  <div class="site">
+    <header class="site-header">
+      <div class="container">
+        <RouterLink to="/" class="site-logo">
+          <span class="site-logo-org">Museum With No Frontiers</span>
+          <span class="site-logo-title">Islamic Art</span>
+        </RouterLink>
+      </div>
     </header>
 
-    <main>
-      <!-- ── Detail view ── -->
-      <template v-if="selected">
-        <a class="back" href="#" @click.prevent="back">← Back to list</a>
+    <nav class="site-nav">
+      <div class="container nav-inner">
+        <RouterLink to="/" active-class="nav-active" exact-active-class="nav-exact-active">Home</RouterLink>
+        <RouterLink to="/permanent-collection" active-class="nav-active">Permanent Collection</RouterLink>
+        <RouterLink to="/database" active-class="nav-active">Database</RouterLink>
+      </div>
+    </nav>
 
-        <div class="detail">
-          <div class="detail-type">{{ selected.type }}</div>
-          <h1>{{ label(selected) }}</h1>
-
-          <!-- Images -->
-          <div v-if="selected.images?.length" class="images">
-            <figure v-for="(img, i) in selected.images" :key="i">
-              <img :src="img.url" :alt="img.captions?.[activeLang] ?? ''" loading="lazy" />
-              <figcaption v-if="img.captions?.[activeLang] || img.photographer">
-                <span v-if="img.captions?.[activeLang]">{{ img.captions[activeLang] }}</span>
-                <span v-if="img.photographer" class="photo-credit">© {{ img.photographer }}</span>
-              </figcaption>
-            </figure>
-          </div>
-
-          <!-- Key facts table (metadata, type-conditional labels & order) -->
-          <table v-if="keyFacts.length" class="key-facts">
-            <tbody>
-              <tr v-for="fact in keyFacts" :key="fact.label">
-                <th>{{ fact.label }}</th>
-                <td>{{ fact.value }}</td>
-              </tr>
-            </tbody>
-          </table>
-
-          <!-- Content sections (named sections with markdown body) -->
-          <section
-            v-for="section in contentSections"
-            :key="section.heading"
-            class="content-section"
-          >
-            <h2>{{ section.heading }}</h2>
-            <div v-html="md(section.value)" class="prose"></div>
-          </section>
-
-          <!-- Credits block -->
-          <div v-if="credits.length" class="credits">
-            <h2 class="credits-heading">Credits</h2>
-            <dl class="credits-list">
-              <template v-for="c in credits" :key="c.label">
-                <dt>{{ c.label }}</dt>
-                <dd>{{ c.value }}</dd>
-              </template>
-            </dl>
-            <p v-if="selected.mwnf_reference" class="mwnf-ref">
-              MWNF Working Number: <strong>{{ selected.mwnf_reference }}</strong>
-            </p>
-          </div>
-
-          <!-- Dynasty detail cards (historical context) -->
-          <div v-if="selectedDynasties.length" class="dynasties">
-            <h2 class="section-title">{{ selectedDynasties.length === 1 ? 'Dynasty' : 'Dynasties' }}</h2>
-            <div v-for="d in selectedDynasties" :key="d.id" class="dynasty-card">
-              <div class="dynasty-header">
-                <span class="dynasty-name">{{ d.name ?? '—' }}</span>
-                <span v-if="d.also_known_as" class="dynasty-aka">also known as {{ d.also_known_as }}</span>
-                <span v-if="d.from_ad || d.to_ad" class="dynasty-dates">
-                  {{ d.date_description_ad ?? (d.from_ad + (d.to_ad ? ' – ' + d.to_ad : '')) }}
-                </span>
-              </div>
-              <p v-if="d.history" class="dynasty-history">{{ d.history }}</p>
-              <p v-if="d.area" class="dynasty-area">Area: {{ d.area }}</p>
-            </div>
-          </div>
-
-          <!-- Related items -->
-          <div v-if="relatedItems.length" class="related">
-            <h2 class="section-title">Related items</h2>
-            <ul class="related-list">
-              <li
-                v-for="rel in relatedItems"
-                :key="rel.id"
-                class="related-item"
-                @click="selectItem(rel)"
-              >
-                <div class="related-thumb">
-                  <img v-if="rel.images?.length" :src="rel.images[0].url" :alt="label(rel)" loading="lazy" />
-                  <div v-else class="related-thumb-placeholder"></div>
-                </div>
-                <div class="related-info">
-                  <span class="related-name">{{ label(rel) }}</span>
-                  <span class="related-type">{{ rel.type }}</span>
-                </div>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </template>
-
-      <!-- ── List view ── -->
-      <template v-else>
-        <ul class="list">
-          <li
-            v-for="item in items"
-            :key="item.id"
-            class="list-item"
-            @click="selectItem(item)"
-          >
-            <div class="item-thumb" v-if="item.images?.length">
-              <img :src="item.images[0].url" :alt="label(item)" loading="lazy" />
-            </div>
-            <div class="item-thumb placeholder" v-else></div>
-            <div class="item-info">
-              <span class="item-name">{{ label(item) }}</span>
-              <span class="item-type">{{ item.type }}</span>
-            </div>
-          </li>
-        </ul>
-      </template>
+    <main class="site-main">
+      <div class="container">
+        <RouterView />
+      </div>
     </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <span>© Museum With No Frontiers — Islamic Art Digital Exhibition</span>
+      </div>
+    </footer>
   </div>
 </template>
 
-<style scoped>
-.shell { min-height: 100vh; display: flex; flex-direction: column; }
+<style>
+/* ── Reset & base ───────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-header {
-  position: sticky; top: 0; z-index: 10;
-  display: flex; align-items: center; gap: 1rem;
-  padding: .75rem 1.5rem;
-  background: #1a1a2e; color: #fff;
+:root {
+  --header-bg:  #3a2510;
+  --header-fg:  #e8d5a3;
+  --nav-bg:     #5a3a1a;
+  --nav-fg:     #f5ead8;
+  --nav-active: #f5c842;
+  --gold:       #c5882e;
+  --gold-light: #e8c97a;
+  --page-bg:    #f0e9d8;
+  --content-bg: #ffffff;
+  --text:       #1a1a1a;
+  --muted:      #5a5252;
+  --border:     #d4b890;
+  --link:       #5a3a1a;
+  --link-hover: #c5882e;
 }
-.logo { font-weight: 700; font-size: 1rem; letter-spacing: .02em; }
-.count { font-size: .8rem; opacity: .6; }
 
-.lang-select {
-  margin-left: auto;
-  background: #2a2a4e; color: #fff;
-  border: 1px solid #4a4a7e; border-radius: 4px;
-  padding: .25rem .5rem; font-size: .8rem; cursor: pointer;
+body {
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 14px;
+  color: var(--text);
+  background: var(--page-bg);
+  min-height: 100vh;
 }
 
-main { flex: 1; max-width: 900px; width: 100%; margin: 0 auto; padding: 1.5rem; }
+a { color: var(--link); text-decoration: none; }
+a:hover { color: var(--link-hover); text-decoration: underline; }
 
-/* ── List ── */
-.list { list-style: none; display: flex; flex-direction: column; gap: .5rem; }
+.container { max-width: 960px; margin: 0 auto; padding: 0 16px; }
 
-.list-item {
-  display: flex; align-items: center; gap: 1rem;
-  padding: .75rem 1rem;
-  background: #fff; border-radius: 8px;
-  cursor: pointer; transition: box-shadow .15s;
+/* ── Header ─────────────────────────────────────────────────────────────── */
+.site-header {
+  background: var(--header-bg);
+  padding: 14px 0;
+  border-bottom: 2px solid var(--gold);
 }
-.list-item:hover { box-shadow: 0 2px 12px rgba(0,0,0,.12); }
 
-.item-thumb { width: 56px; height: 56px; flex-shrink: 0; border-radius: 4px; overflow: hidden; background: #eee; }
-.item-thumb img { width: 100%; height: 100%; object-fit: cover; }
-.item-thumb.placeholder { background: #e0e0e0; }
-
-.item-info { display: flex; flex-direction: column; gap: .2rem; min-width: 0; }
-.item-name { font-weight: 600; font-size: .95rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.item-type { font-size: .75rem; color: #888; text-transform: uppercase; letter-spacing: .05em; }
-
-/* ── Detail ── */
-.back {
-  display: inline-block; margin-bottom: 1.25rem;
-  color: #1a1a2e; font-size: .9rem; text-decoration: none;
+.site-logo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-decoration: none !important;
 }
-.back:hover { text-decoration: underline; }
+.site-logo-org {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--header-fg);
+  opacity: 0.75;
+  font-family: Arial, sans-serif;
+}
+.site-logo-title {
+  font-size: 26px;
+  font-weight: bold;
+  color: var(--gold-light);
+  letter-spacing: 0.04em;
+  font-family: Georgia, serif;
+}
 
-.detail { background: #fff; border-radius: 8px; padding: 2rem; }
-.detail-type {
+/* ── Navigation ─────────────────────────────────────────────────────────── */
+.site-nav {
+  background: var(--nav-bg);
+  border-bottom: 1px solid #3a2008;
+}
+.nav-inner {
+  display: flex;
+  gap: 0;
+}
+.site-nav a {
   display: inline-block;
-  font-size: .7rem; text-transform: uppercase; letter-spacing: .1em;
-  color: #fff; background: #1a1a2e;
-  padding: .2rem .6rem; border-radius: 3px; margin-bottom: .75rem;
+  padding: 9px 18px;
+  color: var(--nav-fg);
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 13px;
+  text-decoration: none !important;
+  border-right: 1px solid rgba(255,255,255,0.1);
+  transition: background 0.15s, color 0.15s;
 }
-.detail h1 { font-size: 1.6rem; margin: 0 0 1.5rem; line-height: 1.3; }
-
-/* Images */
-.images {
-  display: flex; gap: 1rem; flex-wrap: wrap;
-  margin-bottom: 1.75rem;
-}
-.images figure { width: 180px; }
-.images img { width: 100%; height: 130px; object-fit: cover; border-radius: 4px; }
-.images figcaption { font-size: .72rem; color: #666; margin-top: .3rem; }
-.photo-credit { display: block; }
-
-/* Key facts table */
-.key-facts {
-  width: 100%; border-collapse: collapse;
-  margin-bottom: 2rem;
-  font-size: .9rem;
-}
-.key-facts th, .key-facts td {
-  padding: .5rem .75rem;
-  border-bottom: 1px solid #eee;
-  text-align: left;
-  vertical-align: top;
-}
-.key-facts th {
-  width: 36%; font-weight: 600; color: #444;
-  background: #f8f7f4;
-  white-space: nowrap;
-}
-.key-facts td { color: #222; }
-.key-facts tr:last-child th,
-.key-facts tr:last-child td { border-bottom: none; }
-
-/* Content sections */
-.content-section {
-  margin-bottom: 1.75rem;
-  border-top: 1px solid #eee;
-  padding-top: 1.5rem;
-}
-.content-section h2 {
-  font-size: 1rem; font-weight: 700;
-  text-transform: uppercase; letter-spacing: .06em;
-  color: #1a1a2e; margin: 0 0 .9rem;
+.site-nav a:hover,
+.site-nav a.nav-active {
+  background: rgba(0,0,0,0.25);
+  color: var(--nav-active);
 }
 
-/* Prose (markdown output) */
-.prose { font-size: .93rem; line-height: 1.7; color: #222; }
-.prose :deep(p) { margin: 0 0 .75em; }
-.prose :deep(p:last-child) { margin-bottom: 0; }
-.prose :deep(em) { font-style: italic; }
-.prose :deep(strong) { font-weight: 700; }
-.prose :deep(ul), .prose :deep(ol) { padding-left: 1.5em; margin: 0 0 .75em; }
-.prose :deep(li) { margin-bottom: .25em; }
-.prose :deep(a) { color: #1a1a2e; text-decoration: underline; }
+/* ── Main content ────────────────────────────────────────────────────────── */
+.site-main { padding: 20px 0 40px; }
 
-/* Credits */
-.credits {
-  margin-top: 1.75rem; border-top: 2px solid #1a1a2e;
-  padding-top: 1.25rem;
+/* ── Footer ─────────────────────────────────────────────────────────────── */
+.site-footer {
+  background: var(--header-bg);
+  border-top: 2px solid var(--gold);
+  padding: 12px 0;
+  font-family: Arial, sans-serif;
+  font-size: 11px;
+  color: var(--header-fg);
+  opacity: 0.85;
+  text-align: center;
 }
-.credits-heading {
-  font-size: .8rem; font-weight: 700;
-  text-transform: uppercase; letter-spacing: .08em;
-  color: #1a1a2e; margin: 0 0 .75rem;
-}
-.credits-list {
-  display: grid; grid-template-columns: max-content 1fr;
-  gap: .3rem 1rem; font-size: .85rem; margin-bottom: .75rem;
-}
-.credits-list dt { font-weight: 600; color: #555; white-space: nowrap; }
-.credits-list dd { color: #222; }
 
-.mwnf-ref { font-size: .8rem; color: #888; margin-top: .5rem; }
+/* ── Shared content-box ─────────────────────────────────────────────────── */
+.content-box {
+  background: var(--content-bg);
+  border: 1px solid var(--border);
+  padding: 20px;
+  margin-bottom: 16px;
+}
 
-/* Dynasty cards */
-.section-title {
-  font-size: .9rem; font-weight: 700; text-transform: uppercase;
-  letter-spacing: .06em; color: #555; margin-bottom: .75rem;
+/* ── Section heading ─────────────────────────────────────────────────────── */
+.section-heading {
+  font-size: 16px;
+  font-weight: bold;
+  color: var(--header-bg);
+  border-bottom: 2px solid var(--gold);
+  padding-bottom: 6px;
+  margin-bottom: 14px;
+  font-family: Georgia, serif;
 }
-.dynasties { margin-top: 1.75rem; border-top: 1px solid #eee; padding-top: 1.5rem; }
-.dynasty-card {
-  background: #f7f5ee; border-left: 3px solid #b5953a;
-  border-radius: 4px; padding: .75rem 1rem; margin-bottom: .6rem;
-}
-.dynasty-header {
-  display: flex; flex-wrap: wrap; align-items: baseline;
-  gap: .4rem 1rem; margin-bottom: .4rem;
-}
-.dynasty-name { font-weight: 700; font-size: 1rem; }
-.dynasty-aka { font-size: .82rem; color: #777; font-style: italic; }
-.dynasty-dates { font-size: .82rem; color: #888; margin-left: auto; }
-.dynasty-history { font-size: .88rem; line-height: 1.6; color: #333; margin: 0 0 .35rem; }
-.dynasty-area { font-size: .8rem; color: #777; margin: 0; }
 
-/* Related items */
-.related { margin-top: 1.75rem; border-top: 1px solid #eee; padding-top: 1.5rem; }
-.related-list { list-style: none; display: flex; flex-direction: column; gap: .4rem; }
-.related-item {
-  display: flex; align-items: center; gap: .75rem;
-  padding: .5rem .75rem;
-  background: #f7f7f9; border-radius: 6px;
-  cursor: pointer; transition: background .15s;
+/* ── Shared item list & cards ───────────────────────────────────────────── */
+.item-list { list-style: none; }
+.item-list-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid #e8dcc8;
+  cursor: pointer;
 }
-.related-item:hover { background: #eeeef6; }
-.related-thumb {
-  width: 44px; height: 44px; flex-shrink: 0;
-  border-radius: 4px; overflow: hidden; background: #ddd;
+.item-list-row:last-child { border-bottom: none; }
+.item-list-row:hover .item-list-name { color: var(--gold); }
+
+.item-thumb {
+  flex-shrink: 0;
+  width: 64px;
+  height: 64px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: #e8dcc8;
 }
-.related-thumb img { width: 100%; height: 100%; object-fit: cover; }
-.related-thumb-placeholder { width: 100%; height: 100%; }
-.related-info { display: flex; flex-direction: column; gap: .15rem; min-width: 0; }
-.related-name { font-size: .88rem; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.related-type { font-size: .72rem; color: #888; text-transform: uppercase; letter-spacing: .05em; }
+.item-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.item-thumb-placeholder { width: 100%; height: 100%; }
+
+.item-list-info { flex: 1; min-width: 0; }
+.item-list-name {
+  font-weight: bold;
+  font-size: 13px;
+  color: var(--link);
+  margin-bottom: 3px;
+}
+.item-list-meta {
+  font-size: 11px;
+  color: var(--muted);
+  font-family: Arial, sans-serif;
+}
+.item-list-meta span + span::before { content: ' · '; }
+
+/* ── Pagination ─────────────────────────────────────────────────────────── */
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 14px 0 0;
+  flex-wrap: wrap;
+  font-family: Arial, sans-serif;
+  font-size: 12px;
+}
+.pagination-info {
+  margin-right: auto;
+  color: var(--muted);
+}
+.page-btn {
+  display: inline-block;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  background: var(--content-bg);
+  color: var(--link);
+  cursor: pointer;
+  font-size: 12px;
+  font-family: Arial, sans-serif;
+}
+.page-btn:hover { background: #f0e0c0; }
+.page-btn.active {
+  background: var(--header-bg);
+  color: var(--gold-light);
+  border-color: var(--header-bg);
+  font-weight: bold;
+}
+.page-btn:disabled, .page-btn[disabled] {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* ── Form elements ──────────────────────────────────────────────────────── */
+.form-table { width: 100%; border-collapse: collapse; }
+.form-table th {
+  text-align: right;
+  padding: 6px 12px 6px 0;
+  font-weight: bold;
+  font-size: 12px;
+  color: var(--muted);
+  width: 160px;
+  vertical-align: middle;
+  font-family: Arial, sans-serif;
+}
+.form-table td { padding: 6px 0; vertical-align: middle; }
+
+select, input[type="text"], input[type="number"] {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 13px;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  background: #faf6ef;
+  color: var(--text);
+  border-radius: 0;
+  width: auto;
+}
+select:focus, input:focus { outline: 1px solid var(--gold); }
+
+.btn {
+  display: inline-block;
+  padding: 6px 18px;
+  background: var(--header-bg);
+  color: var(--gold-light);
+  font-family: Arial, sans-serif;
+  font-size: 13px;
+  font-weight: bold;
+  border: none;
+  cursor: pointer;
+  letter-spacing: 0.03em;
+}
+.btn:hover { background: var(--nav-bg); }
+.btn-secondary {
+  background: var(--border);
+  color: var(--text);
+}
+.btn-secondary:hover { background: #c0a070; }
+
+/* ── Back link ──────────────────────────────────────────────────────────── */
+.back-link {
+  display: inline-block;
+  margin-bottom: 12px;
+  font-family: Arial, sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+}
+.back-link:hover { color: var(--gold); }
 </style>

--- a/scripts/viewer/src/composables/useInventoryData.js
+++ b/scripts/viewer/src/composables/useInventoryData.js
@@ -1,0 +1,120 @@
+import { ref, computed } from 'vue'
+import { marked } from 'marked'
+import manifestData from '@inventory-data/manifest.json'
+import itemsData from '@inventory-data/items.json'
+import countriesData from '@inventory-data/countries.json'
+import partnersData from '@inventory-data/partners.json'
+import dynastiesData from '@inventory-data/dynasties.json'
+
+// Module-level singletons — loaded once, shared across all views
+const items = ref(itemsData)
+const countries = ref(countriesData)
+const partners = ref(partnersData)
+const dynasties = ref(dynastiesData)
+const availableLangs = ref(manifestData.languages ?? [])
+const defaultLang = (manifestData.languages ?? []).includes('en')
+  ? 'en'
+  : ((manifestData.languages ?? [])[0] ?? 'en')
+
+const enItemTranslations = ref({})
+const enCountryTranslations = ref({})
+const enDynastyTranslations = ref({})
+const enPartnerTranslations = ref({})
+const translationsCache = ref({}) // lang -> item translations (for detail view)
+
+let enLoaded = false
+
+async function loadEnglishTranslations() {
+  if (enLoaded) return
+  enLoaded = true
+  await Promise.allSettled([
+    import('@inventory-data/translations/items.en.json')
+      .then(m => { enItemTranslations.value = m.default }),
+    import('@inventory-data/translations/countries.en.json')
+      .then(m => { enCountryTranslations.value = m.default }),
+    import('@inventory-data/translations/dynasties.en.json')
+      .then(m => { enDynastyTranslations.value = m.default }),
+    import('@inventory-data/translations/partners.en.json')
+      .then(m => { enPartnerTranslations.value = m.default }),
+  ])
+  // Seed English into the detail-view cache too
+  if (!translationsCache.value['en']) {
+    translationsCache.value = { ...translationsCache.value, en: enItemTranslations.value }
+  }
+}
+
+async function loadLangTranslations(lang) {
+  if (translationsCache.value[lang]) return
+  try {
+    const m = await import(`@inventory-data/translations/items.${lang}.json`)
+    translationsCache.value = { ...translationsCache.value, [lang]: m.default }
+  } catch {
+    translationsCache.value = { ...translationsCache.value, [lang]: {} }
+  }
+}
+
+// Call immediately so lists are populated as soon as the app boots
+loadEnglishTranslations()
+
+// ── Label helpers (always English) ─────────────────────────────────────────
+
+function itemLabel(item) {
+  if (!item) return ''
+  return enItemTranslations.value[item.id]?.name ?? item.internal_name ?? item.id
+}
+
+function countryLabel(countryId) {
+  if (!countryId) return ''
+  const fallback = countries.value.find(c => c.id === countryId)
+  return enCountryTranslations.value[countryId]?.name ?? fallback?.internal_name ?? countryId
+}
+
+function dynastyLabel(dynastyId) {
+  if (!dynastyId) return ''
+  return enDynastyTranslations.value[dynastyId]?.name ?? dynastyId
+}
+
+function partnerLabel(partnerId) {
+  if (!partnerId) return ''
+  const fallback = partners.value.find(p => p.id === partnerId)
+  return enPartnerTranslations.value[partnerId]?.name ?? fallback?.id ?? partnerId
+}
+
+// ── Lookup maps ────────────────────────────────────────────────────────────
+
+const itemById = computed(() => {
+  const m = {}
+  for (const item of items.value) m[item.id] = item
+  return m
+})
+
+// ── Markdown helper ────────────────────────────────────────────────────────
+
+function md(text) {
+  if (!text) return ''
+  return marked.parse(text, { breaks: true })
+}
+
+export function useInventoryData() {
+  return {
+    items,
+    countries,
+    partners,
+    dynasties,
+    availableLangs,
+    defaultLang,
+    enItemTranslations,
+    enCountryTranslations,
+    enDynastyTranslations,
+    enPartnerTranslations,
+    translationsCache,
+    loadEnglishTranslations,
+    loadLangTranslations,
+    itemLabel,
+    countryLabel,
+    dynastyLabel,
+    partnerLabel,
+    itemById,
+    md,
+  }
+}

--- a/scripts/viewer/src/main.js
+++ b/scripts/viewer/src/main.js
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+import { router } from './router/index.js'
 import App from './App.vue'
 
-createApp(App).mount('#app')
+createApp(App).use(router).mount('#app')

--- a/scripts/viewer/src/router/index.js
+++ b/scripts/viewer/src/router/index.js
@@ -1,0 +1,24 @@
+import { createRouter, createWebHashHistory } from 'vue-router'
+import Home from '../views/Home.vue'
+import PcEntrance from '../views/PcEntrance.vue'
+import PcList from '../views/PcList.vue'
+import Database from '../views/Database.vue'
+import DatabaseResults from '../views/DatabaseResults.vue'
+import ItemDetail from '../views/ItemDetail.vue'
+
+const routes = [
+  { path: '/', component: Home },
+  { path: '/permanent-collection', component: PcEntrance },
+  { path: '/permanent-collection/results', component: PcList },
+  { path: '/database', component: Database },
+  { path: '/database/results', component: DatabaseResults },
+  { path: '/item/:id', component: ItemDetail },
+]
+
+export const router = createRouter({
+  history: createWebHashHistory(),
+  routes,
+  scrollBehavior() {
+    return { top: 0 }
+  },
+})

--- a/scripts/viewer/src/views/Database.vue
+++ b/scripts/viewer/src/views/Database.vue
@@ -1,0 +1,150 @@
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+const FIELD_OPTIONS = [
+  { value: 'keyword',   label: 'Name / Keyword' },
+  { value: 'location',  label: 'Location' },
+  { value: 'provenance', label: 'Provenance' },
+  { value: 'dynasty',   label: 'Period / Dynasty' },
+  { value: 'patron',    label: 'Patron / Initial Owner' },
+  { value: 'artist',    label: 'Architect / Artist / Master' },
+  { value: 'material',  label: 'Material / Technique' },
+]
+
+const keyword1 = ref('')
+const field1   = ref('keyword')
+const keyword2 = ref('')
+const field2   = ref('keyword')
+const keyword3 = ref('')
+const field3   = ref('keyword')
+const cond2    = ref('AND')
+const cond3    = ref('AND')
+const dateFrom = ref('')
+const dateTo   = ref('')
+
+function search() {
+  const q = {}
+  if (keyword1.value) { q.keyword1 = keyword1.value; q.field1 = field1.value }
+  if (keyword2.value) { q.keyword2 = keyword2.value; q.field2 = field2.value; q.cond2 = cond2.value }
+  if (keyword3.value) { q.keyword3 = keyword3.value; q.field3 = field3.value; q.cond3 = cond3.value }
+  if (dateFrom.value) q.date_from = dateFrom.value
+  if (dateTo.value)   q.date_to   = dateTo.value
+  router.push({ path: '/database/results', query: q })
+}
+
+function showAll() {
+  router.push({ path: '/database/results', query: {} })
+}
+</script>
+
+<template>
+  <div>
+    <h1 class="section-heading">Database</h1>
+
+    <div class="content-box">
+      <p class="intro-text">
+        Search the collection by one or more keywords. Select the field to search in and
+        enter a keyword for each row. Leave a row blank to ignore it.
+        Optionally restrict results to a date range.
+      </p>
+
+      <table class="form-table db-form">
+        <tbody>
+          <!-- Row 1 -->
+          <tr>
+            <th>Keyword 1</th>
+            <td>
+              <select v-model="field1" style="width:200px">
+                <option v-for="f in FIELD_OPTIONS" :key="f.value" :value="f.value">{{ f.label }}</option>
+              </select>
+              <input type="text" v-model="keyword1" placeholder="keyword…" style="width:220px; margin-left:8px" />
+            </td>
+          </tr>
+
+          <!-- Row 2 -->
+          <tr>
+            <th>Keyword 2</th>
+            <td>
+              <select v-model="cond2" style="width:60px">
+                <option value="AND">AND</option>
+                <option value="OR">OR</option>
+              </select>
+              <select v-model="field2" style="width:200px; margin-left:8px">
+                <option v-for="f in FIELD_OPTIONS" :key="f.value" :value="f.value">{{ f.label }}</option>
+              </select>
+              <input type="text" v-model="keyword2" placeholder="keyword…" style="width:220px; margin-left:8px" />
+            </td>
+          </tr>
+
+          <!-- Row 3 -->
+          <tr>
+            <th>Keyword 3</th>
+            <td>
+              <select v-model="cond3" style="width:60px">
+                <option value="AND">AND</option>
+                <option value="OR">OR</option>
+              </select>
+              <select v-model="field3" style="width:200px; margin-left:8px">
+                <option v-for="f in FIELD_OPTIONS" :key="f.value" :value="f.value">{{ f.label }}</option>
+              </select>
+              <input type="text" v-model="keyword3" placeholder="keyword…" style="width:220px; margin-left:8px" />
+            </td>
+          </tr>
+
+          <tr><td colspan="2"><hr class="form-divider" /></td></tr>
+
+          <!-- Date range -->
+          <tr>
+            <th>Date (from year)</th>
+            <td>
+              <input type="number" v-model="dateFrom" placeholder="e.g. 800" style="width:120px" />
+            </td>
+          </tr>
+          <tr>
+            <th>Date (to year)</th>
+            <td>
+              <input type="number" v-model="dateTo" placeholder="e.g. 1400" style="width:120px" />
+            </td>
+          </tr>
+
+          <!-- Actions -->
+          <tr>
+            <th></th>
+            <td style="padding-top:14px">
+              <button class="btn" @click="search">Search</button>
+              <button class="btn btn-secondary" style="margin-left:10px" @click="showAll">Show All</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.intro-text {
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--muted);
+  margin-bottom: 16px;
+  font-family: Arial, sans-serif;
+}
+.db-form th {
+  text-align: right;
+  padding-right: 14px;
+  font-size: 12px;
+  font-family: Arial, sans-serif;
+  color: var(--muted);
+  font-weight: bold;
+  white-space: nowrap;
+  width: 130px;
+}
+.form-divider {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 8px 0;
+}
+</style>

--- a/scripts/viewer/src/views/DatabaseResults.vue
+++ b/scripts/viewer/src/views/DatabaseResults.vue
@@ -1,0 +1,327 @@
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const route = useRoute()
+const router = useRouter()
+const {
+  items, dynasties,
+  itemLabel, countryLabel, dynastyLabel,
+  enItemTranslations,
+} = useInventoryData()
+
+const PAGE_SIZE = 20
+
+// ── Parse query params ────────────────────────────────────────────────
+
+function parseQuery(q) {
+  return {
+    keyword1: q.keyword1 ?? '',
+    field1:   q.field1   ?? 'keyword',
+    keyword2: q.keyword2 ?? '',
+    field2:   q.field2   ?? 'keyword',
+    cond2:    q.cond2    ?? 'AND',
+    keyword3: q.keyword3 ?? '',
+    field3:   q.field3   ?? 'keyword',
+    cond3:    q.cond3    ?? 'AND',
+    dateFrom: q.date_from ?? '',
+    dateTo:   q.date_to   ?? '',
+    page:     parseInt(q.page ?? '1', 10) || 1,
+    // refine row
+    keyword4: q.keyword4 ?? '',
+    field4:   q.field4   ?? 'keyword',
+    cond4:    q.cond4    ?? 'AND',
+  }
+}
+
+const search = ref(parseQuery(route.query))
+const currentPage = ref(search.value.page)
+
+watch(() => route.query, q => {
+  search.value = parseQuery(q)
+  currentPage.value = search.value.page
+})
+
+// ── Refine row ────────────────────────────────────────────────────────
+
+const refineKeyword = ref('')
+const refineField   = ref('keyword')
+const refineCond    = ref('AND')
+const showRefine    = ref(false)
+
+const FIELD_OPTIONS = [
+  { value: 'keyword',   label: 'Name / Keyword' },
+  { value: 'location',  label: 'Location' },
+  { value: 'provenance', label: 'Provenance' },
+  { value: 'dynasty',   label: 'Period / Dynasty' },
+  { value: 'patron',    label: 'Patron / Initial Owner' },
+  { value: 'artist',    label: 'Architect / Artist / Master' },
+  { value: 'material',  label: 'Material / Technique' },
+]
+
+function fieldLabel(val) {
+  return FIELD_OPTIONS.find(f => f.value === val)?.label ?? val
+}
+
+function applyRefine() {
+  if (!refineKeyword.value.trim()) return
+  const q = {
+    ...route.query,
+    keyword4: refineKeyword.value,
+    field4:   refineField.value,
+    cond4:    refineCond.value,
+  }
+  delete q.page
+  router.push({ path: '/database/results', query: q })
+  showRefine.value = false
+}
+
+// ── Keyword matching ─────────────────────────────────────────────────
+
+function matchField(item, field, keyword) {
+  if (!keyword) return true
+  const kw = keyword.toLowerCase().trim()
+  if (!kw) return true
+  const tr = enItemTranslations.value[item.id] ?? {}
+
+  switch (field) {
+    case 'keyword':
+      return (tr.name ?? item.internal_name ?? '').toLowerCase().includes(kw) ||
+             (tr.alternate_name ?? '').toLowerCase().includes(kw)
+    case 'location':
+      return (tr.location ?? '').toLowerCase().includes(kw)
+    case 'provenance':
+      return (tr.provenance ?? '').toLowerCase().includes(kw)
+    case 'dynasty': {
+      const names = item.dynasty_ids.map(id => dynastyLabel(id)).join(' ')
+      return names.toLowerCase().includes(kw)
+    }
+    case 'patron':
+      return (tr.patrons ?? tr.initial_owner ?? '').toLowerCase().includes(kw)
+    case 'artist':
+      return (tr.initial_owner ?? '').toLowerCase().includes(kw)
+    case 'material':
+      return (tr.type ?? '').toLowerCase().includes(kw)
+    default:
+      return (tr.name ?? item.internal_name ?? '').toLowerCase().includes(kw)
+  }
+}
+
+function itemMatches(item, s) {
+  const noSearch = !s.keyword1 && !s.keyword2 && !s.keyword3 && !s.keyword4
+
+  // Date filter (always applied)
+  if (s.dateFrom) {
+    const begin = parseInt(s.dateFrom, 10)
+    if (!isNaN(begin)) {
+      const ok = item.end_date !== null ? item.end_date >= begin
+               : item.start_date !== null ? item.start_date >= begin
+               : true
+      if (!ok) return false
+    }
+  }
+  if (s.dateTo) {
+    const end = parseInt(s.dateTo, 10)
+    if (!isNaN(end)) {
+      const ok = item.start_date !== null ? item.start_date <= end
+               : item.end_date !== null   ? item.end_date <= end
+               : true
+      if (!ok) return false
+    }
+  }
+
+  if (noSearch) return true
+
+  // Keyword rows combined
+  let result = null
+
+  function combine(current, next, cond) {
+    if (current === null) return next
+    if (cond === 'OR') return current || next
+    return current && next
+  }
+
+  if (s.keyword1) {
+    result = combine(result, matchField(item, s.field1, s.keyword1), 'AND')
+  }
+  if (s.keyword2) {
+    result = combine(result, matchField(item, s.field2, s.keyword2), s.cond2)
+  }
+  if (s.keyword3) {
+    result = combine(result, matchField(item, s.field3, s.keyword3), s.cond3)
+  }
+  if (s.keyword4) {
+    result = combine(result, matchField(item, s.field4, s.keyword4), s.cond4)
+  }
+
+  return result === null ? true : result
+}
+
+// ── Filtered results ──────────────────────────────────────────────────
+
+const filteredItems = computed(() => {
+  const s = search.value
+  return items.value.filter(item => itemMatches(item, s))
+})
+
+const totalPages = computed(() => Math.max(1, Math.ceil(filteredItems.value.length / PAGE_SIZE)))
+
+const pagedItems = computed(() => {
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return filteredItems.value.slice(start, start + PAGE_SIZE)
+})
+
+function goToPage(n) {
+  currentPage.value = n
+  const q = { ...route.query, page: String(n) }
+  if (n === 1) delete q.page
+  router.replace({ path: '/database/results', query: q })
+  window.scrollTo(0, 0)
+}
+
+// ── Active search summary ────────────────────────────────────────────
+
+const searchSummary = computed(() => {
+  const s = search.value
+  const parts = []
+  if (s.keyword1) parts.push(`${fieldLabel(s.field1)}: "${s.keyword1}"`)
+  if (s.keyword2) parts.push(`${s.cond2} ${fieldLabel(s.field2)}: "${s.keyword2}"`)
+  if (s.keyword3) parts.push(`${s.cond3} ${fieldLabel(s.field3)}: "${s.keyword3}"`)
+  if (s.keyword4) parts.push(`${s.cond4} ${fieldLabel(s.field4)}: "${s.keyword4}"`)
+  if (s.dateFrom) parts.push(`from ${s.dateFrom}`)
+  if (s.dateTo)   parts.push(`to ${s.dateTo}`)
+  return parts
+})
+</script>
+
+<template>
+  <div>
+    <h1 class="section-heading">Database Results</h1>
+
+    <!-- Search summary -->
+    <div class="content-box search-summary">
+      <span class="summary-label">Search:</span>
+      <template v-if="searchSummary.length">
+        <span v-for="(part, i) in searchSummary" :key="i" class="summary-part">{{ part }}</span>
+      </template>
+      <span v-else class="summary-part muted">all items</span>
+
+      <div class="summary-actions">
+        <router-link to="/database" class="btn btn-secondary" style="font-size:12px; padding:4px 12px; text-decoration:none">
+          New Search
+        </router-link>
+        <button
+          class="btn"
+          style="margin-left:8px; font-size:12px; padding:4px 12px"
+          @click="showRefine = !showRefine"
+        >
+          Refine
+        </button>
+      </div>
+    </div>
+
+    <!-- Refine panel -->
+    <div v-if="showRefine" class="content-box refine-panel">
+      <strong class="filter-label">Add a keyword to refine results:</strong>
+      <div class="refine-row">
+        <select v-model="refineCond" style="width:60px">
+          <option value="AND">AND</option>
+          <option value="OR">OR</option>
+        </select>
+        <select v-model="refineField" style="width:200px; margin-left:8px">
+          <option v-for="f in FIELD_OPTIONS" :key="f.value" :value="f.value">{{ f.label }}</option>
+        </select>
+        <input type="text" v-model="refineKeyword" placeholder="keyword…" style="width:200px; margin-left:8px" @keyup.enter="applyRefine" />
+        <button class="btn" style="margin-left:10px" @click="applyRefine">Add</button>
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="content-box">
+      <p class="result-count">
+        {{ filteredItems.length }} item{{ filteredItems.length !== 1 ? 's' : '' }} found
+      </p>
+
+      <ul v-if="pagedItems.length" class="item-list">
+        <li
+          v-for="item in pagedItems"
+          :key="item.id"
+          class="item-list-row"
+          @click="$router.push(`/item/${encodeURIComponent(item.id)}`)"
+        >
+          <div class="item-thumb">
+            <img v-if="item.images?.length" :src="item.images[0].url" :alt="itemLabel(item)" loading="lazy" />
+            <div v-else class="item-thumb-placeholder" />
+          </div>
+          <div class="item-list-info">
+            <div class="item-list-name">{{ itemLabel(item) }}</div>
+            <div class="item-list-meta">
+              <span v-if="item.country_id">{{ countryLabel(item.country_id) }}</span>
+              <span v-if="enItemTranslations[item.id]?.dates">{{ enItemTranslations[item.id].dates }}</span>
+              <span v-if="enItemTranslations[item.id]?.location">{{ enItemTranslations[item.id].location }}</span>
+              <span class="item-type-badge">{{ item.type }}</span>
+            </div>
+          </div>
+        </li>
+      </ul>
+
+      <p v-else class="no-results">No items match your search. <router-link to="/database">Try a new search.</router-link></p>
+
+      <!-- Pagination -->
+      <div v-if="totalPages > 1" class="pagination">
+        <span class="pagination-info">Page {{ currentPage }} of {{ totalPages }}</span>
+        <button class="page-btn" :disabled="currentPage === 1" @click="goToPage(currentPage - 1)">‹ Prev</button>
+        <template v-for="p in totalPages" :key="p">
+          <button
+            v-if="Math.abs(p - currentPage) <= 3 || p === 1 || p === totalPages"
+            class="page-btn"
+            :class="{ active: p === currentPage }"
+            @click="goToPage(p)"
+          >{{ p }}</button>
+          <span v-else-if="Math.abs(p - currentPage) === 4" class="page-ellipsis">…</span>
+        </template>
+        <button class="page-btn" :disabled="currentPage === totalPages" @click="goToPage(currentPage + 1)">Next ›</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.search-summary {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-family: Arial, sans-serif;
+  font-size: 12px;
+}
+.summary-label { font-weight: bold; color: var(--muted); }
+.summary-part { color: var(--text); }
+.summary-part.muted { color: var(--muted); }
+.summary-actions { margin-left: auto; display: flex; align-items: center; }
+
+.refine-panel { display: flex; flex-direction: column; gap: 10px; }
+.filter-label { font-family: Arial, sans-serif; font-size: 12px; font-weight: bold; color: var(--muted); }
+.refine-row { display: flex; align-items: center; flex-wrap: wrap; gap: 0; }
+
+.result-count {
+  font-family: Arial, sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.no-results { color: var(--muted); font-family: Arial, sans-serif; font-size: 13px; padding: 20px 0; }
+
+.item-type-badge {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 10px;
+  color: #888;
+}
+
+.page-ellipsis { padding: 4px; color: var(--muted); font-family: Arial, sans-serif; font-size: 12px; }
+</style>

--- a/scripts/viewer/src/views/Home.vue
+++ b/scripts/viewer/src/views/Home.vue
@@ -1,0 +1,174 @@
+<script setup>
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const router = useRouter()
+const { items, itemLabel, enItemTranslations } = useInventoryData()
+
+// Pick a random item that has an image, as the featured spotlight
+const featured = computed(() => {
+  const withImages = items.value.filter(i => i.images?.length > 0)
+  if (!withImages.length) return items.value[0] ?? null
+  const idx = Math.floor(Math.random() * withImages.length)
+  return withImages[idx]
+})
+
+function goToItem(item) {
+  router.push({ path: `/item/${encodeURIComponent(item.id)}` })
+}
+</script>
+
+<template>
+  <div class="home">
+    <!-- Welcome banner -->
+    <div class="home-banner content-box">
+      <h1 class="home-title">Welcome to Islamic Art</h1>
+      <p class="home-intro">
+        The Islamic Art digital exhibition presents a wide range of objects and monuments
+        from the Islamic world, held in museums and historic sites across numerous countries.
+        Explore the collection through the Permanent Collection browser or the full-text
+        Database search.
+      </p>
+    </div>
+
+    <!-- Navigation cards -->
+    <div class="home-cards">
+      <div class="home-card content-box" @click="$router.push('/permanent-collection')">
+        <h2 class="home-card-title">Permanent Collection</h2>
+        <p class="home-card-desc">
+          Browse the collection by country, period&nbsp;/&nbsp;dynasty, holding institution,
+          or date range.
+        </p>
+        <span class="home-card-link">Browse →</span>
+      </div>
+
+      <div class="home-card content-box" @click="$router.push('/database')">
+        <h2 class="home-card-title">Database</h2>
+        <p class="home-card-desc">
+          Search the full inventory by name, location, provenance, material, patron
+          and more. Combine up to three keyword fields.
+        </p>
+        <span class="home-card-link">Search →</span>
+      </div>
+    </div>
+
+    <!-- Featured item spotlight -->
+    <div v-if="featured" class="home-featured content-box">
+      <h2 class="section-heading">Item on Display</h2>
+      <div class="featured-inner" @click="goToItem(featured)" title="Click to view details">
+        <div v-if="featured.images?.length" class="featured-img-wrap">
+          <img
+            :src="featured.images[0].url"
+            :alt="itemLabel(featured)"
+            class="featured-img"
+            loading="eager"
+          />
+        </div>
+        <div class="featured-info">
+          <p class="featured-type">{{ featured.type }}</p>
+          <h3 class="featured-name">{{ itemLabel(featured) }}</h3>
+          <p v-if="enItemTranslations[featured.id]?.location" class="featured-meta">
+            {{ enItemTranslations[featured.id].location }}
+          </p>
+          <p v-if="enItemTranslations[featured.id]?.dates" class="featured-meta">
+            {{ enItemTranslations[featured.id].dates }}
+          </p>
+          <span class="featured-link">View details →</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.home { display: flex; flex-direction: column; gap: 16px; }
+
+.home-banner { border-top: 3px solid var(--gold); }
+.home-title {
+  font-size: 20px;
+  font-weight: bold;
+  color: var(--header-bg);
+  margin-bottom: 10px;
+}
+.home-intro {
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--muted);
+  max-width: 680px;
+}
+
+/* Cards */
+.home-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+@media (max-width: 600px) { .home-cards { grid-template-columns: 1fr; } }
+
+.home-card {
+  cursor: pointer;
+  border-top: 3px solid var(--gold);
+  transition: box-shadow 0.15s;
+}
+.home-card:hover { box-shadow: 0 2px 10px rgba(0,0,0,0.12); }
+.home-card-title {
+  font-size: 16px;
+  font-weight: bold;
+  color: var(--header-bg);
+  margin-bottom: 8px;
+  font-family: Georgia, serif;
+}
+.home-card-desc { font-size: 12px; line-height: 1.65; color: var(--muted); margin-bottom: 12px; }
+.home-card-link {
+  font-size: 12px;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  color: var(--gold);
+}
+
+/* Featured */
+.home-featured { border-top: 3px solid var(--gold); }
+.featured-inner {
+  display: flex;
+  gap: 20px;
+  cursor: pointer;
+  align-items: flex-start;
+}
+.featured-inner:hover .featured-name { color: var(--gold); }
+
+.featured-img-wrap {
+  flex-shrink: 0;
+  width: 200px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+.featured-img { width: 100%; height: 160px; object-fit: cover; display: block; }
+
+.featured-info { flex: 1; }
+.featured-type {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  font-family: Arial, sans-serif;
+  margin-bottom: 6px;
+}
+.featured-name {
+  font-size: 18px;
+  font-weight: bold;
+  color: var(--header-bg);
+  margin-bottom: 8px;
+  line-height: 1.3;
+}
+.featured-meta {
+  font-size: 12px;
+  color: var(--muted);
+  font-family: Arial, sans-serif;
+  margin-bottom: 4px;
+}
+.featured-link {
+  display: inline-block;
+  margin-top: 10px;
+  font-size: 12px;
+  font-weight: bold;
+  color: var(--gold);
+  font-family: Arial, sans-serif;
+}
+</style>

--- a/scripts/viewer/src/views/ItemDetail.vue
+++ b/scripts/viewer/src/views/ItemDetail.vue
@@ -1,0 +1,477 @@
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const route  = useRoute()
+const router = useRouter()
+
+const {
+  items, dynasties,
+  availableLangs, defaultLang,
+  translationsCache,
+  loadLangTranslations,
+  itemById,
+  itemLabel, countryLabel, partnerLabel,
+  md,
+} = useInventoryData()
+
+// ── Active item & language ────────────────────────────────────────────
+
+const item = computed(() => itemById.value[decodeURIComponent(route.params.id)] ?? null)
+
+const activeLang = ref(defaultLang)
+
+onMounted(() => {
+  loadLangTranslations(activeLang.value)
+})
+
+watch(activeLang, lang => {
+  loadLangTranslations(lang)
+})
+
+// ── Translation helpers ───────────────────────────────────────────────
+
+function t(it) {
+  if (!it) return {}
+  return translationsCache.value[activeLang.value]?.[it.id] ?? {}
+}
+
+function label(it) {
+  return t(it).name ?? it.internal_name ?? it.id
+}
+
+// ── Dynasties for this item ───────────────────────────────────────────
+
+const dynastyTranslationsCache = ref({})
+
+async function loadDynastyTranslations(lang) {
+  if (dynastyTranslationsCache.value[lang]) return
+  try {
+    const m = await import(`@inventory-data/translations/dynasties.${lang}.json`)
+    dynastyTranslationsCache.value = { ...dynastyTranslationsCache.value, [lang]: m.default }
+  } catch {}
+}
+
+onMounted(() => loadDynastyTranslations(activeLang.value))
+watch(activeLang, lang => loadDynastyTranslations(lang))
+
+const dynastyById = computed(() => {
+  const m = {}
+  for (const d of dynasties.value) m[d.id] = d
+  return m
+})
+
+function tDynasty(dynastyId) {
+  return dynastyTranslationsCache.value[activeLang.value]?.[dynastyId] ?? {}
+}
+
+const selectedDynasties = computed(() => {
+  if (!item.value?.dynasty_ids?.length) return []
+  return item.value.dynasty_ids
+    .map(id => {
+      const d = dynastyById.value[id]
+      if (!d) return null
+      const tr = tDynasty(id)
+      return { ...d, ...tr }
+    })
+    .filter(Boolean)
+})
+
+// ── Related items ─────────────────────────────────────────────────────
+
+const relatedItems = computed(() => {
+  if (!item.value?.related_item_ids?.length) return []
+  const seen = new Set()
+  return item.value.related_item_ids
+    .map(id => itemById.value[id])
+    .filter(it => {
+      if (!it || seen.has(it.id)) return false
+      seen.add(it.id)
+      return true
+    })
+})
+
+// ── Key facts (metadata table), type-conditional field order ─────────
+
+const isMonument = computed(() => item.value?.type === 'monument')
+
+const keyFacts = computed(() => {
+  if (!item.value) return []
+  const it = item.value
+  const tr = t(it)
+  const dynastyNames = selectedDynasties.value.map(d => d.name).filter(Boolean).join(', ')
+  const facts = []
+
+  if (isMonument.value) {
+    if (tr.alternate_name)  facts.push({ label: 'Also known as',    value: tr.alternate_name })
+    if (tr.location)        facts.push({ label: 'Location',         value: tr.location })
+    if (tr.dates)           facts.push({ label: 'Date of Monument', value: tr.dates })
+    if (dynastyNames)       facts.push({ label: 'Period / Dynasty', value: dynastyNames })
+    const patronValue = tr.patrons ?? tr.initial_owner
+    if (patronValue)        facts.push({ label: 'Patron(s)',        value: patronValue })
+  } else {
+    if (tr.location)            facts.push({ label: 'Location',                  value: tr.location })
+    if (tr.holder)              facts.push({ label: 'Holding Museum',             value: tr.holder })
+    if (it.owner_reference)     facts.push({ label: 'Museum Inventory Number',    value: it.owner_reference })
+    if (tr.dates)               facts.push({ label: 'Date of Object',             value: tr.dates })
+    if (dynastyNames)           facts.push({ label: 'Period / Dynasty',           value: dynastyNames })
+    if (tr.provenance)          facts.push({ label: 'Provenance',                 value: tr.provenance })
+    if (tr.type)                facts.push({ label: 'Material(s) / Technique(s)', value: tr.type })
+    if (tr.dimensions)          facts.push({ label: 'Dimensions',                 value: tr.dimensions })
+    if (tr.owner)               facts.push({ label: 'Owner',                      value: tr.owner })
+    if (tr.initial_owner)       facts.push({ label: 'Initial Owner',              value: tr.initial_owner })
+    if (tr.place_of_production) facts.push({ label: 'Place of Production',        value: tr.place_of_production })
+  }
+
+  return facts
+})
+
+// ── Content sections ──────────────────────────────────────────────────
+
+const contentSections = computed(() => {
+  if (!item.value) return []
+  const tr = t(item.value)
+  const monument = isMonument.value
+  const sections = []
+
+  if (monument) {
+    if (tr.history)     sections.push({ heading: 'History',     value: tr.history })
+    if (tr.description) sections.push({ heading: 'Description', value: tr.description })
+  } else {
+    if (tr.description) sections.push({ heading: 'Description',       value: tr.description })
+    if (tr.obtention)   sections.push({ heading: 'History / Acquisition', value: tr.obtention })
+  }
+
+  if (tr.method_for_datation)
+    sections.push({ heading: monument ? 'How Monument Was Dated' : 'How Object Was Dated', value: tr.method_for_datation })
+
+  if (tr.method_for_provenance)
+    sections.push({ heading: monument ? 'How Monument Provenance Was Determined' : 'How Object Provenance Was Determined', value: tr.method_for_provenance })
+
+  if (tr.bibliography)
+    sections.push({ heading: 'Bibliography', value: tr.bibliography })
+
+  return sections
+})
+
+// ── Credits ───────────────────────────────────────────────────────────
+
+const credits = computed(() => {
+  if (!item.value) return []
+  const tr = t(item.value)
+  const c = []
+  if (tr.author)                   c.push({ label: 'Prepared by',                value: tr.author })
+  if (tr.copy_editor)              c.push({ label: 'Copyedited by',              value: tr.copy_editor })
+  if (tr.translator)               c.push({ label: 'Translation by',             value: tr.translator })
+  if (tr.translation_copy_editor)  c.push({ label: 'Translation copyedited by',  value: tr.translation_copy_editor })
+  return c
+})
+
+// ── Navigation ─────────────────────────────────────────────────────────
+
+function back() {
+  if (window.history.length > 2) {
+    router.back()
+  } else {
+    router.push('/')
+  }
+}
+</script>
+
+<template>
+  <div v-if="!item" class="content-box not-found">
+    <p>Item not found.</p>
+    <router-link to="/">← Return home</router-link>
+  </div>
+
+  <div v-else class="detail-wrap">
+    <!-- Breadcrumb / back -->
+    <a class="back-link" href="#" @click.prevent="back">← Back to results</a>
+
+    <!-- Language selector for item content -->
+    <div v-if="availableLangs.length > 1" class="lang-selector">
+      <label class="lang-label">Item language:</label>
+      <select v-model="activeLang" class="lang-select">
+        <option v-for="lang in availableLangs" :key="lang" :value="lang">{{ lang.toUpperCase() }}</option>
+      </select>
+    </div>
+
+    <div class="detail content-box">
+      <!-- Type badge -->
+      <div class="detail-type-badge">{{ item.type }}</div>
+
+      <!-- Title -->
+      <h1 class="detail-title">{{ label(item) }}</h1>
+
+      <!-- Images -->
+      <div v-if="item.images?.length" class="images">
+        <figure v-for="(img, i) in item.images" :key="i">
+          <img :src="img.url" :alt="img.captions?.[activeLang] ?? ''" loading="lazy" class="detail-img" />
+          <figcaption v-if="img.captions?.[activeLang] || img.photographer">
+            <span v-if="img.captions?.[activeLang]">{{ img.captions[activeLang] }}</span>
+            <span v-if="img.photographer" class="photo-credit">© {{ img.photographer }}</span>
+          </figcaption>
+        </figure>
+      </div>
+
+      <!-- Key facts table -->
+      <table v-if="keyFacts.length" class="key-facts">
+        <tbody>
+          <tr v-for="fact in keyFacts" :key="fact.label">
+            <th>{{ fact.label }}</th>
+            <td>{{ fact.value }}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- Content sections (markdown) -->
+      <section
+        v-for="section in contentSections"
+        :key="section.heading"
+        class="content-section"
+      >
+        <h2 class="content-section-heading">{{ section.heading }}</h2>
+        <div v-html="md(section.value)" class="prose" />
+      </section>
+
+      <!-- Credits -->
+      <div v-if="credits.length" class="credits">
+        <h2 class="credits-heading">Credits</h2>
+        <dl class="credits-list">
+          <template v-for="c in credits" :key="c.label">
+            <dt>{{ c.label }}</dt>
+            <dd>{{ c.value }}</dd>
+          </template>
+        </dl>
+        <p v-if="item.mwnf_reference" class="mwnf-ref">
+          MWNF Working Number: <strong>{{ item.mwnf_reference }}</strong>
+        </p>
+      </div>
+
+      <!-- Dynasty cards -->
+      <div v-if="selectedDynasties.length" class="dynasties">
+        <h2 class="sub-section-title">{{ selectedDynasties.length === 1 ? 'Dynasty' : 'Dynasties' }}</h2>
+        <div v-for="d in selectedDynasties" :key="d.id" class="dynasty-card">
+          <div class="dynasty-header">
+            <span class="dynasty-name">{{ d.name ?? '—' }}</span>
+            <span v-if="d.also_known_as" class="dynasty-aka">also known as {{ d.also_known_as }}</span>
+            <span v-if="d.from_ad || d.to_ad" class="dynasty-dates">
+              {{ d.date_description_ad ?? (d.from_ad + (d.to_ad ? ' – ' + d.to_ad : '')) }}
+            </span>
+          </div>
+          <p v-if="d.history" class="dynasty-history">{{ d.history }}</p>
+          <p v-if="d.area" class="dynasty-area">Area: {{ d.area }}</p>
+        </div>
+      </div>
+
+      <!-- Related items -->
+      <div v-if="relatedItems.length" class="related">
+        <h2 class="sub-section-title">Related Items</h2>
+        <ul class="related-list item-list">
+          <li
+            v-for="rel in relatedItems"
+            :key="rel.id"
+            class="item-list-row"
+            @click="$router.push(`/item/${encodeURIComponent(rel.id)}`)"
+          >
+            <div class="item-thumb">
+              <img v-if="rel.images?.length" :src="rel.images[0].url" :alt="itemLabel(rel)" loading="lazy" />
+              <div v-else class="item-thumb-placeholder" />
+            </div>
+            <div class="item-list-info">
+              <div class="item-list-name">{{ itemLabel(rel) }}</div>
+              <div class="item-list-meta">
+                <span class="item-type-badge">{{ rel.type }}</span>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.not-found { color: var(--muted); font-family: Arial, sans-serif; font-size: 13px; }
+
+.detail-wrap { display: flex; flex-direction: column; gap: 10px; }
+
+.lang-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: Arial, sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+  justify-content: flex-end;
+}
+.lang-label { }
+.lang-select { font-size: 12px; padding: 3px 6px; }
+
+.detail { }
+
+.detail-type-badge {
+  display: inline-block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--header-bg);
+  border: 1px solid var(--gold);
+  padding: 2px 8px;
+  margin-bottom: 10px;
+  font-family: Arial, sans-serif;
+}
+
+.detail-title {
+  font-size: 22px;
+  font-weight: bold;
+  color: var(--header-bg);
+  margin-bottom: 16px;
+  line-height: 1.3;
+  font-family: Georgia, serif;
+}
+
+/* Images */
+.images {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+.images figure { flex-shrink: 0; }
+.detail-img {
+  width: 180px;
+  height: 140px;
+  object-fit: cover;
+  border: 1px solid var(--border);
+  display: block;
+}
+.images figcaption {
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 4px;
+  width: 180px;
+  font-family: Arial, sans-serif;
+}
+.photo-credit { display: block; }
+
+/* Key facts table */
+.key-facts {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+  font-size: 13px;
+}
+.key-facts th,
+.key-facts td {
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  vertical-align: top;
+  text-align: left;
+}
+.key-facts th {
+  background: #f8f0e3;
+  width: 36%;
+  font-weight: bold;
+  color: var(--header-bg);
+  font-family: Arial, sans-serif;
+  font-size: 12px;
+  white-space: nowrap;
+}
+.key-facts td { color: var(--text); font-family: Arial, sans-serif; }
+
+/* Content sections */
+.content-section {
+  margin-bottom: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.content-section-heading {
+  font-size: 13px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--header-bg);
+  margin-bottom: 10px;
+  font-family: Arial, sans-serif;
+}
+
+/* Prose */
+.prose { font-size: 13px; line-height: 1.7; color: var(--text); font-family: Arial, sans-serif; }
+.prose :deep(p) { margin: 0 0 .75em; }
+.prose :deep(p:last-child) { margin-bottom: 0; }
+.prose :deep(em) { font-style: italic; }
+.prose :deep(strong) { font-weight: 700; }
+.prose :deep(ul), .prose :deep(ol) { padding-left: 1.5em; margin: 0 0 .75em; }
+.prose :deep(li) { margin-bottom: .25em; }
+.prose :deep(a) { color: var(--link); text-decoration: underline; }
+
+/* Credits */
+.credits {
+  margin-top: 20px;
+  padding-top: 14px;
+  border-top: 2px solid var(--header-bg);
+}
+.credits-heading {
+  font-size: 11px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--header-bg);
+  margin-bottom: 10px;
+  font-family: Arial, sans-serif;
+}
+.credits-list {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: .3rem 1rem;
+  font-size: 12px;
+  margin-bottom: 8px;
+  font-family: Arial, sans-serif;
+}
+.credits-list dt { font-weight: bold; color: var(--muted); }
+.credits-list dd { color: var(--text); }
+.mwnf-ref { font-size: 11px; color: var(--muted); font-family: Arial, sans-serif; }
+
+/* Dynasty cards */
+.sub-section-title {
+  font-size: 12px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin-bottom: 10px;
+  font-family: Arial, sans-serif;
+}
+.dynasties { margin-top: 20px; border-top: 1px solid var(--border); padding-top: 16px; }
+.dynasty-card {
+  background: #faf5ec;
+  border-left: 3px solid var(--gold);
+  padding: 10px 14px;
+  margin-bottom: 8px;
+}
+.dynasty-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: .4rem 1rem;
+  margin-bottom: 4px;
+}
+.dynasty-name { font-weight: bold; font-size: 13px; }
+.dynasty-aka  { font-size: 11px; color: var(--muted); font-style: italic; }
+.dynasty-dates { font-size: 11px; color: var(--muted); margin-left: auto; }
+.dynasty-history { font-size: 12px; line-height: 1.6; color: var(--text); margin: 0 0 4px; font-family: Arial, sans-serif; }
+.dynasty-area { font-size: 11px; color: var(--muted); margin: 0; font-family: Arial, sans-serif; }
+
+/* Related */
+.related { margin-top: 20px; border-top: 1px solid var(--border); padding-top: 16px; }
+.related-list { list-style: none; }
+
+.item-type-badge {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 10px;
+  color: #888;
+}
+</style>

--- a/scripts/viewer/src/views/PcEntrance.vue
+++ b/scripts/viewer/src/views/PcEntrance.vue
@@ -1,0 +1,187 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const router = useRouter()
+const {
+  items, countries, partners, dynasties,
+  countryLabel, dynastyLabel, partnerLabel,
+  enCountryTranslations, enDynastyTranslations, enPartnerTranslations,
+} = useInventoryData()
+
+const filterType = ref('country') // country | dynasty | partner | begin | end
+
+// Build option lists from items actually present
+const availableCountries = computed(() => {
+  const ids = new Set(items.value.map(i => i.country_id).filter(Boolean))
+  return countries.value
+    .filter(c => ids.has(c.id))
+    .map(c => ({ id: c.id, name: countryLabel(c.id) }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+const availableDynasties = computed(() => {
+  const ids = new Set(items.value.flatMap(i => i.dynasty_ids))
+  return dynasties.value
+    .filter(d => ids.has(d.id))
+    .map(d => ({
+      id: d.id,
+      name: dynastyLabel(d.id),
+      from_ad: d.from_ad,
+    }))
+    .sort((a, b) => (a.from_ad ?? 9999) - (b.from_ad ?? 9999))
+})
+
+const availablePartners = computed(() => {
+  const ids = new Set(items.value.map(i => i.partner_id).filter(Boolean))
+  return partners.value
+    .filter(p => ids.has(p.id))
+    .map(p => ({ id: p.id, name: partnerLabel(p.id) }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+const selectedCountry = ref('')
+const selectedDynasty = ref('')
+const selectedPartner = ref('')
+const beginDate = ref('')
+const endDate = ref('')
+
+function search() {
+  const q = {}
+  if (filterType.value === 'country' && selectedCountry.value)   q.country = selectedCountry.value
+  if (filterType.value === 'dynasty' && selectedDynasty.value)   q.dynasty = selectedDynasty.value
+  if (filterType.value === 'partner' && selectedPartner.value)   q.partner = selectedPartner.value
+  if (filterType.value === 'begin'   && beginDate.value)         q.begin   = beginDate.value
+  if (filterType.value === 'end'     && endDate.value)           q.end     = endDate.value
+  router.push({ path: '/permanent-collection/results', query: q })
+}
+</script>
+
+<template>
+  <div>
+    <h1 class="section-heading">Permanent Collection</h1>
+
+    <div class="content-box">
+      <p class="intro-text">
+        Select a filter to browse the Permanent Collection. Choose a category below,
+        then select a value and click <strong>Browse</strong>.
+      </p>
+
+      <table class="form-table filter-table">
+        <tbody>
+          <!-- Filter type selector -->
+          <tr v-for="opt in [
+            { value: 'country', label: 'Country' },
+            { value: 'dynasty', label: 'Period / Dynasty' },
+            { value: 'partner', label: 'Holding Institution' },
+            { value: 'begin',   label: 'Start Date (from year)' },
+            { value: 'end',     label: 'End Date (up to year)' },
+          ]" :key="opt.value">
+            <th>
+              <label :for="'filter-' + opt.value">
+                <input
+                  type="radio"
+                  :id="'filter-' + opt.value"
+                  name="filterType"
+                  :value="opt.value"
+                  v-model="filterType"
+                />
+                {{ opt.label }}
+              </label>
+            </th>
+            <td>
+              <!-- Country -->
+              <template v-if="opt.value === 'country'">
+                <select v-model="selectedCountry" :disabled="filterType !== 'country'" style="width:280px">
+                  <option value="">— select a country —</option>
+                  <option v-for="c in availableCountries" :key="c.id" :value="c.id">{{ c.name }}</option>
+                </select>
+              </template>
+
+              <!-- Dynasty -->
+              <template v-else-if="opt.value === 'dynasty'">
+                <select v-model="selectedDynasty" :disabled="filterType !== 'dynasty'" style="width:280px">
+                  <option value="">— select a period / dynasty —</option>
+                  <option v-for="d in availableDynasties" :key="d.id" :value="d.id">{{ d.name }}</option>
+                </select>
+              </template>
+
+              <!-- Partner -->
+              <template v-else-if="opt.value === 'partner'">
+                <select v-model="selectedPartner" :disabled="filterType !== 'partner'" style="width:280px">
+                  <option value="">— select an institution —</option>
+                  <option v-for="p in availablePartners" :key="p.id" :value="p.id">{{ p.name }}</option>
+                </select>
+              </template>
+
+              <!-- Begin date -->
+              <template v-else-if="opt.value === 'begin'">
+                <input
+                  type="number"
+                  v-model="beginDate"
+                  :disabled="filterType !== 'begin'"
+                  placeholder="e.g. 800"
+                  style="width:120px"
+                />
+              </template>
+
+              <!-- End date -->
+              <template v-else-if="opt.value === 'end'">
+                <input
+                  type="number"
+                  v-model="endDate"
+                  :disabled="filterType !== 'end'"
+                  placeholder="e.g. 1200"
+                  style="width:120px"
+                />
+              </template>
+            </td>
+          </tr>
+
+          <!-- Submit -->
+          <tr>
+            <th></th>
+            <td style="padding-top:12px">
+              <button class="btn" @click="search">Browse</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.intro-text {
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--muted);
+  margin-bottom: 16px;
+  font-family: Arial, sans-serif;
+}
+
+.filter-table th {
+  text-align: left;
+  font-weight: normal;
+  padding: 6px 16px 6px 0;
+  font-family: Arial, sans-serif;
+  font-size: 13px;
+  color: var(--text);
+  vertical-align: middle;
+  width: auto;
+}
+.filter-table th label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-weight: normal;
+}
+.filter-table input[type="radio"] { cursor: pointer; }
+
+select:disabled, input:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+</style>

--- a/scripts/viewer/src/views/PcList.vue
+++ b/scripts/viewer/src/views/PcList.vue
@@ -1,0 +1,281 @@
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const route = useRoute()
+const router = useRouter()
+const {
+  items, countries, partners, dynasties,
+  countryLabel, dynastyLabel, partnerLabel,
+  itemLabel, enItemTranslations,
+} = useInventoryData()
+
+const PAGE_SIZE = 20
+
+// ── Filter state (synced with URL query) ────────────────────────────────
+
+const filterCountry = ref(route.query.country ?? '')
+const filterDynasty = ref(route.query.dynasty ?? '')
+const filterPartner = ref(route.query.partner ?? '')
+const filterBegin   = ref(route.query.begin   ?? '')
+const filterEnd     = ref(route.query.end     ?? '')
+const currentPage   = ref(parseInt(route.query.page ?? '1', 10) || 1)
+
+watch(
+  [filterCountry, filterDynasty, filterPartner, filterBegin, filterEnd],
+  () => { currentPage.value = 1 }
+)
+
+watch(
+  () => route.query,
+  q => {
+    filterCountry.value = q.country ?? ''
+    filterDynasty.value = q.dynasty ?? ''
+    filterPartner.value = q.partner ?? ''
+    filterBegin.value   = q.begin   ?? ''
+    filterEnd.value     = q.end     ?? ''
+    currentPage.value   = parseInt(q.page ?? '1', 10) || 1
+  }
+)
+
+function applyFilters() {
+  const q = {}
+  if (filterCountry.value) q.country = filterCountry.value
+  if (filterDynasty.value) q.dynasty = filterDynasty.value
+  if (filterPartner.value) q.partner = filterPartner.value
+  if (filterBegin.value)   q.begin   = filterBegin.value
+  if (filterEnd.value)     q.end     = filterEnd.value
+  router.push({ path: '/permanent-collection/results', query: q })
+}
+
+function resetFilters() {
+  filterCountry.value = ''
+  filterDynasty.value = ''
+  filterPartner.value = ''
+  filterBegin.value   = ''
+  filterEnd.value     = ''
+  applyFilters()
+}
+
+// ── Build available options from actual items ───────────────────────────
+
+const availableCountries = computed(() => {
+  const ids = new Set(items.value.map(i => i.country_id).filter(Boolean))
+  return countries.value
+    .filter(c => ids.has(c.id))
+    .map(c => ({ id: c.id, name: countryLabel(c.id) }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+const availableDynasties = computed(() => {
+  const ids = new Set(items.value.flatMap(i => i.dynasty_ids))
+  return dynasties.value
+    .filter(d => ids.has(d.id))
+    .map(d => ({ id: d.id, name: dynastyLabel(d.id), from_ad: d.from_ad }))
+    .sort((a, b) => (a.from_ad ?? 9999) - (b.from_ad ?? 9999))
+})
+
+const availablePartners = computed(() => {
+  const ids = new Set(items.value.map(i => i.partner_id).filter(Boolean))
+  return partners.value
+    .filter(p => ids.has(p.id))
+    .map(p => ({ id: p.id, name: partnerLabel(p.id) }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+// ── Filtered items ────────────────────────────────────────────────────
+
+const filteredItems = computed(() => {
+  let result = items.value
+
+  if (filterCountry.value) {
+    result = result.filter(item => item.country_id === filterCountry.value)
+  }
+  if (filterDynasty.value) {
+    result = result.filter(item => item.dynasty_ids.includes(filterDynasty.value))
+  }
+  if (filterPartner.value) {
+    result = result.filter(item => item.partner_id === filterPartner.value)
+  }
+  if (filterBegin.value) {
+    const begin = parseInt(filterBegin.value, 10)
+    if (!isNaN(begin)) {
+      result = result.filter(item => {
+        if (item.end_date !== null) return item.end_date >= begin
+        if (item.start_date !== null) return item.start_date >= begin
+        return true
+      })
+    }
+  }
+  if (filterEnd.value) {
+    const end = parseInt(filterEnd.value, 10)
+    if (!isNaN(end)) {
+      result = result.filter(item => {
+        if (item.start_date !== null) return item.start_date <= end
+        if (item.end_date !== null) return item.end_date <= end
+        return true
+      })
+    }
+  }
+
+  return result
+})
+
+const totalPages = computed(() => Math.max(1, Math.ceil(filteredItems.value.length / PAGE_SIZE)))
+
+const pagedItems = computed(() => {
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return filteredItems.value.slice(start, start + PAGE_SIZE)
+})
+
+function goToPage(n) {
+  currentPage.value = n
+  const q = { ...route.query, page: String(n) }
+  if (n === 1) delete q.page
+  router.replace({ path: '/permanent-collection/results', query: q })
+  window.scrollTo(0, 0)
+}
+
+// ── Active filter label ───────────────────────────────────────────────
+
+const activeFilterLabel = computed(() => {
+  if (filterCountry.value) return countryLabel(filterCountry.value)
+  if (filterDynasty.value) return dynastyLabel(filterDynasty.value)
+  if (filterPartner.value) return partnerLabel(filterPartner.value)
+  if (filterBegin.value)   return `from ${filterBegin.value}`
+  if (filterEnd.value)     return `up to ${filterEnd.value}`
+  return 'All Items'
+})
+</script>
+
+<template>
+  <div>
+    <h1 class="section-heading">
+      Permanent Collection
+      <span v-if="activeFilterLabel !== 'All Items'" class="heading-filter"> — {{ activeFilterLabel }}</span>
+    </h1>
+
+    <!-- Filter panel -->
+    <div class="content-box filter-panel">
+      <strong class="filter-label">Filter:</strong>
+
+      <div class="filter-row">
+        <label>Country</label>
+        <select v-model="filterCountry" style="width:200px">
+          <option value="">— any —</option>
+          <option v-for="c in availableCountries" :key="c.id" :value="c.id">{{ c.name }}</option>
+        </select>
+      </div>
+
+      <div class="filter-row">
+        <label>Period / Dynasty</label>
+        <select v-model="filterDynasty" style="width:200px">
+          <option value="">— any —</option>
+          <option v-for="d in availableDynasties" :key="d.id" :value="d.id">{{ d.name }}</option>
+        </select>
+      </div>
+
+      <div class="filter-row">
+        <label>Holding Institution</label>
+        <select v-model="filterPartner" style="width:200px">
+          <option value="">— any —</option>
+          <option v-for="p in availablePartners" :key="p.id" :value="p.id">{{ p.name }}</option>
+        </select>
+      </div>
+
+      <div class="filter-row">
+        <label>From year</label>
+        <input type="number" v-model="filterBegin" placeholder="e.g. 800" style="width:100px" />
+      </div>
+
+      <div class="filter-row">
+        <label>To year</label>
+        <input type="number" v-model="filterEnd" placeholder="e.g. 1400" style="width:100px" />
+      </div>
+
+      <div class="filter-actions">
+        <button class="btn" @click="applyFilters">Apply</button>
+        <button class="btn btn-secondary" style="margin-left:8px" @click="resetFilters">Reset</button>
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="content-box">
+      <p class="result-count">
+        {{ filteredItems.length }} item{{ filteredItems.length !== 1 ? 's' : '' }} found
+      </p>
+
+      <ul v-if="pagedItems.length" class="item-list">
+        <li
+          v-for="item in pagedItems"
+          :key="item.id"
+          class="item-list-row"
+          @click="$router.push(`/item/${encodeURIComponent(item.id)}`)"
+        >
+          <div class="item-thumb">
+            <img v-if="item.images?.length" :src="item.images[0].url" :alt="itemLabel(item)" loading="lazy" />
+            <div v-else class="item-thumb-placeholder" />
+          </div>
+          <div class="item-list-info">
+            <div class="item-list-name">{{ itemLabel(item) }}</div>
+            <div class="item-list-meta">
+              <span v-if="item.country_id">{{ countryLabel(item.country_id) }}</span>
+              <span v-if="enItemTranslations[item.id]?.dates">{{ enItemTranslations[item.id].dates }}</span>
+              <span v-if="item.type" class="item-type-badge">{{ item.type }}</span>
+            </div>
+          </div>
+        </li>
+      </ul>
+
+      <p v-else class="no-results">No items match the selected filter.</p>
+
+      <!-- Pagination -->
+      <div v-if="totalPages > 1" class="pagination">
+        <span class="pagination-info">
+          Page {{ currentPage }} of {{ totalPages }}
+        </span>
+        <button class="page-btn" :disabled="currentPage === 1" @click="goToPage(currentPage - 1)">‹ Prev</button>
+        <template v-for="p in totalPages" :key="p">
+          <button
+            v-if="Math.abs(p - currentPage) <= 3 || p === 1 || p === totalPages"
+            class="page-btn"
+            :class="{ active: p === currentPage }"
+            @click="goToPage(p)"
+          >{{ p }}</button>
+          <span v-else-if="Math.abs(p - currentPage) === 4" class="page-ellipsis">…</span>
+        </template>
+        <button class="page-btn" :disabled="currentPage === totalPages" @click="goToPage(currentPage + 1)">Next ›</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.heading-filter { font-weight: normal; font-size: 14px; color: var(--muted); }
+
+.filter-panel { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; }
+.filter-label { font-family: Arial, sans-serif; font-size: 12px; font-weight: bold; color: var(--muted); }
+.filter-row { display: flex; align-items: center; gap: 6px; font-family: Arial, sans-serif; font-size: 12px; color: var(--muted); }
+.filter-actions { margin-left: auto; }
+
+.result-count {
+  font-family: Arial, sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.no-results { color: var(--muted); font-family: Arial, sans-serif; font-size: 13px; padding: 20px 0; }
+
+.item-type-badge {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 10px;
+  color: #888;
+}
+
+.page-ellipsis { padding: 4px 4px; color: var(--muted); font-family: Arial, sans-serif; font-size: 12px; }
+</style>


### PR DESCRIPTION
## Summary

- **Splash / Home page** (`/`): MWNF Islamic Art-themed landing page with welcome banner, navigation cards to Permanent Collection and Database, and a randomly selected item spotlight.
- **Permanent Collection entrance** (`/permanent-collection`): filter picker (Country, Period/Dynasty, Holding Institution, start date, end date) matching the legacy `pc_entrance.php` flow.
- **Permanent Collection results** (`/permanent-collection/results`): live filter panel across all five axes, paginated list with thumbnail + name + country + date. URL query params keep filters bookmarkable.
- **Database search** (`/database`): three keyword rows each with a field selector (Name/Keyword, Location, Provenance, Period/Dynasty, Patron, Architect/Artist/Master, Material/Technique), AND/OR combinators, and optional date-range inputs — matching the legacy `database.php`.
- **Database results** (`/database/results`): paginated item list, inline "Refine" panel to append a fourth keyword row, search summary at top — matching `database_results.php`.
- **Item detail** (`/item/:id`): extracted into its own view; language switcher retained so users can change the item's display language without changing the English UI — matching `database_item.php`.

Architecture changes:
- Added `vue-router` (hash mode) for proper multi-page navigation with browser-back support.
- Extracted shared data loading into `src/composables/useInventoryData.js` (singleton refs, loaded once on boot).
- Visual theme mirrors legacy: dark warm-brown header/nav, gold accents, cream page background, Georgia serif typography.

## Constraints observed

- UI language is English only (no language picker in the UI).
- Item detail page retains the per-item language switcher (legacy feature).
- All data comes from the `@metanull/islamicart-data` package only.
- Fields shown in the item detail follow the same order and labels as the legacy site.

## Test plan

- [ ] Home page shows splash with navigation cards and a random item spotlight.
- [ ] Clicking "Permanent Collection" → filter form; selecting Country → browse → paginated results filtered by country.
- [ ] Filter panel in PC results allows changing/combining all five axes.
- [ ] Clicking "Database" → search form; entering keywords with field selectors → results.
- [ ] "Refine" in DB results adds a 4th keyword and re-filters.
- [ ] Clicking any item in any list → item detail page with correct fields in legacy order.
- [ ] Language switcher on item detail changes content without changing UI language.
- [ ] Browser back button works correctly between pages.
- [ ] Pagination works on both results pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)