### PR TITLE
feat(provision+ci): Nginx snippet includes and viewer deploy workflow

### DIFF
--- a/.github/workflows/deploy-viewer-ovh.yml
+++ b/.github/workflows/deploy-viewer-ovh.yml
@@ -1,0 +1,89 @@
+name: Deploy Viewer to OVH
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "scripts/viewer/**"
+
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-viewer-ovh
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: read   # Required to pull @metanull/islamicart-data from GitHub Packages
+
+jobs:
+
+  build-and-deploy:
+    name: Build and Deploy islamicart Viewer
+    runs-on: ubuntu-latest
+    environment:
+      name: inventory.metanull.eu
+      url: https://inventory.metanull.eu/islamicart/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "lts/Krypton"
+          registry-url: https://npm.pkg.github.com/
+
+      - name: Install dependencies
+        working-directory: scripts/viewer
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm ci --no-audit --no-fund
+
+      - name: Update data package to latest published version
+        working-directory: scripts/viewer
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Always pull the newest @metanull/islamicart-data regardless of what
+        # is pinned in package-lock.json — the viewer must reflect current data.
+        run: npm install @metanull/islamicart-data@latest --no-audit --no-fund
+
+      - name: Build viewer
+        working-directory: scripts/viewer
+        run: npm run build -- --base=/islamicart/
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.VPS_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Check VPS connectivity
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+        run: |
+          nc -z -w 10 "$VPS_HOST" 22 || \
+            { echo "::error::Cannot reach ${VPS_HOST}:22 — check VPS_HOST and firewall"; exit 1; }
+
+      - name: Verify SSH authentication
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_SSH_USER }}
+        run: |
+          ssh -i ~/.ssh/deploy_key -o ConnectTimeout=10 -o BatchMode=yes \
+            "${VPS_USER}@${VPS_HOST}" whoami || \
+            { echo "::error::SSH auth failed — check VPS_SSH_KEY and VPS_SSH_USER secrets"; exit 1; }
+
+      - name: Deploy to VPS
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_SSH_USER }}
+        run: |
+          scp -i ~/.ssh/deploy_key -o ConnectTimeout=30 -r \
+            scripts/viewer/dist/. "${VPS_USER}@${VPS_HOST}:/opt/islamicart/"
+
+      - name: Cleanup
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -358,6 +358,45 @@ else
     SSL_KEY="/etc/letsencrypt/live/${DOMAIN}/privkey.pem"
 fi
 
+# ── Nginx shared location snippets ──────────────────────────────────────────
+# Location blocks that are identical across all deploy modes (bare-metal/docker)
+# and SSL states live here — written once, included in each vhost variant.
+# Adding a new shared location means editing ONE place, not four.
+info "Writing shared Nginx location snippets..."
+mkdir -p /etc/nginx/snippets
+
+# Quoted delimiter: $uri etc. are Nginx variables and must NOT be shell-expanded.
+cat > /etc/nginx/snippets/inventory-shared-locations.conf << 'SNIPPET'
+# islamicart viewer SPA (Vue 3, hash router — static files at /opt/islamicart)
+# index index.html overrides the server-level "index index.php" so directory
+# requests return the SPA entry point rather than a 403.
+location /islamicart {
+    alias /opt/islamicart;
+    index index.html;
+    try_files $uri $uri/ /islamicart/index.html;
+}
+
+location = /favicon.ico { access_log off; log_not_found off; }
+location = /robots.txt  { access_log off; log_not_found off; }
+
+location ~ /\.(?!well-known).* {
+    deny all;
+}
+SNIPPET
+
+# Unquoted delimiter: ${PHP_VERSION} must expand; \$ escapes Nginx variables.
+cat > /etc/nginx/snippets/inventory-php-handler.conf << SNIPPET
+error_page 404 /index.php;
+
+location ~ \.php\$ {
+    fastcgi_pass unix:/run/php/php${PHP_VERSION}-fpm.sock;
+    fastcgi_param SCRIPT_FILENAME \$realpath_root\$fastcgi_script_name;
+    include fastcgi_params;
+}
+SNIPPET
+info "Nginx snippets written to /etc/nginx/snippets/."
+
+# ── Main vhost config ────────────────────────────────────────────────────────
 if [[ "$DEPLOY_MODE" == "docker" ]]; then
     # Docker mode: Nginx is a reverse proxy to the app container on a loopback port.
     if [[ -f "$SSL_CERT" && -f "$SSL_KEY" ]]; then
@@ -380,11 +419,7 @@ server {
 
     client_max_body_size 20M;
 
-    location /islamicart {
-        alias /opt/islamicart;
-        index index.html;
-        try_files \$uri \$uri/ /islamicart/index.html;
-    }
+    include /etc/nginx/snippets/inventory-shared-locations.conf;
 
     location / {
         proxy_pass         http://127.0.0.1:${DOCKER_APP_PORT};
@@ -407,11 +442,7 @@ server {
 
     client_max_body_size 20M;
 
-    location /islamicart {
-        alias /opt/islamicart;
-        index index.html;
-        try_files \$uri \$uri/ /islamicart/index.html;
-    }
+    include /etc/nginx/snippets/inventory-shared-locations.conf;
 
     location / {
         proxy_pass         http://127.0.0.1:${DOCKER_APP_PORT};
@@ -453,30 +484,13 @@ server {
 
     charset utf-8;
 
-    location /islamicart {
-        alias /opt/islamicart;
-        index index.html;
-        try_files \$uri \$uri/ /islamicart/index.html;
-    }
+    include /etc/nginx/snippets/inventory-shared-locations.conf;
 
     location / {
         try_files \$uri \$uri/ /index.php?\$query_string;
     }
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
-
-    error_page 404 /index.php;
-
-    location ~ \.php\$ {
-        fastcgi_pass unix:/run/php/php${PHP_VERSION}-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME \$realpath_root\$fastcgi_script_name;
-        include fastcgi_params;
-    }
-
-    location ~ /\.(?!well-known).* {
-        deny all;
-    }
+    include /etc/nginx/snippets/inventory-php-handler.conf;
 }
 NGINX
     else
@@ -495,30 +509,13 @@ server {
 
     charset utf-8;
 
-    location /islamicart {
-        alias /opt/islamicart;
-        index index.html;
-        try_files \$uri \$uri/ /islamicart/index.html;
-    }
+    include /etc/nginx/snippets/inventory-shared-locations.conf;
 
     location / {
         try_files \$uri \$uri/ /index.php?\$query_string;
     }
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
-
-    error_page 404 /index.php;
-
-    location ~ \.php\$ {
-        fastcgi_pass unix:/run/php/php${PHP_VERSION}-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME \$realpath_root\$fastcgi_script_name;
-        include fastcgi_params;
-    }
-
-    location ~ /\.(?!well-known).* {
-        deny all;
-    }
+    include /etc/nginx/snippets/inventory-php-handler.conf;
 }
 NGINX
     fi

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -27,8 +27,9 @@
 #   9. Installs Certbot + issues SSL certificate (before Nginx config)
 #   10. Configures Nginx vhost for inventory-app (HTTPS if cert available)
 #   11. Creates the application directory structure (owned by deploy)
-#   12. Creates queue worker systemd service
-#   13. Sets up daily MySQL backup cron
+#   12. Creates /opt/islamicart static-file directory (islamicart viewer SPA)
+#   13. Creates queue worker systemd service
+#   14. Sets up daily MySQL backup cron
 #
 # The 'deploy' user has NO sudo. All privileged operations belong here.
 #
@@ -379,6 +380,12 @@ server {
 
     client_max_body_size 20M;
 
+    location /islamicart {
+        alias /opt/islamicart;
+        index index.html;
+        try_files \$uri \$uri/ /islamicart/index.html;
+    }
+
     location / {
         proxy_pass         http://127.0.0.1:${DOCKER_APP_PORT};
         proxy_http_version 1.1;
@@ -399,6 +406,12 @@ server {
     server_name ${DOMAIN};
 
     client_max_body_size 20M;
+
+    location /islamicart {
+        alias /opt/islamicart;
+        index index.html;
+        try_files \$uri \$uri/ /islamicart/index.html;
+    }
 
     location / {
         proxy_pass         http://127.0.0.1:${DOCKER_APP_PORT};
@@ -440,6 +453,12 @@ server {
 
     charset utf-8;
 
+    location /islamicart {
+        alias /opt/islamicart;
+        index index.html;
+        try_files \$uri \$uri/ /islamicart/index.html;
+    }
+
     location / {
         try_files \$uri \$uri/ /index.php?\$query_string;
     }
@@ -475,6 +494,12 @@ server {
     add_header X-Content-Type-Options "nosniff";
 
     charset utf-8;
+
+    location /islamicart {
+        alias /opt/islamicart;
+        index index.html;
+        try_files \$uri \$uri/ /islamicart/index.html;
+    }
 
     location / {
         try_files \$uri \$uri/ /index.php?\$query_string;
@@ -528,7 +553,20 @@ find "${APP_DIR}/shared/storage" -type d -exec chmod g+s {} +
 info "Application directories created."
 
 # =============================================================================
-# 12. Queue worker systemd service
+# 12. islamicart static-file directory
+# =============================================================================
+info "Creating /opt/islamicart for the islamicart viewer SPA..."
+# The viewer is a static Vue 3 SPA deployed via CI/CD (scp into this directory).
+# Nginx serves it under /islamicart using an alias location block (see step 10).
+# Owned by deploy so the CI/CD user can write files without sudo.
+# World-readable (755/644) so Nginx (www-data) can read without group membership.
+mkdir -p /opt/islamicart
+chown "${DEPLOY_USER}:${DEPLOY_USER}" /opt/islamicart
+chmod 755 /opt/islamicart
+info "/opt/islamicart created (owned by ${DEPLOY_USER}, readable by Nginx)."
+
+# =============================================================================
+# 13. Queue worker systemd service
 # =============================================================================
 info "Creating queue worker systemd service..."
 cat > /etc/systemd/system/inventory-queue.service <<UNIT
@@ -561,7 +599,7 @@ else
 fi
 
 # =============================================================================
-# 13. Daily MySQL backup
+# 14. Daily MySQL backup
 # =============================================================================
 info "Setting up daily MySQL backup..."
 
@@ -614,7 +652,8 @@ info ""
 info "  Deploy user:   ${DEPLOY_USER} (no sudo)"
 info "  App directory: ${APP_DIR} (owned by ${DEPLOY_USER}:www-data)"
 info "  PHP-FPM:       ${PHP_VERSION}"
-info "  Nginx:         configured for ${DOMAIN}"
+info "  Nginx:         configured for ${DOMAIN} (+ /islamicart static SPA)"
+info "  islamicart:    /opt/islamicart (deploy-owned, CI/CD deploys viewer dist here)"
 info ""
 info "  MySQL:         ${DB_NAME} (credentials in ${DB_CREDENTIALS_FILE})"
 info "  Valkey:        localhost:6379 (use REDIS_DB=2, REDIS_CACHE_DB=3)"


### PR DESCRIPTION
## Summary

### `scripts/provision.sh` — Nginx refactor (fixes duplication)
The script previously wrote 4 complete Nginx vhost configs (bare-metal/docker × HTTPS/HTTP), repeating the same location blocks 4 times. Any change required 4 edits — which is exactly what happened when islamicart was added manually.

**Fix:** shared location blocks are now extracted to `/etc/nginx/snippets/`:
- `inventory-shared-locations.conf` — `/islamicart` SPA, favicon, robots, dotfile deny
- `inventory-php-handler.conf` — `error_page` + PHP fastcgi (bare-metal only)

Each vhost variant uses `include` for these. Adding a new shared location now requires editing one file, not four.

Also adds section 12: creates `/opt/islamicart/` (owned by `deploy`, world-readable for Nginx).

### `.github/workflows/deploy-viewer-ovh.yml` — new workflow
Builds and deploys the islamicart viewer SPA automatically on every push to `main` that touches `scripts/viewer/**`, or on `workflow_dispatch`.

- **Token:** `GITHUB_TOKEN` with `packages: read` — no PAT needed (same org)
- **Data:** always installs `@metanull/islamicart-data@latest` — viewer always reflects current published data
- **Build:** `vite build --base=/islamicart/`
- **Deploy:** SCP to `/opt/islamicart/` on VPS using existing `VPS_HOST` / `VPS_SSH_KEY` / `VPS_SSH_USER` secrets from the `inventory.metanull.eu` environment
- Single job (build is ~3s, no reason to split build/deploy like the Laravel pipeline)

## Test plan
- [ ] `bash -n scripts/provision.sh` passes (syntax check)
- [ ] Nginx snippet files are written before the vhost config is tested
- [ ] `nginx -t` passes on re-provision (includes resolve correctly)
- [ ] Workflow triggers on a viewer source change pushed to main
- [ ] `workflow_dispatch` runs successfully and deploys to https://inventory.metanull.eu/islamicart/

🤖 Generated with [Claude Code](https://claude.com/claude-code)