### PR TITLE
Fix/viewer partners

### DIFF
--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -83,16 +83,27 @@ export class PartnerExporter extends BaseExporter {
 
     const ph = this.placeholders(this.projectIds.length)
 
-    // Partners that hold at least one object/monument in these projects.
-    // items.partner_id is the authoritative link: museums hold objects,
-    // institutions hold monuments.
+    // Partners listed in the curated legacy hierarchy (partner_museums/partner_institutions
+    // and their associated/minor tiers, imported into collection_partner) for these projects.
+    // This is deliberately narrower than "owns an item in this project": most institutions
+    // attached to a monument are just the country's generic administrative authority (e.g.
+    // a Ministry of Culture recorded as the monument's owner), not an actual listed project
+    // partner — legacy's Partners page only ever shows the curated hierarchy, never every
+    // institution that happens to own an item.
     const partners = await this.db.query<PartnerRow>(
       `SELECT DISTINCT p.id, p.type, p.internal_name, p.backward_compatibility,
               p.country_id, p.latitude, p.longitude, p.map_zoom, p.monument_item_id
        FROM partners p
-       JOIN items i ON i.partner_id = p.id
-       WHERE i.project_id IN (${ph})
-         AND i.type IN ('object', 'monument', 'detail')
+       WHERE EXISTS (
+         SELECT 1
+         FROM collection_partner cp
+         JOIN collections c ON c.id = cp.collection_id
+         JOIN projects proj ON proj.context_id = c.context_id
+         WHERE cp.collection_type = 'project'
+           AND cp.visible = true
+           AND cp.partner_id = p.id
+           AND proj.id IN (${ph})
+       )
        ORDER BY p.type, p.internal_name`,
       this.projectIds
     )

--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -19,6 +19,7 @@ interface PartnerTranslationRow {
   name: string
   description: string | null
   city_display: string | null
+  address_notes: string | null
   contact_website: string | null
   contact_phone: string | null
   contact_email_general: string | null
@@ -108,7 +109,7 @@ export class PartnerExporter extends BaseExporter {
 
     const [translations, images, logos, levels] = await Promise.all([
       this.db.query<PartnerTranslationRow>(
-        `SELECT partner_id, language_id, name, description, city_display,
+        `SELECT partner_id, language_id, name, description, city_display, address_notes,
                 contact_website, contact_phone, contact_email_general, extra
          FROM partner_translations
          WHERE partner_id IN (${partnerPh})`,
@@ -155,6 +156,7 @@ export class PartnerExporter extends BaseExporter {
           name: t.name,
           description: t.description,
           city: t.city_display,
+          address: t.address_notes,
           website: t.contact_website,
           phone: t.contact_phone,
           email: t.contact_email_general,

--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -9,6 +9,7 @@ interface PartnerRow {
   country_id: string | null
   latitude: string | null
   longitude: string | null
+  map_zoom: number | null
   monument_item_id: string | null
 }
 
@@ -21,6 +22,25 @@ interface PartnerTranslationRow {
   contact_website: string | null
   contact_phone: string | null
   contact_email_general: string | null
+  extra: string | null
+}
+
+interface ContactPerson {
+  name?: string
+  title?: string
+  phone?: string
+  fax?: string
+  email?: string
+}
+
+// Shape written by the importer's museum/institution transformers into
+// partner_translations.extra. Contact persons and extra URLs are legacy
+// fields on the museum/institution row itself (not per-language), so the
+// same values are duplicated across every language row for a given partner.
+interface PartnerExtraFields {
+  contact_person_1?: ContactPerson
+  contact_person_2?: ContactPerson
+  urls?: Array<{ url: string; title?: string }>
 }
 
 interface PartnerImageRow {
@@ -28,6 +48,7 @@ interface PartnerImageRow {
   path: string
   alt_text: string | null
   display_order: number
+  extra: string | null
 }
 
 interface PartnerLogoRow {
@@ -66,7 +87,7 @@ export class PartnerExporter extends BaseExporter {
     // institutions hold monuments.
     const partners = await this.db.query<PartnerRow>(
       `SELECT DISTINCT p.id, p.type, p.internal_name, p.backward_compatibility,
-              p.country_id, p.latitude, p.longitude, p.monument_item_id
+              p.country_id, p.latitude, p.longitude, p.map_zoom, p.monument_item_id
        FROM partners p
        JOIN items i ON i.partner_id = p.id
        WHERE i.project_id IN (${ph})
@@ -88,13 +109,13 @@ export class PartnerExporter extends BaseExporter {
     const [translations, images, logos, levels] = await Promise.all([
       this.db.query<PartnerTranslationRow>(
         `SELECT partner_id, language_id, name, description, city_display,
-                contact_website, contact_phone, contact_email_general
+                contact_website, contact_phone, contact_email_general, extra
          FROM partner_translations
          WHERE partner_id IN (${partnerPh})`,
         partnerIds
       ),
       this.db.query<PartnerImageRow>(
-        `SELECT partner_id, path, alt_text, display_order
+        `SELECT partner_id, path, alt_text, display_order, extra
          FROM partner_images
          WHERE partner_id IN (${partnerPh})
          ORDER BY partner_id, display_order`,
@@ -124,6 +145,8 @@ export class PartnerExporter extends BaseExporter {
 
     // partner_id -> lang_code -> fields
     const translationMap = new Map<string, Record<string, Record<string, string | null>>>()
+    // partner_id -> contact persons / extra URLs (same across languages, take the first seen)
+    const contactMap = new Map<string, PartnerExtraFields>()
     for (const t of translations) {
       if (!translationMap.has(t.partner_id)) translationMap.set(t.partner_id, {})
       const code = langCodeMap.get(t.language_id)
@@ -135,6 +158,16 @@ export class PartnerExporter extends BaseExporter {
           website: t.contact_website,
           phone: t.contact_phone,
           email: t.contact_email_general,
+        }
+      }
+      if (!contactMap.has(t.partner_id) && t.extra) {
+        const extra = parseJson<PartnerExtraFields>(t.extra)
+        if (extra && (extra.contact_person_1 || extra.contact_person_2 || extra.urls)) {
+          contactMap.set(t.partner_id, {
+            contact_person_1: extra.contact_person_1,
+            contact_person_2: extra.contact_person_2,
+            urls: extra.urls,
+          })
         }
       }
     }
@@ -152,14 +185,23 @@ export class PartnerExporter extends BaseExporter {
     // partner_id -> images[]
     const imageMap = new Map<
       string,
-      { url: string; alt_text: string | null; display_order: number }[]
+      {
+        url: string
+        alt_text: string | null
+        display_order: number
+        photographer: string | null
+        copyright: string | null
+      }[]
     >()
     for (const img of images) {
       if (!imageMap.has(img.partner_id)) imageMap.set(img.partner_id, [])
+      const extra = img.extra ? parseJson<{ photographer?: string; copyright?: string }>(img.extra) : null
       imageMap.get(img.partner_id)!.push({
         url: this.imageUrl(img.path),
         alt_text: img.alt_text,
         display_order: img.display_order,
+        photographer: extra?.photographer ?? null,
+        copyright: extra?.copyright ?? null,
       })
     }
 
@@ -195,8 +237,12 @@ export class PartnerExporter extends BaseExporter {
       country_id: p.country_id,
       latitude: p.latitude !== null ? parseFloat(p.latitude) : null,
       longitude: p.longitude !== null ? parseFloat(p.longitude) : null,
+      map_zoom: p.map_zoom,
       monument_item_id: p.monument_item_id,
       level: levelMap.get(p.id) ?? null,
+      contact_person_1: contactMap.get(p.id)?.contact_person_1 ?? null,
+      contact_person_2: contactMap.get(p.id)?.contact_person_2 ?? null,
+      additional_urls: contactMap.get(p.id)?.urls ?? [],
       images: imageMap.get(p.id) ?? [],
       logos: logoMap.get(p.id) ?? [],
     }))
@@ -205,5 +251,13 @@ export class PartnerExporter extends BaseExporter {
     this.logger.success(`partners.json (${output.length} partners)`)
 
     return { file: 'partners.json', count: output.length }
+  }
+}
+
+function parseJson<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return null
   }
 }

--- a/scripts/importer/src/cli/import.ts
+++ b/scripts/importer/src/cli/import.ts
@@ -132,6 +132,7 @@ import {
   ThgTimelineImporter,
   ThgGalleryContentImporter,
   PartnerHierarchyImporter,
+  InstitutionHierarchyImporter,
   Mwnf3ExhibitionImporter,
   Mwnf3ExhibitionTranslationImporter,
   Mwnf3ExhibitionItemImporter,
@@ -220,6 +221,14 @@ const ALL_IMPORTERS: ImporterConfig[] = [
     description:
       'Import partner hierarchy levels (partner/associated/minor) from partner_museums tables',
     importerClass: PartnerHierarchyImporter,
+    dependencies: ['project', 'partner'],
+  },
+  {
+    key: 'institution-hierarchy',
+    name: 'Institution Hierarchy',
+    description:
+      'Import institution hierarchy levels (partner/associated) from partner_institutions tables',
+    importerClass: InstitutionHierarchyImporter,
     dependencies: ['project', 'partner'],
   },
   {

--- a/scripts/importer/src/importers/index.ts
+++ b/scripts/importer/src/importers/index.ts
@@ -18,6 +18,7 @@ export { DynastyImporter } from './phase-01/index.js';
 export { AuthorImporter } from './phase-01/index.js';
 export { SchoolImporter } from './phase-01/index.js';
 export { PartnerHierarchyImporter } from './phase-01/index.js';
+export { InstitutionHierarchyImporter } from './phase-01/index.js';
 export { Mwnf3ExhibitionImporter } from './phase-01/index.js';
 export { Mwnf3ExhibitionTranslationImporter } from './phase-01/index.js';
 export { Mwnf3ExhibitionItemImporter } from './phase-01/index.js';

--- a/scripts/importer/src/importers/phase-01/index.ts
+++ b/scripts/importer/src/importers/phase-01/index.ts
@@ -12,6 +12,7 @@ export { DynastyImporter } from './dynasty-importer.js';
 export { AuthorImporter } from './author-importer.js';
 export { SchoolImporter } from './school-importer.js';
 export { PartnerHierarchyImporter } from './partner-hierarchy-importer.js';
+export { InstitutionHierarchyImporter } from './institution-hierarchy-importer.js';
 export { Mwnf3ExhibitionImporter } from './mwnf3-exhibition-importer.js';
 export { Mwnf3ExhibitionTranslationImporter } from './mwnf3-exhibition-translation-importer.js';
 export { Mwnf3ExhibitionItemImporter } from './mwnf3-exhibition-item-importer.js';

--- a/scripts/importer/src/importers/phase-01/institution-hierarchy-importer.ts
+++ b/scripts/importer/src/importers/phase-01/institution-hierarchy-importer.ts
@@ -1,0 +1,216 @@
+/**
+ * Institution Hierarchy Importer
+ *
+ * Imports institution hierarchy levels from legacy tables:
+ * - mwnf3.partner_institutions (tier 1: partner)
+ * - mwnf3.associated_institutions (tier 2: associated_partner)
+ *
+ * Unlike museums, legacy has no `further_associated_institutions` table, so
+ * there is no `minor_contributor` tier for institutions.
+ *
+ * These map to collection_partner.level in inventory-app.
+ *
+ * This is the curated "Partner Institutions" list shown on the legacy
+ * Partners page — a much narrower set than "every institution that owns an
+ * item in this project" (which is how institutions were included in the
+ * exporter before this importer existed: most institutions own monuments as
+ * the country's generic administrative authority, e.g. a Ministry of
+ * Culture, without being a listed project partner).
+ *
+ * Dependencies:
+ * - ProjectImporter (creates collections from projects)
+ * - PartnerImporter (creates partners from institutions)
+ */
+
+import { BaseImporter } from '../../core/base-importer.js';
+import type { ImportResult } from '../../core/types.js';
+import { formatBackwardCompatibility } from '../../utils/backward-compatibility.js';
+
+const DEFAULT_ASSOCIATED_INSTITUTION_PROJECT_ID = 'ISL';
+
+interface LegacyPartnerInstitution {
+  partner_id: number;
+  project_id: string;
+  institution_id: string;
+  country_id: string;
+}
+
+interface LegacyAssociatedInstitution {
+  associated_id: number;
+  partner_id: number | null;
+  project_id: string | null;
+  institution_id: string;
+  country_id: string;
+}
+
+export class InstitutionHierarchyImporter extends BaseImporter {
+  getName(): string {
+    return 'InstitutionHierarchyImporter';
+  }
+
+  async import(): Promise<ImportResult> {
+    const result = this.createResult();
+
+    try {
+      this.logInfo('Importing institution hierarchy levels...');
+
+      // Import tier 1: partner_institutions → level = 'partner'
+      await this.importPartnerInstitutions(result);
+
+      // Import tier 2: associated_institutions → level = 'associated_partner'
+      await this.importAssociatedInstitutions(result);
+
+      this.showSummary(
+        result.imported,
+        result.skipped,
+        result.errors.length,
+        result.warnings?.length
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.errors.push(`Failed to import institution hierarchy: ${message}`);
+      result.success = false;
+    }
+
+    result.success = result.errors.length === 0;
+    return result;
+  }
+
+  private async importPartnerInstitutions(result: ImportResult): Promise<void> {
+    this.logInfo('Importing tier 1: partner_institutions...');
+
+    const rows = await this.context.legacyDb.query<LegacyPartnerInstitution>(
+      'SELECT partner_id, project_id, institution_id, country_id FROM mwnf3.partner_institutions ORDER BY partner_id'
+    );
+
+    this.logInfo(`Found ${rows.length} partner_institutions rows`);
+
+    for (const row of rows) {
+      try {
+        const imported = await this.attachInstitutionToProject(
+          row.project_id,
+          row.institution_id,
+          row.country_id,
+          'partner'
+        );
+        if (imported) {
+          result.imported++;
+          this.showProgress();
+        } else {
+          result.skipped++;
+          this.showSkipped();
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const bc = `partner_institutions:${row.partner_id}`;
+        result.errors.push(`${bc}: ${message}`);
+        this.logError(`PartnerInstitution ${bc}`, message);
+        this.showError();
+      }
+    }
+  }
+
+  private async importAssociatedInstitutions(result: ImportResult): Promise<void> {
+    this.logInfo('Importing tier 2: associated_institutions...');
+
+    const rows = await this.context.legacyDb.query<LegacyAssociatedInstitution>(
+      'SELECT associated_id, partner_id, project_id, institution_id, country_id FROM mwnf3.associated_institutions ORDER BY associated_id'
+    );
+
+    this.logInfo(`Found ${rows.length} associated_institutions rows`);
+
+    for (const row of rows) {
+      try {
+        const projectId = this.resolveAssociatedInstitutionProjectId(row, result);
+
+        const imported = await this.attachInstitutionToProject(
+          projectId,
+          row.institution_id,
+          row.country_id,
+          'associated_partner'
+        );
+        if (imported) {
+          result.imported++;
+          this.showProgress();
+        } else {
+          result.skipped++;
+          this.showSkipped();
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const bc = `associated_institutions:${row.associated_id}`;
+        result.errors.push(`${bc}: ${message}`);
+        this.logError(`AssociatedInstitution ${bc}`, message);
+        this.showError();
+      }
+    }
+  }
+
+  private resolveAssociatedInstitutionProjectId(
+    row: LegacyAssociatedInstitution,
+    result: ImportResult
+  ): string {
+    if (row.project_id) {
+      return row.project_id;
+    }
+
+    const warning =
+      `associated_institutions id=${row.associated_id} has no project_id, ` +
+      `assigning default legacy project ${DEFAULT_ASSOCIATED_INSTITUTION_PROJECT_ID}`;
+    this.logWarning(warning);
+    result.warnings.push(warning);
+
+    return DEFAULT_ASSOCIATED_INSTITUTION_PROJECT_ID;
+  }
+
+  private async attachInstitutionToProject(
+    projectId: string,
+    institutionId: string,
+    countryId: string,
+    level: string
+  ): Promise<boolean> {
+    // Resolve collection from project
+    const collectionBackwardCompat = formatBackwardCompatibility({
+      schema: 'mwnf3',
+      table: 'projects',
+      pkValues: [projectId],
+    });
+    const collectionId = await this.getEntityUuidAsync(collectionBackwardCompat, 'collection');
+    if (!collectionId) {
+      this.logWarning(
+        `Collection not found for project ${projectId}, skipping institution hierarchy entry`
+      );
+      return false;
+    }
+
+    // Resolve partner from institution
+    const partnerBackwardCompat = formatBackwardCompatibility({
+      schema: 'mwnf3',
+      table: 'institutions',
+      pkValues: [institutionId, countryId],
+    });
+    const partnerId = await this.getEntityUuidAsync(partnerBackwardCompat, 'partner');
+    if (!partnerId) {
+      this.logWarning(
+        `Partner not found for institution ${institutionId}:${countryId}, skipping institution hierarchy entry`
+      );
+      return false;
+    }
+
+    if (this.isDryRun || this.isSampleOnlyMode) {
+      this.logInfo(
+        `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would attach institution ${institutionId}:${countryId} to project ${projectId} with level=${level}`
+      );
+      return true;
+    }
+
+    await this.context.strategy.attachPartnerToCollectionWithLevel(
+      collectionId,
+      partnerId,
+      'project',
+      level
+    );
+
+    return true;
+  }
+}

--- a/scripts/importer/src/strategies/sql-strategy.ts
+++ b/scripts/importer/src/strategies/sql-strategy.ts
@@ -403,8 +403,8 @@ export class SqlWriteStrategy implements IWriteStrategy {
     const sanitized = sanitizeAllStrings(data);
     const id = uuidv4();
     await this.db.execute(
-      `INSERT INTO partner_translations (id, partner_id, language_id, context_id, name, description, city_display, contact_website, contact_phone, contact_email_general, extra, backward_compatibility, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO partner_translations (id, partner_id, language_id, context_id, name, description, city_display, address_notes, contact_website, contact_phone, contact_email_general, extra, backward_compatibility, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         id,
         sanitized.partner_id,
@@ -413,6 +413,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
         sanitized.name,
         sanitized.description,
         sanitized.city_display,
+        sanitized.address,
         sanitized.contact_website,
         sanitized.contact_phone,
         sanitized.contact_email_general,

--- a/scripts/viewer/package-lock.json
+++ b/scripts/viewer/package-lock.json
@@ -105,9 +105,9 @@
       "license": "MIT"
     },
     "node_modules/@metanull/islamicart-data": {
-      "version": "1.0.9",
-      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.9/654d9c344c7ad973cca783a4612a429911d91a8f",
-      "integrity": "sha512-VwJNKpKgnG3AWeu4zF3Znn/UfTWp7wG5GD8emx2ndNyriO49U+XsH4wwyvela8psEPwHQPKEkfbwH9iOqilJ5A==",
+      "version": "1.0.10",
+      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.10/d3cd2d47795481d366216459360675dbb1fd5dc1",
+      "integrity": "sha512-frvjXvsRq3mFgbuU7LfAakXEVp1b/OZZylbkCzYCFF8QsyIW0I1W7sCnn5QSMZrW6SAiyAsRaBF14tY332xM0Q==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=16.0.0",

--- a/scripts/viewer/src/App.vue
+++ b/scripts/viewer/src/App.vue
@@ -20,6 +20,7 @@ import { RouterView, RouterLink } from 'vue-router'
         <RouterLink to="/database" active-class="nav-active">Database</RouterLink>
         <RouterLink to="/timeline" active-class="nav-active">Timeline</RouterLink>
         <RouterLink to="/partners" active-class="nav-active">Partners</RouterLink>
+        <RouterLink to="/dynasties" active-class="nav-active">Dynasties</RouterLink>
       </div>
     </nav>
 

--- a/scripts/viewer/src/router/index.js
+++ b/scripts/viewer/src/router/index.js
@@ -8,6 +8,7 @@ import TimelineEntrance from '../views/TimelineEntrance.vue'
 import TimelineResults from '../views/TimelineResults.vue'
 import PartnersEntrance from '../views/PartnersEntrance.vue'
 import PartnersResults from '../views/PartnersResults.vue'
+import PartnerDetail from '../views/PartnerDetail.vue'
 import ItemDetail from '../views/ItemDetail.vue'
 
 const routes = [
@@ -20,6 +21,7 @@ const routes = [
   { path: '/timeline/results', component: TimelineResults },
   { path: '/partners', component: PartnersEntrance },
   { path: '/partners/results', component: PartnersResults },
+  { path: '/partner/:id', component: PartnerDetail },
   { path: '/item/:id', component: ItemDetail },
 ]
 

--- a/scripts/viewer/src/router/index.js
+++ b/scripts/viewer/src/router/index.js
@@ -9,6 +9,8 @@ import TimelineResults from '../views/TimelineResults.vue'
 import PartnersEntrance from '../views/PartnersEntrance.vue'
 import PartnersResults from '../views/PartnersResults.vue'
 import PartnerDetail from '../views/PartnerDetail.vue'
+import Dynasties from '../views/Dynasties.vue'
+import DynastyDetail from '../views/DynastyDetail.vue'
 import ItemDetail from '../views/ItemDetail.vue'
 
 const routes = [
@@ -22,6 +24,8 @@ const routes = [
   { path: '/partners', component: PartnersEntrance },
   { path: '/partners/results', component: PartnersResults },
   { path: '/partner/:id', component: PartnerDetail },
+  { path: '/dynasties', component: Dynasties },
+  { path: '/dynasty/:id', component: DynastyDetail },
   { path: '/item/:id', component: ItemDetail },
 ]
 

--- a/scripts/viewer/src/views/Dynasties.vue
+++ b/scripts/viewer/src/views/Dynasties.vue
@@ -1,0 +1,138 @@
+<script setup>
+import { computed } from 'vue'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const { dynasties, items, dynastyLabel, enDynastyTranslations } = useInventoryData()
+
+// Only list dynasties actually linked to items in the collection, sorted
+// chronologically (from_ad), mirroring the "Period / Dynasty" ordering
+// already used by the Permanent Collection filters.
+const dynastyList = computed(() => {
+  const ids = new Set(items.value.flatMap(i => i.dynasty_ids))
+  return dynasties.value
+    .filter(d => ids.has(d.id))
+    .map(d => ({
+      ...d,
+      name: dynastyLabel(d.id),
+      also_known_as: enDynastyTranslations.value[d.id]?.also_known_as ?? '',
+      area: enDynastyTranslations.value[d.id]?.area ?? '',
+      date_description_ad: enDynastyTranslations.value[d.id]?.date_description_ad ?? '',
+      itemCount: items.value.filter(i => i.dynasty_ids.includes(d.id)).length,
+    }))
+    .sort((a, b) => (a.from_ad ?? 9999) - (b.from_ad ?? 9999))
+})
+
+function dateRangeLabel(d) {
+  if (d.date_description_ad) return d.date_description_ad
+  if (d.from_ad || d.to_ad) return `${d.from_ad ?? '?'} – ${d.to_ad ?? '?'} AD`
+  return ''
+}
+</script>
+
+<template>
+  <div>
+    <h1 class="section-heading">Islamic Dynasties</h1>
+
+    <div class="content-box">
+      <p class="intro-text">
+        Browse the dynasties and ruling periods of the Islamic world. Select a
+        dynasty below to read its history and see the objects and monuments
+        linked to it.
+      </p>
+
+      <p class="result-count">
+        {{ dynastyList.length }} dynast{{ dynastyList.length !== 1 ? 'ies' : 'y' }}
+      </p>
+
+      <ul v-if="dynastyList.length" class="dynasty-list">
+        <li
+          v-for="d in dynastyList"
+          :key="d.id"
+          class="dynasty-row"
+          @click="$router.push(`/dynasty/${encodeURIComponent(d.id)}`)"
+        >
+          <div class="dynasty-date">{{ dateRangeLabel(d) }}</div>
+          <div class="dynasty-body">
+            <div class="dynasty-name">{{ d.name }}</div>
+            <div v-if="d.also_known_as" class="dynasty-aka">also known as {{ d.also_known_as }}</div>
+            <div v-if="d.area" class="dynasty-area">{{ d.area }}</div>
+          </div>
+          <div class="dynasty-count">{{ d.itemCount }} item{{ d.itemCount !== 1 ? 's' : '' }}</div>
+        </li>
+      </ul>
+
+      <p v-else class="no-results">No dynasties found.</p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.intro-text {
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--muted);
+  margin-bottom: 16px;
+  font-family: 'Roboto', sans-serif;
+}
+
+.result-count {
+  font-family: 'Roboto', sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.no-results { color: var(--muted); font-family: 'Roboto', sans-serif; font-size: 13px; padding: 20px 0; }
+
+.dynasty-list { list-style: none; }
+.dynasty-row {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  padding: 12px 4px;
+  border-bottom: 1px solid #e8dcc8;
+  cursor: pointer;
+}
+.dynasty-row:last-child { border-bottom: none; }
+.dynasty-row:hover .dynasty-name { color: var(--nav-active); }
+
+.dynasty-date {
+  flex-shrink: 0;
+  width: 140px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--heading);
+}
+
+.dynasty-body { flex: 1; min-width: 0; }
+.dynasty-name {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--heading);
+  font-family: 'Roboto', sans-serif;
+}
+.dynasty-aka {
+  font-size: 12px;
+  font-style: italic;
+  color: var(--muted);
+  font-family: 'Roboto', sans-serif;
+  margin-top: 2px;
+}
+.dynasty-area {
+  font-size: 12px;
+  color: var(--muted);
+  font-family: 'Roboto', sans-serif;
+  margin-top: 2px;
+}
+
+.dynasty-count {
+  flex-shrink: 0;
+  font-size: 12px;
+  color: var(--muted);
+  font-family: 'Roboto', sans-serif;
+  white-space: nowrap;
+}
+</style>

--- a/scripts/viewer/src/views/DynastyDetail.vue
+++ b/scripts/viewer/src/views/DynastyDetail.vue
@@ -1,0 +1,265 @@
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const route = useRoute()
+const router = useRouter()
+const {
+  dynasties, items,
+  availableLangs, defaultLang,
+  md, mdInline,
+} = useInventoryData()
+
+const dynasty = computed(() => dynasties.value.find(d => d.id === decodeURIComponent(route.params.id)) ?? null)
+
+// ── Language selector (dynasty translations are loaded on demand, per-lang) ──
+
+const activeLang = ref(defaultLang)
+const dynastyTranslationsCache = ref({})
+
+async function loadDynastyLangTranslations(lang) {
+  if (dynastyTranslationsCache.value[lang]) return
+  try {
+    const m = await import(`@inventory-data/translations/dynasties.${lang}.json`)
+    dynastyTranslationsCache.value = { ...dynastyTranslationsCache.value, [lang]: m.default }
+  } catch {
+    dynastyTranslationsCache.value = { ...dynastyTranslationsCache.value, [lang]: {} }
+  }
+}
+
+onMounted(() => loadDynastyLangTranslations(activeLang.value))
+watch(activeLang, lang => loadDynastyLangTranslations(lang))
+
+const t = computed(() => dynastyTranslationsCache.value[activeLang.value]?.[dynasty.value?.id] ?? {})
+
+// ── Key facts ──────────────────────────────────────────────────────────
+
+const keyFacts = computed(() => {
+  if (!dynasty.value) return []
+  const facts = []
+  if (t.value.also_known_as) facts.push({ label: 'Also known as', value: t.value.also_known_as })
+  if (t.value.area) facts.push({ label: 'Area', value: t.value.area })
+  if (t.value.date_description_ah) facts.push({ label: 'Dates (AH)', value: t.value.date_description_ah })
+  if (t.value.date_description_ad) facts.push({ label: 'Dates (AD)', value: t.value.date_description_ad })
+  return facts
+})
+
+// ── Related items (objects / monuments linked to this dynasty) ─────────
+
+const relatedItems = computed(() => {
+  if (!dynasty.value) return []
+  return items.value.filter(i => i.dynasty_ids.includes(dynasty.value.id))
+})
+
+function relatedItemsLink() {
+  return { path: '/permanent-collection/results', query: { dynasty: dynasty.value.id } }
+}
+
+// ── Timeline (historical cross-reference over the dynasty's date range) ─
+
+const timelineLink = computed(() => {
+  if (!dynasty.value || (dynasty.value.from_ad == null && dynasty.value.to_ad == null)) return null
+  const q = {}
+  if (dynasty.value.from_ad != null) q.begin = String(dynasty.value.from_ad)
+  if (dynasty.value.to_ad != null) q.end = String(dynasty.value.to_ad)
+  return { path: '/timeline/results', query: q }
+})
+
+function back() {
+  if (window.history.length > 2) {
+    router.back()
+  } else {
+    router.push('/dynasties')
+  }
+}
+</script>
+
+<template>
+  <div v-if="!dynasty" class="content-box not-found">
+    <p>Dynasty not found.</p>
+    <router-link to="/dynasties">← Return to Islamic Dynasties</router-link>
+  </div>
+
+  <div v-else class="detail-wrap">
+    <a class="back-link" href="#" @click.prevent="back">← Back to Islamic Dynasties</a>
+
+    <div v-if="availableLangs.length > 1" class="lang-selector">
+      <label class="lang-label">Dynasty language:</label>
+      <select v-model="activeLang" class="lang-select">
+        <option v-for="lang in availableLangs" :key="lang" :value="lang">{{ lang.toUpperCase() }}</option>
+      </select>
+    </div>
+
+    <div class="detail content-box">
+      <h1 class="detail-title" v-html="mdInline(t.name ?? dynasty.id)" />
+
+      <!-- View objects / monuments -->
+      <div v-if="relatedItems.length || timelineLink" class="view-items-row">
+        <RouterLink v-if="relatedItems.length" :to="relatedItemsLink()" class="btn">
+          View Objects &amp; Monuments ({{ relatedItems.length }}) →
+        </RouterLink>
+        <RouterLink v-if="timelineLink" :to="timelineLink" class="homepage-link">
+          View on Timeline →
+        </RouterLink>
+      </div>
+
+      <!-- Key facts table -->
+      <table v-if="keyFacts.length" class="key-facts">
+        <tbody>
+          <tr v-for="fact in keyFacts" :key="fact.label">
+            <th>{{ fact.label }}</th>
+            <td>{{ fact.value }}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- History -->
+      <section v-if="t.history" class="content-section">
+        <h2 class="content-section-heading">History</h2>
+        <div v-html="md(t.history)" class="prose" />
+      </section>
+
+      <!-- Related items -->
+      <div v-if="relatedItems.length" class="related">
+        <h2 class="sub-section-title">Objects &amp; Monuments from this Dynasty</h2>
+        <ul class="related-list item-list">
+          <li
+            v-for="rel in relatedItems.slice(0, 12)"
+            :key="rel.id"
+            class="item-list-row"
+            @click="$router.push(`/item/${encodeURIComponent(rel.id)}`)"
+          >
+            <div class="item-thumb">
+              <img v-if="rel.images?.length" :src="rel.images[0].url" :alt="rel.internal_name ?? ''" loading="lazy" />
+              <div v-else class="item-thumb-placeholder" />
+            </div>
+            <div class="item-list-info">
+              <div class="item-list-name">{{ rel.internal_name ?? rel.id }}</div>
+              <div class="item-list-meta">
+                <span class="item-type-badge">{{ rel.type }}</span>
+              </div>
+            </div>
+          </li>
+        </ul>
+        <RouterLink v-if="relatedItems.length > 12" :to="relatedItemsLink()" class="see-all-link">
+          See all {{ relatedItems.length }} objects &amp; monuments →
+        </RouterLink>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.not-found { color: var(--muted); font-family: 'Roboto', sans-serif; font-size: 13px; }
+
+.detail-wrap { display: flex; flex-direction: column; gap: 10px; }
+
+.lang-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+  justify-content: flex-end;
+}
+.lang-select { font-size: 12px; padding: 3px 6px; }
+
+.detail-title {
+  font-size: 24px;
+  font-weight: 400;
+  color: var(--heading);
+  margin-bottom: 16px;
+  line-height: 1.3;
+  font-family: 'Roboto', sans-serif;
+}
+
+.view-items-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+.homepage-link {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--nav-active);
+  font-family: 'Roboto', sans-serif;
+}
+
+/* Key facts table */
+.key-facts {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+  font-size: 14px;
+}
+.key-facts th,
+.key-facts td {
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  vertical-align: top;
+  text-align: left;
+}
+.key-facts th {
+  background: var(--gold-pale);
+  width: 36%;
+  font-weight: 500;
+  color: var(--heading);
+  font-family: 'Roboto', sans-serif;
+  font-size: 13px;
+  white-space: nowrap;
+}
+.key-facts td { color: var(--text); font-family: 'Roboto', sans-serif; }
+
+/* Content sections */
+.content-section {
+  margin-bottom: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.content-section-heading {
+  font-size: 13px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--heading);
+  margin-bottom: 10px;
+  font-family: 'Roboto', sans-serif;
+}
+
+.prose { font-size: 14px; line-height: 1.7; color: var(--text); font-family: 'Roboto', sans-serif; }
+.prose :deep(p) { margin: 0 0 .75em; }
+.prose :deep(p:last-child) { margin-bottom: 0; }
+
+/* Related items */
+.sub-section-title {
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin-bottom: 10px;
+  font-family: 'Roboto', sans-serif;
+}
+.related { margin-top: 20px; border-top: 1px solid var(--border); padding-top: 16px; }
+.related-list { list-style: none; }
+
+.item-type-badge {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 10px;
+  color: var(--muted);
+  font-family: 'Roboto', sans-serif;
+}
+
+.see-all-link {
+  display: inline-block;
+  margin-top: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--nav-active);
+  font-family: 'Roboto', sans-serif;
+}
+</style>

--- a/scripts/viewer/src/views/Home.vue
+++ b/scripts/viewer/src/views/Home.vue
@@ -69,6 +69,15 @@ function goToItem(item) {
         </p>
         <span class="home-card-link">Browse →</span>
       </div>
+
+      <div class="home-card content-box" @click="$router.push('/dynasties')">
+        <h2 class="home-card-title">Islamic Dynasties</h2>
+        <p class="home-card-desc">
+          Discover the dynasties and ruling periods of the Islamic world, and
+          see the objects and monuments linked to each one.
+        </p>
+        <span class="home-card-link">Explore →</span>
+      </div>
     </div>
 
     <!-- Featured item spotlight -->

--- a/scripts/viewer/src/views/PartnerDetail.vue
+++ b/scripts/viewer/src/views/PartnerDetail.vue
@@ -49,7 +49,7 @@ function viewItemsLink() {
 // ── Contact ────────────────────────────────────────────────────────────
 
 const hasContactInfo = computed(() =>
-  !!(t.value.phone || t.value.email || t.value.website || partner.value?.additional_urls?.length)
+  !!(t.value.address || t.value.phone || t.value.email || t.value.website || partner.value?.additional_urls?.length)
 )
 
 function normalizeUrl(url) {
@@ -145,6 +145,7 @@ function back() {
         <h2 class="content-section-heading">Contact</h2>
 
         <div v-if="hasContactInfo" class="contact-block">
+          <p v-if="t.address" class="contact-address">{{ t.address }}</p>
           <p v-if="t.phone">Phone: {{ t.phone }}</p>
           <p v-if="t.email"><a :href="`mailto:${t.email}`">{{ t.email }}</a></p>
           <p v-if="t.website">
@@ -295,6 +296,7 @@ function back() {
   border-left: 3px solid var(--gold-dark);
 }
 .contact-person-title { font-weight: 500; color: var(--heading); }
+.contact-address { white-space: pre-line; }
 
 .logos { display: flex; gap: 16px; flex-wrap: wrap; align-items: center; }
 .logo-img { max-height: 80px; max-width: 200px; object-fit: contain; }

--- a/scripts/viewer/src/views/PartnerDetail.vue
+++ b/scripts/viewer/src/views/PartnerDetail.vue
@@ -1,0 +1,307 @@
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const route = useRoute()
+const router = useRouter()
+const {
+  partners, items,
+  availableLangs, defaultLang,
+  countryLabel, md, mdInline,
+} = useInventoryData()
+
+const partner = computed(() => partners.value.find(p => p.id === decodeURIComponent(route.params.id)) ?? null)
+
+// ── Language selector (partner translations are loaded on demand, per-lang) ──
+
+const activeLang = ref(defaultLang)
+const partnerTranslationsCache = ref({})
+
+async function loadPartnerLangTranslations(lang) {
+  if (partnerTranslationsCache.value[lang]) return
+  try {
+    const m = await import(`@inventory-data/translations/partners.${lang}.json`)
+    partnerTranslationsCache.value = { ...partnerTranslationsCache.value, [lang]: m.default }
+  } catch {
+    partnerTranslationsCache.value = { ...partnerTranslationsCache.value, [lang]: {} }
+  }
+}
+
+onMounted(() => loadPartnerLangTranslations(activeLang.value))
+watch(activeLang, lang => loadPartnerLangTranslations(lang))
+
+const t = computed(() => partnerTranslationsCache.value[activeLang.value]?.[partner.value?.id] ?? {})
+
+// ── Related items (View Objects / View Monuments) ────────────────────────
+
+const relatedItems = computed(() => {
+  if (!partner.value) return []
+  return items.value.filter(i => i.partner_id === partner.value.id)
+})
+
+const viewItemsLabel = computed(() => (partner.value?.type === 'institution' ? 'View Monuments' : 'View Objects'))
+
+function viewItemsLink() {
+  return { path: '/permanent-collection/results', query: { partner: partner.value.id } }
+}
+
+// ── Contact ────────────────────────────────────────────────────────────
+
+const hasContactInfo = computed(() =>
+  !!(t.value.phone || t.value.email || t.value.website || partner.value?.additional_urls?.length)
+)
+
+function normalizeUrl(url) {
+  return url.startsWith('http') ? url : `http://${url}`
+}
+
+const contactPersons = computed(() => {
+  if (!partner.value) return []
+  return [partner.value.contact_person_1, partner.value.contact_person_2].filter(
+    cp => cp && (cp.name || cp.title)
+  )
+})
+
+// ── Map (OpenStreetMap embed — no API key required) ───────────────────────
+
+const mapEmbedUrl = computed(() => {
+  if (partner.value?.type !== 'museum') return null
+  const { latitude: lat, longitude: lon } = partner.value
+  if (lat == null || lon == null) return null
+  const delta = 0.01
+  const bbox = [lon - delta, lat - delta, lon + delta, lat + delta].join(',')
+  return `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=mapnik&marker=${lat},${lon}`
+})
+
+function imageCredit(img) {
+  const parts = []
+  if (img.copyright) parts.push(`© ${img.copyright}`)
+  if (img.photographer) parts.push(img.photographer)
+  return parts.join(' — ')
+}
+
+function back() {
+  if (window.history.length > 2) {
+    router.back()
+  } else {
+    router.push('/partners')
+  }
+}
+</script>
+
+<template>
+  <div v-if="!partner" class="content-box not-found">
+    <p>Partner not found.</p>
+    <router-link to="/partners">← Return to Partners</router-link>
+  </div>
+
+  <div v-else class="detail-wrap">
+    <a class="back-link" href="#" @click.prevent="back">← Back to Partners</a>
+
+    <div v-if="availableLangs.length > 1" class="lang-selector">
+      <label class="lang-label">Partner language:</label>
+      <select v-model="activeLang" class="lang-select">
+        <option v-for="lang in availableLangs" :key="lang" :value="lang">{{ lang.toUpperCase() }}</option>
+      </select>
+    </div>
+
+    <div class="detail content-box">
+      <div class="detail-type-badge">{{ partner.type }}</div>
+
+      <h1 class="detail-title" v-html="mdInline(t.name ?? partner.id)" />
+      <h2 v-if="t.city || partner.country_id" class="detail-subtitle">
+        <template v-if="t.city">{{ t.city }}<template v-if="partner.country_id">, </template></template>
+        <template v-if="partner.country_id">{{ countryLabel(partner.country_id) }}</template>
+      </h2>
+
+      <!-- View objects / monuments -->
+      <div v-if="relatedItems.length" class="view-items-row">
+        <RouterLink :to="viewItemsLink()" class="btn">{{ viewItemsLabel }} ({{ relatedItems.length }}) →</RouterLink>
+        <a v-if="t.website" :href="normalizeUrl(t.website)" target="_blank" rel="noopener" class="homepage-link">
+          Visit Website ↗
+        </a>
+      </div>
+
+      <!-- Images -->
+      <div v-if="partner.images?.length" class="images">
+        <figure v-for="(img, i) in partner.images" :key="i">
+          <img :src="img.url" :alt="img.alt_text ?? ''" loading="lazy" class="detail-img" />
+          <figcaption v-if="img.alt_text || imageCredit(img)">
+            <span v-if="img.alt_text">{{ img.alt_text }}</span>
+            <span v-if="imageCredit(img)" class="photo-credit">{{ imageCredit(img) }}</span>
+          </figcaption>
+        </figure>
+      </div>
+
+      <!-- About -->
+      <section v-if="t.description" class="content-section">
+        <h2 class="content-section-heading">About</h2>
+        <div v-html="md(t.description)" class="prose" />
+      </section>
+
+      <!-- Contact -->
+      <section v-if="hasContactInfo || contactPersons.length" class="content-section">
+        <h2 class="content-section-heading">Contact</h2>
+
+        <div v-if="hasContactInfo" class="contact-block">
+          <p v-if="t.phone">Phone: {{ t.phone }}</p>
+          <p v-if="t.email"><a :href="`mailto:${t.email}`">{{ t.email }}</a></p>
+          <p v-if="t.website">
+            <a :href="normalizeUrl(t.website)" target="_blank" rel="noopener">{{ t.website }}</a>
+            <template v-for="(u, i) in partner.additional_urls" :key="i">
+              &nbsp;|&nbsp;<a :href="normalizeUrl(u.url)" target="_blank" rel="noopener">{{ u.title ?? u.url }}</a>
+            </template>
+          </p>
+        </div>
+
+        <div v-for="(cp, i) in contactPersons" :key="i" class="contact-block contact-person">
+          <p v-if="cp.title" class="contact-person-title">{{ cp.title }}</p>
+          <p v-if="cp.name">{{ cp.name }}</p>
+          <p v-if="cp.phone">Phone: {{ cp.phone }}</p>
+          <p v-if="cp.fax">Fax: {{ cp.fax }}</p>
+          <p v-if="cp.email"><a :href="`mailto:${cp.email}`">{{ cp.email }}</a></p>
+        </div>
+      </section>
+
+      <!-- Logos -->
+      <section v-if="partner.logos?.length" class="content-section">
+        <h2 class="content-section-heading">Logo</h2>
+        <div class="logos">
+          <img v-for="(logo, i) in partner.logos" :key="i" :src="logo.url" :alt="logo.alt_text ?? ''" class="logo-img" />
+        </div>
+      </section>
+
+      <!-- Map -->
+      <section v-if="mapEmbedUrl" class="content-section">
+        <h2 class="content-section-heading">Map</h2>
+        <iframe class="map-frame" :src="mapEmbedUrl" loading="lazy" title="Partner location map" />
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.not-found { color: var(--muted); font-family: 'Roboto', sans-serif; font-size: 13px; }
+
+.detail-wrap { display: flex; flex-direction: column; gap: 10px; }
+
+.lang-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+  justify-content: flex-end;
+}
+.lang-select { font-size: 12px; padding: 3px 6px; }
+
+.detail-type-badge {
+  display: inline-block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--heading);
+  border: 1px solid var(--gold-dark);
+  padding: 2px 8px;
+  margin-bottom: 10px;
+  font-family: 'Roboto', sans-serif;
+}
+
+.detail-title {
+  font-size: 24px;
+  font-weight: 400;
+  color: var(--heading);
+  margin-bottom: 4px;
+  line-height: 1.3;
+  font-family: 'Roboto', sans-serif;
+}
+.detail-subtitle {
+  font-size: 14px;
+  font-weight: 400;
+  font-style: italic;
+  color: var(--muted);
+  margin-bottom: 16px;
+  font-family: 'Roboto', sans-serif;
+}
+
+.view-items-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+.homepage-link {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--nav-active);
+  font-family: 'Roboto', sans-serif;
+}
+
+/* Images */
+.images {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+.images figure { flex-shrink: 0; }
+.detail-img {
+  width: 180px;
+  height: 140px;
+  object-fit: cover;
+  border: 1px solid var(--border);
+  display: block;
+}
+.images figcaption {
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 4px;
+  width: 180px;
+  font-family: 'Roboto', sans-serif;
+}
+.photo-credit { display: block; }
+
+/* Content sections */
+.content-section {
+  margin-bottom: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.content-section-heading {
+  font-size: 13px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--heading);
+  margin-bottom: 10px;
+  font-family: 'Roboto', sans-serif;
+}
+
+.prose { font-size: 14px; line-height: 1.7; color: var(--text); font-family: 'Roboto', sans-serif; }
+.prose :deep(p) { margin: 0 0 .75em; }
+.prose :deep(p:last-child) { margin-bottom: 0; }
+
+.contact-block {
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--text);
+  font-family: 'Roboto', sans-serif;
+  margin-bottom: 12px;
+}
+.contact-person {
+  padding-left: 12px;
+  border-left: 3px solid var(--gold-dark);
+}
+.contact-person-title { font-weight: 500; color: var(--heading); }
+
+.logos { display: flex; gap: 16px; flex-wrap: wrap; align-items: center; }
+.logo-img { max-height: 80px; max-width: 200px; object-fit: contain; }
+
+.map-frame {
+  width: 100%;
+  height: 380px;
+  border: 1px solid var(--border);
+}
+</style>

--- a/scripts/viewer/src/views/PartnersResults.vue
+++ b/scripts/viewer/src/views/PartnersResults.vue
@@ -45,7 +45,7 @@ const totalCount = computed(() =>
 )
 
 function partnerLink(partner) {
-  return { path: '/permanent-collection/results', query: { partner: partner.id } }
+  return { path: `/partner/${encodeURIComponent(partner.id)}` }
 }
 </script>
 


### PR DESCRIPTION
Feat(viewer): Partner Details

## Pipeline re-analysis: mixed result

**Safe to export — fixed now** (all captured correctly in the DB, just weren't exposed):
- `map_zoom`, `contact_person_1`/`contact_person_2` (name, title, phone, fax, email), and extra website URLs — all sitting in `partner_translations.extra` JSON, now parsed and exported
- Picture `photographer`/`copyright` — sitting in `partner_images.extra`, now exported alongside each image

I extended [partner-exporter.ts](scripts/exporter/src/exporters/partner-exporter.ts) for these (type-checks clean). **You'll need to re-export and republish the data package again** for these fields to show up — the viewer already handles their absence gracefully in the meantime.

**Found a real bug, not just a gap — needs your decision**: the museum/institution street address (legacy `address_`) is computed by the importer's transformer but then **silently dropped**. [sql-strategy.ts:402-425](scripts/importer/src/strategies/sql-strategy.ts:402) `writePartnerTranslation()` never includes `address_line_1`/`address_line_2`/`postal_code`/`address_notes` in its INSERT — those columns exist in the schema but are permanently empty for every partner. This isn't an export-side fix; it needs an importer code change and a **re-run of the import** against the live legacy DB, which I didn't want to do without checking with you first since it writes to your real database. I left the address off the new detail page for now (contact persons, phone, email, and website are all there and cover most of legacy's "Contact" tab).

Want me to fix the importer bug now, or hold off until you're ready to re-run the import?

## Partner Detail page — built and verified

Added [PartnerDetail.vue](scripts/viewer/src/views/PartnerDetail.vue) at route `/partner/:id`, mirroring `pm_partner.php`: type badge, name/city/country header, "View Objects"/"View Monuments" link (count + filtered link into Permanent Collection — this is the link you asked to relocate here), website link, image gallery with photographer/copyright credit, About, Contact (phone/email/website + both contact persons once republished), Logo, and a Map section (OpenStreetMap embed, museums only, no API key needed — Google Maps isn't wired into this project). [PartnersResults.vue](scripts/viewer/src/views/PartnersResults.vue) now links partner names here instead of straight to the item list.

Verified live for both a museum (Algiers, full images/contact/logo/map) and an institution (no map, correct "View Monuments" label) — no console errors.