### PR TITLE
fix(viewer): Md rendering

### DIFF
--- a/scripts/viewer/src/composables/useInventoryData.js
+++ b/scripts/viewer/src/composables/useInventoryData.js
@@ -102,10 +102,20 @@ function mdInline(text) {
   return marked.parseInline(text)
 }
 
-// Strip all markdown to plain text (for alt attributes, list badges, etc.)
+// Strip all markdown to plain text (for alt attributes, search matching, etc.)
+// Walks marked's inline token tree directly — no HTML intermediate, no regex.
 function mdStrip(text) {
   if (!text) return ''
-  return marked.parseInline(text).replace(/<[^>]*>/g, '')
+  function tokensToText(tokens) {
+    return tokens.map(t => {
+      if (t.tokens?.length) return tokensToText(t.tokens)
+      if (t.type === 'image') return t.text ?? ''   // alt text
+      if (t.type === 'html') return ''              // discard raw HTML nodes
+      if (t.type === 'br' || t.type === 'softbreak') return ' '
+      return t.text ?? ''
+    }).join('')
+  }
+  return tokensToText(marked.Lexer.lexInline(text))
 }
 
 export function useInventoryData() {

--- a/scripts/viewer/src/composables/useInventoryData.js
+++ b/scripts/viewer/src/composables/useInventoryData.js
@@ -60,24 +60,24 @@ loadEnglishTranslations()
 
 function itemLabel(item) {
   if (!item) return ''
-  return enItemTranslations.value[item.id]?.name ?? item.internal_name ?? item.id
+  return mdStrip(enItemTranslations.value[item.id]?.name ?? item.internal_name ?? item.id)
 }
 
 function countryLabel(countryId) {
   if (!countryId) return ''
   const fallback = countries.value.find(c => c.id === countryId)
-  return enCountryTranslations.value[countryId]?.name ?? fallback?.internal_name ?? countryId
+  return mdStrip(enCountryTranslations.value[countryId]?.name ?? fallback?.internal_name ?? countryId)
 }
 
 function dynastyLabel(dynastyId) {
   if (!dynastyId) return ''
-  return enDynastyTranslations.value[dynastyId]?.name ?? dynastyId
+  return mdStrip(enDynastyTranslations.value[dynastyId]?.name ?? dynastyId)
 }
 
 function partnerLabel(partnerId) {
   if (!partnerId) return ''
   const fallback = partners.value.find(p => p.id === partnerId)
-  return enPartnerTranslations.value[partnerId]?.name ?? fallback?.id ?? partnerId
+  return mdStrip(enPartnerTranslations.value[partnerId]?.name ?? fallback?.id ?? partnerId)
 }
 
 // ── Lookup maps ────────────────────────────────────────────────────────────
@@ -88,11 +88,24 @@ const itemById = computed(() => {
   return m
 })
 
-// ── Markdown helper ────────────────────────────────────────────────────────
+// ── Markdown helpers ───────────────────────────────────────────────────────
 
+// Full block markdown → HTML (for prose sections)
 function md(text) {
   if (!text) return ''
   return marked.parse(text, { breaks: true })
+}
+
+// Inline markdown → HTML without block-level <p> wrapping (for titles, names)
+function mdInline(text) {
+  if (!text) return ''
+  return marked.parseInline(text)
+}
+
+// Strip all markdown to plain text (for alt attributes, list badges, etc.)
+function mdStrip(text) {
+  if (!text) return ''
+  return marked.parseInline(text).replace(/<[^>]*>/g, '')
 }
 
 export function useInventoryData() {
@@ -116,5 +129,7 @@ export function useInventoryData() {
     partnerLabel,
     itemById,
     md,
+    mdInline,
+    mdStrip,
   }
 }

--- a/scripts/viewer/src/views/DatabaseResults.vue
+++ b/scripts/viewer/src/views/DatabaseResults.vue
@@ -8,7 +8,7 @@ const router = useRouter()
 const {
   items, dynasties,
   itemLabel, countryLabel, dynastyLabel,
-  enItemTranslations,
+  enItemTranslations, mdInline,
 } = useInventoryData()
 
 const PAGE_SIZE = 20
@@ -255,7 +255,7 @@ const searchSummary = computed(() => {
             <div v-else class="item-thumb-placeholder" />
           </div>
           <div class="item-list-info">
-            <div class="item-list-name">{{ itemLabel(item) }}</div>
+            <div class="item-list-name" v-html="mdInline(enItemTranslations[item.id]?.name ?? item.internal_name ?? item.id)" />
             <div class="item-list-meta">
               <span v-if="item.country_id">{{ countryLabel(item.country_id) }}</span>
               <span v-if="enItemTranslations[item.id]?.dates">{{ enItemTranslations[item.id].dates }}</span>

--- a/scripts/viewer/src/views/Home.vue
+++ b/scripts/viewer/src/views/Home.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 import { useInventoryData } from '../composables/useInventoryData.js'
 
 const router = useRouter()
-const { items, itemLabel, enItemTranslations } = useInventoryData()
+const { items, itemLabel, enItemTranslations, mdInline } = useInventoryData()
 
 // Pick a random item that has an image, as the featured spotlight
 const featured = computed(() => {
@@ -67,7 +67,7 @@ function goToItem(item) {
         </div>
         <div class="featured-info">
           <p class="featured-type">{{ featured.type }}</p>
-          <h3 class="featured-name">{{ itemLabel(featured) }}</h3>
+          <h3 class="featured-name" v-html="mdInline(enItemTranslations[featured.id]?.name ?? featured.internal_name ?? featured.id)" />
           <p v-if="enItemTranslations[featured.id]?.location" class="featured-meta">
             {{ enItemTranslations[featured.id].location }}
           </p>

--- a/scripts/viewer/src/views/ItemDetail.vue
+++ b/scripts/viewer/src/views/ItemDetail.vue
@@ -13,7 +13,7 @@ const {
   loadLangTranslations,
   itemById,
   itemLabel, countryLabel, partnerLabel,
-  md,
+  md, mdInline,
 } = useInventoryData()
 
 // ── Active item & language ────────────────────────────────────────────
@@ -37,8 +37,14 @@ function t(it) {
   return translationsCache.value[activeLang.value]?.[it.id] ?? {}
 }
 
-function label(it) {
-  return t(it).name ?? it.internal_name ?? it.id
+function labelText(it) {
+  if (!it) return ''
+  return itemLabel(it) // already mdStrip'd
+}
+
+function labelHtml(it) {
+  if (!it) return ''
+  return mdInline(t(it).name ?? it.internal_name ?? it.id)
 }
 
 // ── Dynasties for this item ───────────────────────────────────────────
@@ -201,7 +207,7 @@ function back() {
       <div class="detail-type-badge">{{ item.type }}</div>
 
       <!-- Title -->
-      <h1 class="detail-title">{{ label(item) }}</h1>
+      <h1 class="detail-title" v-html="labelHtml(item)" />
 
       <!-- Images -->
       <div v-if="item.images?.length" class="images">
@@ -253,7 +259,7 @@ function back() {
         <h2 class="sub-section-title">{{ selectedDynasties.length === 1 ? 'Dynasty' : 'Dynasties' }}</h2>
         <div v-for="d in selectedDynasties" :key="d.id" class="dynasty-card">
           <div class="dynasty-header">
-            <span class="dynasty-name">{{ d.name ?? '—' }}</span>
+            <span class="dynasty-name" v-html="d.name ? mdInline(d.name) : '—'" />
             <span v-if="d.also_known_as" class="dynasty-aka">also known as {{ d.also_known_as }}</span>
             <span v-if="d.from_ad || d.to_ad" class="dynasty-dates">
               {{ d.date_description_ad ?? (d.from_ad + (d.to_ad ? ' – ' + d.to_ad : '')) }}
@@ -275,11 +281,11 @@ function back() {
             @click="$router.push(`/item/${encodeURIComponent(rel.id)}`)"
           >
             <div class="item-thumb">
-              <img v-if="rel.images?.length" :src="rel.images[0].url" :alt="itemLabel(rel)" loading="lazy" />
+              <img v-if="rel.images?.length" :src="rel.images[0].url" :alt="labelText(rel)" loading="lazy" />
               <div v-else class="item-thumb-placeholder" />
             </div>
             <div class="item-list-info">
-              <div class="item-list-name">{{ itemLabel(rel) }}</div>
+              <div class="item-list-name" v-html="mdInline(t(rel).name ?? rel.internal_name ?? rel.id)" />
               <div
                 v-if="justifications[activeLang]"
                 class="item-list-justification"

--- a/scripts/viewer/src/views/PcList.vue
+++ b/scripts/viewer/src/views/PcList.vue
@@ -8,7 +8,7 @@ const router = useRouter()
 const {
   items, countries, partners, dynasties,
   countryLabel, dynastyLabel, partnerLabel,
-  itemLabel, enItemTranslations,
+  itemLabel, enItemTranslations, mdInline,
 } = useInventoryData()
 
 const PAGE_SIZE = 20
@@ -218,7 +218,7 @@ const activeFilterLabel = computed(() => {
             <div v-else class="item-thumb-placeholder" />
           </div>
           <div class="item-list-info">
-            <div class="item-list-name">{{ itemLabel(item) }}</div>
+            <div class="item-list-name" v-html="mdInline(enItemTranslations[item.id]?.name ?? item.internal_name ?? item.id)" />
             <div class="item-list-meta">
               <span v-if="item.country_id">{{ countryLabel(item.country_id) }}</span>
               <span v-if="enItemTranslations[item.id]?.dates">{{ enItemTranslations[item.id].dates }}</span>


### PR DESCRIPTION
**`useInventoryData.js`** — two new helpers:
- `mdInline(text)` → `marked.parseInline(text)` — renders inline markdown (`*italic*`, `**bold**`) to HTML without wrapping `<p>` tags. Used with `v-html` in name/heading contexts.
- `mdStrip(text)` → strips all HTML from the inline render — plain text. Used wherever a string is needed (not HTML), such as `alt=""` attributes and computed filter values.

**Label helpers** (`itemLabel`, `countryLabel`, `dynastyLabel`, `partnerLabel`) — now run through `mdStrip`. These functions are used in many contexts (sort keys, filter dropdowns, `alt` text) where raw HTML would be wrong.

**Templates** — every place a name is displayed to the user in a visible heading or list row now uses `v-html` + `mdInline(...)` instead of `{{ itemLabel(...) }}`. This means `*Kohl Container*` renders as *Kohl Container* (italic) rather than showing the asterisks.

The key rule: `{{ }}` for values that must be plain text → use `mdStrip`; `v-html` for visible rendered text → use `mdInline`.