### PR TITLE
fix(exporter+viewer): context filter, directed links, and justification captions

### DIFF
--- a/scripts/exporter/src/cli/export.ts
+++ b/scripts/exporter/src/cli/export.ts
@@ -132,12 +132,20 @@ program
         logger.info(`Resolving project IDs for: ${projectKeys.join(', ')}`)
         const projectIds = await db.resolveProjectIds(projectKeys)
         console.log(chalk.green(`  ✓ Found ${projectIds.length} project(s)`))
+
+        // Resolve context IDs — same keys, but contexts table.
+        // Used to filter item_translations to only the right project context,
+        // excluding explore-context translations that would otherwise overwrite.
+        logger.info(`Resolving context IDs for: ${projectKeys.join(', ')}`)
+        const contextIds = await db.resolveContextIds(projectKeys)
+        console.log(chalk.green(`  ✓ Found ${contextIds.length} context(s)`))
         console.log('')
 
         const context: ExportContext = {
           db,
           outputDir,
           projectIds,
+          contextIds,
           projectKeys,
           baseUrl: options.baseUrl,
           logger,

--- a/scripts/exporter/src/core/database.ts
+++ b/scripts/exporter/src/core/database.ts
@@ -59,4 +59,37 @@ export class Database {
 
     return rows.map(r => r.id)
   }
+
+  /**
+   * Resolve context UUIDs for the given project keys.
+   *
+   * Each legacy project (e.g. "ISL") has a corresponding context row whose
+   * backward_compatibility matches the project: "mwnf3:projects:ISL".
+   * Item translations must be filtered to these context IDs so that
+   * explore-context translations (mwnf3_explore:context) are excluded.
+   */
+  async resolveContextIds(projectKeys: string[]): Promise<string[]> {
+    const bcValues = projectKeys.map(k => `mwnf3:projects:${k}`)
+    const placeholders = bcValues.map(() => '?').join(', ')
+
+    const rows = await this.query<{ id: string; backward_compatibility: string }>(
+      `SELECT id, backward_compatibility FROM contexts WHERE backward_compatibility IN (${placeholders})`,
+      bcValues
+    )
+
+    if (rows.length === 0) {
+      throw new Error(
+        `No contexts found. Looked for: ${bcValues.join(', ')}\n` +
+          `Run: SELECT backward_compatibility FROM contexts; to list available contexts.`
+      )
+    }
+
+    if (rows.length < projectKeys.length) {
+      const found = new Set(rows.map(r => r.backward_compatibility))
+      const missing = bcValues.filter(v => !found.has(v))
+      throw new Error(`Contexts not found for: ${missing.join(', ')}`)
+    }
+
+    return rows.map(r => r.id)
+  }
 }

--- a/scripts/exporter/src/core/types.ts
+++ b/scripts/exporter/src/core/types.ts
@@ -5,6 +5,7 @@ export interface ExportContext {
   db: Database
   outputDir: string
   projectIds: string[]
+  contextIds: string[]
   projectKeys: string[]
   baseUrl: string
   logger: Logger

--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -69,6 +69,8 @@ interface ItemDynastyRow {
 interface ItemItemLinkRow {
   source_id: string
   target_id: string
+  language_id: string
+  justification: string | null
 }
 
 interface ItemTagRow {
@@ -109,7 +111,12 @@ export class ItemExporter extends BaseExporter {
     const itemPh = this.placeholders(itemIds.length)
     const langCodeMap = await this.buildLangCodeMap()
 
+    const contextIds = this.context.contextIds
+    const contextPh = this.placeholders(contextIds.length)
+
     // ── 1. Content translations (name, description, …) ──────────────────────
+    // Filter by context_id so that explore-context translations (which may have
+    // extra=null) do not overwrite the canonical project translations.
     const translations = await this.db.query<ItemTranslationRow>(
       `SELECT it.item_id, it.language_id,
               it.name, it.alternate_name, it.description,
@@ -126,8 +133,9 @@ export class ItemExporter extends BaseExporter {
        LEFT JOIN authors a2 ON a2.id = it.text_copy_editor_id
        LEFT JOIN authors a3 ON a3.id = it.translator_id
        LEFT JOIN authors a4 ON a4.id = it.translation_copy_editor_id
-       WHERE it.item_id IN (${itemPh})`,
-      itemIds
+       WHERE it.item_id IN (${itemPh})
+         AND it.context_id IN (${contextPh})`,
+      [...itemIds, ...contextIds]
     )
 
     // ── 2. Images via picture child items ────────────────────────────────────
@@ -171,10 +179,16 @@ export class ItemExporter extends BaseExporter {
          WHERE it2.item_id IN (${itemPh})`,
         itemIds
       ),
+      // Outgoing links only (source_id IN items). The legacy data model stores
+      // directed links; fetching both directions and reversing doubles the list.
+      // Justification texts are joined per link per language.
       this.db.query<ItemItemLinkRow>(
-        `SELECT source_id, target_id FROM item_item_links
-         WHERE source_id IN (${itemPh}) OR target_id IN (${itemPh})`,
-        [...itemIds, ...itemIds]
+        `SELECT iil.source_id, iil.target_id,
+                iilt.language_id, iilt.description AS justification
+         FROM item_item_links iil
+         LEFT JOIN item_item_link_translations iilt ON iilt.item_item_link_id = iil.id
+         WHERE iil.source_id IN (${itemPh})`,
+        itemIds
       ),
     ])
 
@@ -294,15 +308,23 @@ export class ItemExporter extends BaseExporter {
       tagMap.get(link.item_id)!.push(link.tag)
     }
 
-    // item_id -> related_item_ids[] (bidirectional; only items present in this export)
+    // item_id -> related item entries (outgoing links only; only targets present in this export)
+    // source_id -> target_id -> lang_code -> justification text
     const itemIdSet = new Set(itemIds)
     const relatedMap = new Map<string, string[]>()
+    const justificationMap = new Map<string, Map<string, Record<string, string>>>()
     for (const link of itemItemLinks) {
-      if (itemIdSet.has(link.source_id) && itemIdSet.has(link.target_id)) {
-        if (!relatedMap.has(link.source_id)) relatedMap.set(link.source_id, [])
-        relatedMap.get(link.source_id)!.push(link.target_id)
-        if (!relatedMap.has(link.target_id)) relatedMap.set(link.target_id, [])
-        relatedMap.get(link.target_id)!.push(link.source_id)
+      if (!itemIdSet.has(link.target_id)) continue
+      if (!relatedMap.has(link.source_id)) relatedMap.set(link.source_id, [])
+      const existing = relatedMap.get(link.source_id)!
+      if (!existing.includes(link.target_id)) existing.push(link.target_id)
+
+      const code = langCodeMap.get(link.language_id)
+      if (code && link.justification) {
+        if (!justificationMap.has(link.source_id)) justificationMap.set(link.source_id, new Map())
+        const tgtMap = justificationMap.get(link.source_id)!
+        if (!tgtMap.has(link.target_id)) tgtMap.set(link.target_id, {})
+        tgtMap.get(link.target_id)![code] = link.justification
       }
     }
 
@@ -323,7 +345,10 @@ export class ItemExporter extends BaseExporter {
       longitude: item.longitude !== null ? parseFloat(item.longitude) : null,
       images: imageMap.get(item.id) ?? [],
       dynasty_ids: dynastyMap.get(item.id) ?? [],
-      related_item_ids: relatedMap.get(item.id) ?? [],
+      related_items: (relatedMap.get(item.id) ?? []).map(targetId => ({
+        id: targetId,
+        justifications: justificationMap.get(item.id)?.get(targetId) ?? {},
+      })),
       tags: tagMap.get(item.id) ?? [],
     }))
 

--- a/scripts/viewer/package-lock.json
+++ b/scripts/viewer/package-lock.json
@@ -105,9 +105,9 @@
       "license": "MIT"
     },
     "node_modules/@metanull/islamicart-data": {
-      "version": "1.0.5",
-      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.5/16184b0ed8d309cdc478b3a0982a898bf0eb8023",
-      "integrity": "sha512-/KeI14lJlGeWCiPa4Lt1sb+ioDP9Jzrr1FJsnsVkFZ2w6uwKwHQx7bRkASrzz11xyrM/eTdrtUn7wjk9PuNjiA==",
+      "version": "1.0.6",
+      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.6/46ad06af585be912da51e59dc4021bb31bb3fc1b",
+      "integrity": "sha512-vl3uVda9LrsCnhNpS0NcJQgRHjLKwBVGoEU/oV1PPq0hGjqE833B7JovXN3DgdeM+PGaNcnquF7K51ZY5EHxdw==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=16.0.0",
@@ -1024,16 +1024,16 @@
       "optional": true
     },
     "node_modules/vite": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
-      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.1.tgz",
+      "integrity": "sha512-X/05/cT+VITy2AeDc1der6smvGWWREtL4hPbPTaVbjSBuuWkmNOjR6HP3NzqcQA2nF6VHGUPaFRJyft/2AE9Kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "~1.1.2",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/scripts/viewer/package-lock.json
+++ b/scripts/viewer/package-lock.json
@@ -105,9 +105,9 @@
       "license": "MIT"
     },
     "node_modules/@metanull/islamicart-data": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.6/46ad06af585be912da51e59dc4021bb31bb3fc1b",
-      "integrity": "sha512-vl3uVda9LrsCnhNpS0NcJQgRHjLKwBVGoEU/oV1PPq0hGjqE833B7JovXN3DgdeM+PGaNcnquF7K51ZY5EHxdw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.7/c4417c0796ea45aa2857ca1583354f75af829803",
+      "integrity": "sha512-wFLkhpXuEbNuTLMG76k4RD3O34YvOSnMOwORLoSHkLEPa9dAbvm7p2neyqa8ZB68CISxmqYarkQdxDQVhtJG0Q==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=16.0.0",
@@ -1024,9 +1024,9 @@
       "optional": true
     },
     "node_modules/vite": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.1.tgz",
-      "integrity": "sha512-X/05/cT+VITy2AeDc1der6smvGWWREtL4hPbPTaVbjSBuuWkmNOjR6HP3NzqcQA2nF6VHGUPaFRJyft/2AE9Kg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/viewer/src/views/ItemDetail.vue
+++ b/scripts/viewer/src/views/ItemDetail.vue
@@ -81,15 +81,17 @@ const selectedDynasties = computed(() => {
 // ── Related items ─────────────────────────────────────────────────────
 
 const relatedItems = computed(() => {
-  if (!item.value?.related_item_ids?.length) return []
+  const links = item.value?.related_items ?? []
+  if (!links.length) return []
   const seen = new Set()
-  return item.value.related_item_ids
-    .map(id => itemById.value[id])
-    .filter(it => {
-      if (!it || seen.has(it.id)) return false
+  return links
+    .map(link => {
+      const it = itemById.value[link.id]
+      if (!it || seen.has(it.id)) return null
       seen.add(it.id)
-      return true
+      return { item: it, justifications: link.justifications ?? {} }
     })
+    .filter(Boolean)
 })
 
 // ── Key facts (metadata table), type-conditional field order ─────────
@@ -113,12 +115,12 @@ const keyFacts = computed(() => {
   } else {
     if (tr.location)            facts.push({ label: 'Location',                  value: tr.location })
     if (tr.holder)              facts.push({ label: 'Holding Museum',             value: tr.holder })
-    if (it.owner_reference)     facts.push({ label: 'Museum Inventory Number',    value: it.owner_reference })
     if (tr.dates)               facts.push({ label: 'Date of Object',             value: tr.dates })
-    if (dynastyNames)           facts.push({ label: 'Period / Dynasty',           value: dynastyNames })
-    if (tr.provenance)          facts.push({ label: 'Provenance',                 value: tr.provenance })
+    if (it.owner_reference)     facts.push({ label: 'Museum Inventory Number',    value: it.owner_reference })
     if (tr.type)                facts.push({ label: 'Material(s) / Technique(s)', value: tr.type })
     if (tr.dimensions)          facts.push({ label: 'Dimensions',                 value: tr.dimensions })
+    if (dynastyNames)           facts.push({ label: 'Period / Dynasty',           value: dynastyNames })
+    if (tr.provenance)          facts.push({ label: 'Provenance',                 value: tr.provenance })
     if (tr.owner)               facts.push({ label: 'Owner',                      value: tr.owner })
     if (tr.initial_owner)       facts.push({ label: 'Initial Owner',              value: tr.initial_owner })
     if (tr.place_of_production) facts.push({ label: 'Place of Production',        value: tr.place_of_production })
@@ -136,21 +138,18 @@ const contentSections = computed(() => {
   const sections = []
 
   if (monument) {
-    if (tr.history)     sections.push({ heading: 'History',     value: tr.history })
-    if (tr.description) sections.push({ heading: 'Description', value: tr.description })
+    if (tr.history)               sections.push({ heading: 'History',                        value: tr.history })
+    if (tr.description)           sections.push({ heading: 'Description',                    value: tr.description })
+    if (tr.method_for_datation)   sections.push({ heading: 'How Monument was dated',         value: tr.method_for_datation })
+    if (tr.method_for_provenance) sections.push({ heading: 'How provenance was established', value: tr.method_for_provenance })
+    if (tr.bibliography)          sections.push({ heading: 'Selected bibliography',          value: tr.bibliography })
   } else {
-    if (tr.description) sections.push({ heading: 'Description',       value: tr.description })
-    if (tr.obtention)   sections.push({ heading: 'History / Acquisition', value: tr.obtention })
+    if (tr.description)           sections.push({ heading: 'Description',                          value: tr.description })
+    if (tr.method_for_datation)   sections.push({ heading: 'How date and origin were established', value: tr.method_for_datation })
+    if (tr.obtention)             sections.push({ heading: 'How Object was obtained',              value: tr.obtention })
+    if (tr.method_for_provenance) sections.push({ heading: 'How provenance was established',       value: tr.method_for_provenance })
+    if (tr.bibliography)          sections.push({ heading: 'Selected bibliography',                value: tr.bibliography })
   }
-
-  if (tr.method_for_datation)
-    sections.push({ heading: monument ? 'How Monument Was Dated' : 'How Object Was Dated', value: tr.method_for_datation })
-
-  if (tr.method_for_provenance)
-    sections.push({ heading: monument ? 'How Monument Provenance Was Determined' : 'How Object Provenance Was Determined', value: tr.method_for_provenance })
-
-  if (tr.bibliography)
-    sections.push({ heading: 'Bibliography', value: tr.bibliography })
 
   return sections
 })
@@ -270,7 +269,7 @@ function back() {
         <h2 class="sub-section-title">Related Items</h2>
         <ul class="related-list item-list">
           <li
-            v-for="rel in relatedItems"
+            v-for="{ item: rel, justifications } in relatedItems"
             :key="rel.id"
             class="item-list-row"
             @click="$router.push(`/item/${encodeURIComponent(rel.id)}`)"
@@ -281,6 +280,10 @@ function back() {
             </div>
             <div class="item-list-info">
               <div class="item-list-name">{{ itemLabel(rel) }}</div>
+              <div
+                v-if="justifications[activeLang]"
+                class="item-list-justification"
+              >{{ justifications[activeLang] }}</div>
               <div class="item-list-meta">
                 <span class="item-type-badge">{{ rel.type }}</span>
               </div>
@@ -473,5 +476,13 @@ function back() {
   letter-spacing: 0.06em;
   font-size: 10px;
   color: #888;
+}
+.item-list-justification {
+  font-size: 12px;
+  color: var(--muted);
+  font-style: italic;
+  margin: 2px 0 4px;
+  font-family: Arial, sans-serif;
+  line-height: 1.4;
 }
 </style>


### PR DESCRIPTION
## Summary

- **Context filter**: item translations are now filtered by `context_id` matching the exported project (e.g. `mwnf3:projects:ISL`). This prevents explore-context translations (which have `extra: null`) from overwriting canonical project translations and causing monument `history`/`patrons` fields to disappear.
- **Directed links only**: the `item_item_links` query was fetching both directions (`source_id IN … OR target_id IN …`) and then adding reverse entries to the related-items map, doubling the count. Query is now `WHERE source_id IN (items)` only; reverse insertion removed.
- **Justification captions**: `item_item_link_translations.description` was never exported. The query now LEFT JOINs that table and the output shape changes from `related_item_ids: string[]` to `related_items: { id, justifications: { [lang]: string } }[]`. The viewer renders the justification text below each related item's name.

## Root cause tracing

All three bugs were confirmed by tracing the full pipeline:
legacy MySQL DB → importer → inventory-app DB → exporter → viewer.

The legacy data was correct at every step; all three bugs lived exclusively in the exporter.

## Test plan

- [ ] Re-run the exporter for the ISL project and verify `items.json` output
- [ ] Confirm `object;ISL;eg;Mus01;6` (Kohl Container) has exactly 2 `related_items` entries
- [ ] Confirm each related item entry carries `justifications.en` = `"An example of a kohl container made from different materials."`
- [ ] Confirm monument translations include `history` and `patrons` fields
- [ ] Publish new package version and verify viewer displays justification text under related item thumbnails

🤖 Generated with [Claude Code](https://claude.com/claude-code)