### PR TITLE
Feat(viewer): Partners

### DIFF
--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -38,6 +38,19 @@ interface PartnerLogoRow {
   display_order: number
 }
 
+interface PartnerLevelRow {
+  partner_id: string
+  level: string | null
+}
+
+// Legacy tiers, most to least prominent. A partner attached at multiple
+// levels across the exported projects is reported at its most prominent tier.
+const LEVEL_RANK: Record<string, number> = {
+  partner: 0,
+  associated_partner: 1,
+  minor_contributor: 2,
+}
+
 export class PartnerExporter extends BaseExporter {
   getName(): string {
     return 'Partners'
@@ -72,7 +85,7 @@ export class PartnerExporter extends BaseExporter {
     const partnerPh = this.placeholders(partnerIds.length)
     const langCodeMap = await this.buildLangCodeMap()
 
-    const [translations, images, logos] = await Promise.all([
+    const [translations, images, logos, levels] = await Promise.all([
       this.db.query<PartnerTranslationRow>(
         `SELECT partner_id, language_id, name, description, city_display,
                 contact_website, contact_phone, contact_email_general
@@ -93,6 +106,19 @@ export class PartnerExporter extends BaseExporter {
          WHERE partner_id IN (${partnerPh})
          ORDER BY partner_id, display_order`,
         partnerIds
+      ),
+      // Legacy tier (partner / associated_partner / minor_contributor), scoped to the
+      // collections that represent the exported projects themselves.
+      this.db.query<PartnerLevelRow>(
+        `SELECT cp.partner_id, cp.level
+         FROM collection_partner cp
+         JOIN collections c ON c.id = cp.collection_id
+         JOIN projects proj ON proj.context_id = c.context_id
+         WHERE cp.collection_type = 'project'
+           AND cp.visible = true
+           AND proj.id IN (${ph})
+           AND cp.partner_id IN (${partnerPh})`,
+        [...this.projectIds, ...partnerIds]
       ),
     ])
 
@@ -152,6 +178,16 @@ export class PartnerExporter extends BaseExporter {
       })
     }
 
+    // partner_id -> most prominent level across the exported projects
+    const levelMap = new Map<string, string>()
+    for (const row of levels) {
+      if (!row.level) continue
+      const current = levelMap.get(row.partner_id)
+      if (!current || (LEVEL_RANK[row.level] ?? 99) < (LEVEL_RANK[current] ?? 99)) {
+        levelMap.set(row.partner_id, row.level)
+      }
+    }
+
     const output = partners.map(p => ({
       id: p.id,
       type: p.type,
@@ -160,6 +196,7 @@ export class PartnerExporter extends BaseExporter {
       latitude: p.latitude !== null ? parseFloat(p.latitude) : null,
       longitude: p.longitude !== null ? parseFloat(p.longitude) : null,
       monument_item_id: p.monument_item_id,
+      level: levelMap.get(p.id) ?? null,
       images: imageMap.get(p.id) ?? [],
       logos: logoMap.get(p.id) ?? [],
     }))

--- a/scripts/viewer/src/App.vue
+++ b/scripts/viewer/src/App.vue
@@ -19,6 +19,7 @@ import { RouterView, RouterLink } from 'vue-router'
         <RouterLink to="/permanent-collection" active-class="nav-active">Permanent Collection</RouterLink>
         <RouterLink to="/database" active-class="nav-active">Database</RouterLink>
         <RouterLink to="/timeline" active-class="nav-active">Timeline</RouterLink>
+        <RouterLink to="/partners" active-class="nav-active">Partners</RouterLink>
       </div>
     </nav>
 

--- a/scripts/viewer/src/router/index.js
+++ b/scripts/viewer/src/router/index.js
@@ -6,6 +6,8 @@ import Database from '../views/Database.vue'
 import DatabaseResults from '../views/DatabaseResults.vue'
 import TimelineEntrance from '../views/TimelineEntrance.vue'
 import TimelineResults from '../views/TimelineResults.vue'
+import PartnersEntrance from '../views/PartnersEntrance.vue'
+import PartnersResults from '../views/PartnersResults.vue'
 import ItemDetail from '../views/ItemDetail.vue'
 
 const routes = [
@@ -16,6 +18,8 @@ const routes = [
   { path: '/database/results', component: DatabaseResults },
   { path: '/timeline', component: TimelineEntrance },
   { path: '/timeline/results', component: TimelineResults },
+  { path: '/partners', component: PartnersEntrance },
+  { path: '/partners/results', component: PartnersResults },
   { path: '/item/:id', component: ItemDetail },
 ]
 

--- a/scripts/viewer/src/views/Home.vue
+++ b/scripts/viewer/src/views/Home.vue
@@ -60,6 +60,15 @@ function goToItem(item) {
         </p>
         <span class="home-card-link">Explore →</span>
       </div>
+
+      <div class="home-card content-box" @click="$router.push('/partners')">
+        <h2 class="home-card-title">Partners</h2>
+        <p class="home-card-desc">
+          Meet the partner museums and institutions across the Islamic world
+          that hold and share the objects and monuments in the collection.
+        </p>
+        <span class="home-card-link">Browse →</span>
+      </div>
     </div>
 
     <!-- Featured item spotlight -->

--- a/scripts/viewer/src/views/PartnersEntrance.vue
+++ b/scripts/viewer/src/views/PartnersEntrance.vue
@@ -1,0 +1,62 @@
+<script setup>
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+function browse(type) {
+  router.push({ path: '/partners/results', query: { type } })
+}
+</script>
+
+<template>
+  <div>
+    <h1 class="section-heading">Partners</h1>
+
+    <div class="content-box">
+      <p class="intro-text">
+        Discover Islamic Art is a collaborative project bringing together museums and
+        institutions from across the Islamic world and beyond. Browse the partner
+        museums that lend and hold the objects in the collection, or the partner
+        institutions responsible for the monuments and historic sites.
+      </p>
+
+      <table class="form-table filter-table">
+        <tbody>
+          <tr>
+            <th><label>Partner Museums</label></th>
+            <td>
+              <button class="btn" @click="browse('museum')">Browse Museums →</button>
+            </td>
+          </tr>
+          <tr>
+            <th><label>Partner Institutions</label></th>
+            <td>
+              <button class="btn" @click="browse('institution')">Browse Institutions →</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.intro-text {
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--muted);
+  margin-bottom: 16px;
+  font-family: 'Roboto', sans-serif;
+}
+
+.filter-table th {
+  text-align: left;
+  font-weight: normal;
+  padding: 10px 16px 10px 0;
+  font-family: 'Roboto', sans-serif;
+  font-size: 13px;
+  color: var(--text);
+  vertical-align: middle;
+  width: auto;
+}
+</style>

--- a/scripts/viewer/src/views/PartnersResults.vue
+++ b/scripts/viewer/src/views/PartnersResults.vue
@@ -1,0 +1,152 @@
+<script setup>
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const route = useRoute()
+const { partners, countryLabel, partnerLabel } = useInventoryData()
+
+const filterType = computed(() => (route.query.type === 'institution' ? 'institution' : 'museum'))
+const otherType = computed(() => (filterType.value === 'museum' ? 'institution' : 'museum'))
+const typeLabel = computed(() => (filterType.value === 'museum' ? 'Museums' : 'Institutions'))
+const otherTypeLabel = computed(() => (otherType.value === 'museum' ? 'Partner Museums' : 'Partner Institutions'))
+
+// Associated tiers are nested under the main "Partners" list per country,
+// mirroring the legacy pm_partner_list.php accordion (level is only present
+// once the exporter's partner-hierarchy join has been re-published; a
+// partner without a level is treated as a main partner).
+const groupedByCountry = computed(() => {
+  const byType = partners.value.filter(p => p.type === filterType.value)
+
+  const countries = new Map()
+  for (const p of byType) {
+    const key = p.country_id ?? ''
+    if (!countries.has(key)) countries.set(key, { main: [], associated: [] })
+    const bucket = countries.get(key)
+    if (p.level === 'associated_partner' || p.level === 'minor_contributor') {
+      bucket.associated.push(p)
+    } else {
+      bucket.main.push(p)
+    }
+  }
+
+  return [...countries.entries()]
+    .map(([countryId, group]) => ({
+      countryId,
+      name: countryId ? countryLabel(countryId) : 'Other',
+      main: group.main.sort((a, b) => partnerLabel(a.id).localeCompare(partnerLabel(b.id))),
+      associated: group.associated.sort((a, b) => partnerLabel(a.id).localeCompare(partnerLabel(b.id))),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+const totalCount = computed(() =>
+  groupedByCountry.value.reduce((sum, g) => sum + g.main.length + g.associated.length, 0)
+)
+
+function partnerLink(partner) {
+  return { path: '/permanent-collection/results', query: { partner: partner.id } }
+}
+</script>
+
+<template>
+  <div>
+    <RouterLink to="/partners" class="back-link">‹ Back to Partners</RouterLink>
+
+    <h1 class="section-heading">
+      Partner {{ typeLabel }}
+    </h1>
+
+    <div class="content-box">
+      <p class="result-count">
+        {{ totalCount }} partner{{ totalCount !== 1 ? 's' : '' }} found —
+        <RouterLink :to="{ path: '/partners/results', query: { type: otherType } }">
+          view {{ otherTypeLabel }} instead
+        </RouterLink>
+      </p>
+
+      <div v-if="groupedByCountry.length" class="country-accordion">
+        <details v-for="group in groupedByCountry" :key="group.countryId" class="country-group" open>
+          <summary class="country-head">
+            <h3>{{ group.name }}</h3>
+          </summary>
+
+          <div class="country-body">
+            <div class="partner-col">
+              <p v-for="p in group.main" :key="p.id">
+                <RouterLink :to="partnerLink(p)">{{ partnerLabel(p.id) }}</RouterLink>
+              </p>
+            </div>
+
+            <div v-if="group.associated.length" class="partner-col associated-col">
+              <p class="associated-label">Associated {{ typeLabel }}</p>
+              <p v-for="p in group.associated" :key="p.id">
+                <RouterLink :to="partnerLink(p)">{{ partnerLabel(p.id) }}</RouterLink>
+              </p>
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <p v-else class="no-results">No partner {{ typeLabel.toLowerCase() }} found.</p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.result-count {
+  font-family: 'Roboto', sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.no-results { color: var(--muted); font-family: 'Roboto', sans-serif; font-size: 13px; padding: 20px 0; }
+
+.country-group {
+  border-bottom: 1px solid #e8dcc8;
+  padding: 10px 0;
+}
+.country-group:last-child { border-bottom: none; }
+
+.country-head {
+  cursor: pointer;
+  list-style: none;
+}
+.country-head::-webkit-details-marker { display: none; }
+.country-head h3 {
+  display: inline-block;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--heading);
+  font-family: 'Roboto', sans-serif;
+}
+.country-head h3::before {
+  content: '▸ ';
+  color: var(--gold-dark);
+}
+details[open] > .country-head h3::before { content: '▾ '; }
+
+.country-body {
+  display: flex;
+  gap: 32px;
+  padding: 8px 0 4px 16px;
+  flex-wrap: wrap;
+}
+.partner-col { flex: 1; min-width: 220px; }
+.partner-col p {
+  font-size: 13px;
+  font-family: 'Roboto', sans-serif;
+  padding: 3px 0;
+}
+.associated-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+</style>


### PR DESCRIPTION
**Investigation confirmed the pipeline is sound except for one gap**, which is now fixed:

- The "ISL vs EIAC" concern was unfounded — the `ISL` project already has `backward_compatibility: 'ISL,EPM'`, so exporting `ISL` automatically includes all EIAC/EPM partners and items.
- The real gap was that the partner tier hierarchy (main partner / associated museum / minor contributor) exists in the DB (`collection_partner.level`) but was never exported. Fixed in [partner-exporter.ts](scripts/exporter/src/exporters/partner-exporter.ts) — `partners.json` now carries a `level` field, joined from `collection_partner` scoped to the exported projects, resolving to the most prominent tier when a partner spans multiple projects. Type-checks clean.

**Viewer additions** (mirroring legacy `partners.php` / `pm_partner_list.php`):
- [PartnersEntrance.vue](scripts/viewer/src/views/PartnersEntrance.vue) — splash with Museums/Institutions browse links
- [PartnersResults.vue](scripts/viewer/src/views/PartnersResults.vue) — country-grouped accordion, main partners + nested "Associated" tier, type toggle, partner names link into the Permanent Collection filtered by that partner
- Wired into [router](scripts/viewer/src/router/index.js), the [nav bar](scripts/viewer/src/App.vue), and the [home splash card](scripts/viewer/src/views/Home.vue)

Verified live in the browser: 46 museums / 11 institutions rendering grouped by country, type toggle works, partner→collection linking works, no console errors. Since the installed `@metanull/islamicart-data` package predates this exporter change, all partners currently render at the top "main partner" tier — the associated-museum nesting will populate automatically once the data package is regenerated and republished with the updated exporter, no viewer changes needed.

One acknowledged simplification: legacy nests each associated museum under its *specific* sponsoring main partner; the importer's `collection_partner.level` only captures the tier, not that specific parent link, so the viewer groups by tier-within-country rather than exact sponsor. Reproducing the precise legacy nesting would require additional importer work to carry over legacy's `partner_museums.partner_id` grouping key — flagging this as a possible future refinement, not blocking.