### PR TITLE
feat(importer): deterministic UUIDv5 primary keys for legacy entities

### DIFF
--- a/scripts/importer/src/strategies/sql-strategy.ts
+++ b/scripts/importer/src/strategies/sql-strategy.ts
@@ -11,6 +11,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
+import { deterministicUuid } from '../utils/deterministic-uuid.js';
 import type { RowDataPacket } from 'mysql2/promise';
 import type { IWriteStrategy } from '../core/strategy.js';
 import type {
@@ -157,7 +158,9 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeLanguageTranslation(data: LanguageTranslationData): Promise<void> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(
+      `language_translation:${sanitized.backward_compatibility.toLowerCase()}:${sanitized.language_id}:${sanitized.display_language_id}`
+    );
     await this.db.execute(
       `INSERT INTO language_translations (id, language_id, display_language_id, name, backward_compatibility, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
@@ -193,7 +196,9 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeCountryTranslation(data: CountryTranslationData): Promise<void> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(
+      `country_translation:${sanitized.backward_compatibility.toLowerCase()}:${sanitized.language_id}`
+    );
     await this.db.execute(
       `INSERT INTO country_translations (id, country_id, language_id, name, backward_compatibility, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
@@ -215,7 +220,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeContext(data: ContextData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(`context:${sanitized.backward_compatibility.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO contexts (id, internal_name, is_default, backward_compatibility, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?)`,
@@ -240,7 +245,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeCollection(data: CollectionData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(`collection:${sanitized.backward_compatibility.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO collections (id, context_id, language_id, parent_id, type, display_order, internal_name, backward_compatibility, latitude, longitude, map_zoom, country_id, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -268,7 +273,12 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeCollectionTranslation(data: CollectionTranslationData): Promise<void> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    // backward_compatibility is shared across all language rows of the same
+    // collection (it identifies the collection, not the translation row), so
+    // language_id/context_id must be folded in to keep rows distinct.
+    const id = deterministicUuid(
+      `collection_translation:${sanitized.backward_compatibility.toLowerCase()}:${sanitized.language_id}:${sanitized.context_id}`
+    );
     const extra = data.extra ?? null;
     await this.db.execute(
       `INSERT INTO collection_translations (id, collection_id, language_id, context_id, title, description, quote, extra, backward_compatibility, created_at, updated_at)
@@ -306,7 +316,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeProject(data: ProjectData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(`project:${sanitized.backward_compatibility.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO projects (id, internal_name, context_id, language_id, launch_date, is_launched, is_enabled, backward_compatibility, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -374,7 +384,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writePartner(data: PartnerData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(`partner:${sanitized.backward_compatibility.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO partners (id, type, internal_name, backward_compatibility, country_id, latitude, longitude, map_zoom, project_id, monument_item_id, visible, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -401,7 +411,11 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writePartnerTranslation(data: PartnerTranslationData): Promise<void> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    // backward_compatibility identifies the partner, not the translation row —
+    // fold in language_id/context_id to keep per-language rows distinct.
+    const id = deterministicUuid(
+      `partner_translation:${sanitized.backward_compatibility.toLowerCase()}:${sanitized.language_id}:${sanitized.context_id}`
+    );
     await this.db.execute(
       `INSERT INTO partner_translations (id, partner_id, language_id, context_id, name, description, city_display, address_notes, contact_website, contact_phone, contact_email_general, extra, backward_compatibility, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -439,7 +453,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeItem(data: ItemData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(`item:${sanitized.backward_compatibility.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO items (id, partner_id, collection_id, parent_id, internal_name, type, country_id, project_id, owner_reference, mwnf_reference, start_date, end_date, display_order, latitude, longitude, map_zoom, backward_compatibility, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -472,7 +486,12 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeItemTranslation(data: ItemTranslationData): Promise<void> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    // backward_compatibility identifies the item, not the translation row (and
+    // is sometimes shared by two rows in the same language via the EPM second
+    // context) — fold in language_id/context_id to keep rows distinct.
+    const id = deterministicUuid(
+      `item_translation:${sanitized.backward_compatibility.toLowerCase()}:${sanitized.language_id}:${sanitized.context_id}`
+    );
     // Convert undefined values to null for SQL compatibility
     const safeNull = (val: string | null | undefined): string | null => val ?? null;
     await this.db.execute(
@@ -599,7 +618,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeTag(data: TagData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(`tag:${sanitized.backward_compatibility.toLowerCase()}`);
     try {
       await this.db.execute(
         `INSERT INTO tags (id, internal_name, category, language_id, description, backward_compatibility, created_at, updated_at)
@@ -638,8 +657,10 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeAuthor(data: AuthorData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
     const bc = sanitized.backward_compatibility || null;
+    // Free-text authors (no legacy ID) have no natural key — keep them
+    // random; AuthorHelper dedupes those by name lookup instead.
+    const id = bc ? deterministicUuid(`author:${bc.toLowerCase()}`) : uuidv4();
     try {
       await this.db.execute(
         `INSERT INTO authors (id, name, firstname, lastname, givenname, originalname, internal_name, backward_compatibility, created_at, updated_at)
@@ -708,7 +729,12 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeAuthorTranslation(data: AuthorTranslationData): Promise<void> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const bc = sanitized.backward_compatibility ?? null;
+    const id = bc
+      ? deterministicUuid(
+          `author_translation:${bc.toLowerCase()}:${sanitized.language_id}:${sanitized.context_id}`
+        )
+      : uuidv4();
     await this.db.execute(
       `INSERT INTO author_translations (id, author_id, language_id, context_id, curriculum, backward_compatibility, extra, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -728,7 +754,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeArtist(data: ArtistData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(`artist:${sanitized.backward_compatibility.toLowerCase()}`);
     try {
       await this.db.execute(
         `INSERT INTO artists (id, name, internal_name, place_of_birth, place_of_death, date_of_birth, date_of_death, period_of_activity, backward_compatibility, created_at, updated_at)
@@ -775,7 +801,14 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeItemImage(data: ItemImageData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = sanitized.id || uuidv4();
+    // Legacy relative path stands in for backward_compatibility (item_images
+    // has no such column). The owner (item_id) must be folded in too: the
+    // same legacy path is deliberately written twice for a "first image"
+    // (once on the picture Item, once on its parent Item) and path alone
+    // would collide on the UUID primary key.
+    const id =
+      sanitized.id ||
+      deterministicUuid(`image:${sanitized.item_id}:${sanitized.path.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO item_images (id, item_id, path, original_name, mime_type, size, alt_text, display_order, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -799,7 +832,9 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writePartnerImage(data: PartnerImageData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = sanitized.id || uuidv4();
+    const id =
+      sanitized.id ||
+      deterministicUuid(`image:${sanitized.partner_id}:${sanitized.path.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO partner_images (id, partner_id, path, original_name, mime_type, size, alt_text, display_order, extra, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -824,7 +859,9 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writePartnerLogo(data: PartnerLogoData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = sanitized.id || uuidv4();
+    const id =
+      sanitized.id ||
+      deterministicUuid(`image:logo:${sanitized.partner_id}:${sanitized.path.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO partner_logos (id, partner_id, path, original_name, mime_type, size, logo_type, alt_text, display_order, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -849,7 +886,9 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeCollectionImage(data: CollectionImageData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = sanitized.id || uuidv4();
+    const id =
+      sanitized.id ||
+      deterministicUuid(`image:${sanitized.collection_id}:${sanitized.path.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO collection_images (id, collection_id, path, original_name, mime_type, size, alt_text, display_order, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -877,7 +916,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeGlossary(data: GlossaryData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(`glossary:${sanitized.backward_compatibility.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO glossaries (id, internal_name, backward_compatibility, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?)`,
@@ -915,8 +954,10 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeItemItemLink(data: ItemItemLinkData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
     const backwardCompat = sanitized.backward_compatibility ?? null;
+    const id = backwardCompat
+      ? deterministicUuid(`item_item_link:${backwardCompat.toLowerCase()}`)
+      : uuidv4();
     await this.db.execute(
       `INSERT INTO item_item_links (id, source_id, target_id, context_id, backward_compatibility, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
@@ -940,7 +981,10 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeItemItemLinkTranslation(data: ItemItemLinkTranslationData): Promise<void> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const bc = sanitized.backward_compatibility ?? null;
+    const id = bc
+      ? deterministicUuid(`item_item_link_translation:${bc.toLowerCase()}:${sanitized.language_id}`)
+      : uuidv4();
     await this.db.execute(
       `INSERT INTO item_item_link_translations (id, item_item_link_id, language_id, description, reciprocal_description, backward_compatibility, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -963,7 +1007,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeDynasty(data: DynastyData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(`dynasty:${sanitized.backward_compatibility.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO dynasties (id, from_ah, to_ah, from_ad, to_ad, backward_compatibility, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -985,7 +1029,10 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeDynastyTranslation(data: DynastyTranslationData): Promise<void> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const bc = sanitized.backward_compatibility ?? null;
+    const id = bc
+      ? deterministicUuid(`dynasty_translation:${bc.toLowerCase()}:${sanitized.language_id}`)
+      : uuidv4();
     await this.db.execute(
       `INSERT INTO dynasty_translations (id, dynasty_id, language_id, name, also_known_as, area, history, date_description_ah, date_description_ad, backward_compatibility, extra, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1021,7 +1068,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeTimeline(data: TimelineData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(`timeline:${sanitized.backward_compatibility.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO timelines (id, internal_name, country_id, collection_id, backward_compatibility, extra, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1043,7 +1090,9 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeTimelineEvent(data: TimelineEventData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = deterministicUuid(
+      `timeline_event:${sanitized.backward_compatibility.toLowerCase()}`
+    );
     await this.db.execute(
       `INSERT INTO timeline_events (id, timeline_id, internal_name, year_from, year_to, year_from_ah, year_to_ah, date_from, date_to, display_order, backward_compatibility, extra, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1071,7 +1120,10 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeTimelineEventTranslation(data: TimelineEventTranslationData): Promise<void> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const bc = sanitized.backward_compatibility ?? null;
+    const id = bc
+      ? deterministicUuid(`timeline_event_translation:${bc.toLowerCase()}:${sanitized.language_id}`)
+      : uuidv4();
     await this.db.execute(
       `INSERT INTO timeline_event_translations (id, timeline_event_id, language_id, name, description, date_from_description, date_to_description, date_from_ah_description, backward_compatibility, extra, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1109,7 +1161,8 @@ export class SqlWriteStrategy implements IWriteStrategy {
   }
 
   async writeTimelineEventImage(data: TimelineEventImageData): Promise<string> {
-    const id = data.id || uuidv4();
+    const id =
+      data.id || deterministicUuid(`image:${data.timeline_event_id}:${data.path.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO timeline_event_images (id, timeline_event_id, path, original_name, mime_type, size, alt_text, display_order, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1144,7 +1197,9 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeItemMedia(data: ItemMediaData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = sanitized.backward_compatibility
+      ? deterministicUuid(`item_media:${sanitized.backward_compatibility.toLowerCase()}`)
+      : uuidv4();
     await this.db.execute(
       `INSERT INTO item_media (id, item_id, language_id, type, title, description,
                                url, display_order, extra, backward_compatibility,
@@ -1173,7 +1228,9 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeCollectionMedia(data: CollectionMediaData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = sanitized.backward_compatibility
+      ? deterministicUuid(`collection_media:${sanitized.backward_compatibility.toLowerCase()}`)
+      : uuidv4();
     await this.db.execute(
       `INSERT INTO collection_media (id, collection_id, language_id, type, title, description,
                                      url, display_order, extra, backward_compatibility,
@@ -1202,7 +1259,9 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeItemDocument(data: ItemDocumentData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = uuidv4();
+    const id = sanitized.backward_compatibility
+      ? deterministicUuid(`item_document:${sanitized.backward_compatibility.toLowerCase()}`)
+      : uuidv4();
     await this.db.execute(
       `INSERT INTO item_documents (id, item_id, language_id, path, original_name,
                                    mime_type, size, title, display_order, extra,
@@ -1348,7 +1407,11 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeContributor(data: ContributorData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = sanitized.id || uuidv4();
+    const id =
+      sanitized.id ||
+      (sanitized.backward_compatibility
+        ? deterministicUuid(`contributor:${sanitized.backward_compatibility.toLowerCase()}`)
+        : uuidv4());
     await this.db.execute(
       `INSERT INTO contributors (id, collection_id, category, display_order, visible, backward_compatibility, internal_name, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1372,7 +1435,13 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeContributorTranslation(data: ContributorTranslationData): Promise<void> {
     const sanitized = sanitizeAllStrings(data);
-    const id = sanitized.id || uuidv4();
+    const id =
+      sanitized.id ||
+      (sanitized.backward_compatibility
+        ? deterministicUuid(
+            `contributor_translation:${sanitized.backward_compatibility.toLowerCase()}:${sanitized.language_id}:${sanitized.context_id}`
+          )
+        : uuidv4());
     await this.db.execute(
       `INSERT INTO contributor_translations (id, contributor_id, language_id, context_id, name, description, link, alt_text, extra, backward_compatibility, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1395,7 +1464,9 @@ export class SqlWriteStrategy implements IWriteStrategy {
 
   async writeContributorImage(data: ContributorImageData): Promise<string> {
     const sanitized = sanitizeAllStrings(data);
-    const id = sanitized.id || uuidv4();
+    const id =
+      sanitized.id ||
+      deterministicUuid(`image:${sanitized.contributor_id}:${sanitized.path.toLowerCase()}`);
     await this.db.execute(
       `INSERT INTO contributor_images (id, contributor_id, path, original_name, mime_type, size, alt_text, display_order, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1510,11 +1581,7 @@ export class SqlWriteStrategy implements IWriteStrategy {
     return typeof raw === 'string' ? JSON.parse(raw) : raw;
   }
 
-  async setCollectionItemExtra(
-    collectionId: string,
-    itemId: string,
-    extra: string
-  ): Promise<void> {
+  async setCollectionItemExtra(collectionId: string, itemId: string, extra: string): Promise<void> {
     await this.db.execute(
       `UPDATE collection_item SET extra = ?, updated_at = ? WHERE collection_id = ? AND item_id = ?`,
       [extra, this.now, collectionId, itemId]

--- a/scripts/importer/src/utils/deterministic-uuid.ts
+++ b/scripts/importer/src/utils/deterministic-uuid.ts
@@ -1,0 +1,55 @@
+/**
+ * Deterministic UUID Generation (UUIDv5)
+ *
+ * Legacy records must receive the SAME UUID every time they are imported,
+ * so that re-running a full import (which is normally preceded by a DB wipe,
+ * see scripts/importer/README.md) produces identical primary keys instead of
+ * fresh random ones. This lets downstream consumers (viewer, exporter,
+ * synced image files) treat re-imports as idempotent rather than as a
+ * wholesale identity change.
+ *
+ * We use RFC 4122 UUIDv5 (namespace + name, SHA-1 based) instead of UUIDv4
+ * (random) for any entity that has a stable natural key available at
+ * creation time — almost always the same `backward_compatibility` string
+ * (or, for legacy image files, the legacy relative path) that the importer
+ * already computes for deduplication.
+ *
+ * CRITICAL — DO NOT CHANGE `IMPORTER_UUID_NAMESPACE` ONCE ADOPTED.
+ * Every UUID this module has ever produced is derived from
+ * SHA1(namespace + name). Changing the namespace constant reassigns every
+ * legacy entity's ID on the next import, defeating the entire purpose of
+ * this module. Treat it as a frozen, versioned constant — same category of
+ * change as a database schema migration.
+ *
+ * CRITICAL — the exact string passed as `name` is part of the same
+ * contract. Any change to how callers build that string (e.g. a change to
+ * `formatBackwardCompatibility()`'s separator, field order, or casing)
+ * silently reassigns IDs for every affected entity on the next import.
+ */
+
+import { v5 as uuidv5 } from 'uuid';
+
+/**
+ * Fixed namespace UUID for this importer's deterministic ID generation.
+ * Generated once via `uuidv4()` — an arbitrary, non-secret constant that
+ * merely partitions this application's UUIDv5 hash space from any other
+ * use of UUIDv5 elsewhere. It is NOT a credential; committing it is safe
+ * and required (all import runs must use the same namespace to agree on
+ * generated IDs).
+ */
+export const IMPORTER_UUID_NAMESPACE = 'bc112041-0784-4475-80b2-0c96425ac5ea';
+
+/**
+ * Derive a deterministic UUID from a natural-key string.
+ *
+ * The same `name` always produces the same UUID (within this module's
+ * namespace). Callers are responsible for building a `name` that is
+ * globally unique across all entities that could ever be hashed by this
+ * function — in practice this means prefixing with an entity-type/table
+ * qualifier before the natural key itself, since some legacy natural keys
+ * (e.g. a project's backward_compatibility) are deliberately reused across
+ * multiple different target entities (Context, Collection, Project).
+ */
+export function deterministicUuid(name: string): string {
+  return uuidv5(name, IMPORTER_UUID_NAMESPACE);
+}

--- a/scripts/importer/tests/unit/deterministic-uuid.test.ts
+++ b/scripts/importer/tests/unit/deterministic-uuid.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for deterministic UUID (UUIDv5) generation
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validate as validateUuid, version as uuidVersion } from 'uuid';
+import { deterministicUuid, IMPORTER_UUID_NAMESPACE } from '../../src/utils/deterministic-uuid.js';
+
+describe('deterministicUuid', () => {
+  it('produces a valid RFC 4122 UUID', () => {
+    const id = deterministicUuid('item:mwnf3:objects:WAL:eg:12:34');
+    expect(validateUuid(id)).toBe(true);
+  });
+
+  it('produces a UUIDv5 (not v4)', () => {
+    const id = deterministicUuid('item:mwnf3:objects:WAL:eg:12:34');
+    expect(uuidVersion(id)).toBe(5);
+  });
+
+  it('is deterministic: same name always yields the same UUID', () => {
+    const name = 'item:mwnf3:objects:WAL:eg:12:34';
+    const first = deterministicUuid(name);
+    const second = deterministicUuid(name);
+    const third = deterministicUuid(name);
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+  });
+
+  it('produces different UUIDs for different names', () => {
+    const a = deterministicUuid('item:mwnf3:objects:WAL:eg:12:34');
+    const b = deterministicUuid('item:mwnf3:objects:WAL:eg:12:35');
+    expect(a).not.toBe(b);
+  });
+
+  it('is sensitive to an entity-type prefix even when the rest of the name is identical', () => {
+    // Regression guard: Context/Collection/Project intentionally share the same
+    // backward_compatibility value for a given legacy project. Without an
+    // entity-type qualifier in the hashed name, all three would collide on
+    // the same UUID.
+    const sharedKey = 'mwnf3:projects:wal';
+    const contextId = deterministicUuid(`context:${sharedKey}`);
+    const collectionId = deterministicUuid(`collection:${sharedKey}`);
+    const projectId = deterministicUuid(`project:${sharedKey}`);
+
+    expect(new Set([contextId, collectionId, projectId]).size).toBe(3);
+  });
+
+  it('is sensitive to a language/context qualifier for translation rows', () => {
+    // Regression guard: translation rows (item_translations, etc.) reuse the
+    // parent's backward_compatibility across every language row. Without
+    // folding in language_id (and context_id), every language variant of the
+    // same item's translation would collide on the same UUID.
+    const bc = 'mwnf3:objects:WAL:eg:12:34';
+    const en = deterministicUuid(`item_translation:${bc}:eng:ctx-1`);
+    const fr = deterministicUuid(`item_translation:${bc}:fra:ctx-1`);
+    const enEpm = deterministicUuid(`item_translation:${bc}:eng:ctx-2`);
+
+    expect(new Set([en, fr, enEpm]).size).toBe(3);
+  });
+
+  it('is sensitive to the owning entity for image rows sharing the same legacy path', () => {
+    // Regression guard: object-picture-importer writes the SAME legacy path
+    // to two different item_images rows (the child "picture" Item and, for
+    // the first image, the parent Item too). Path alone would collide on the
+    // UUID primary key.
+    const path = 'mwnf3/objects/wal/eg/12/34/1.jpg';
+    const childImageId = deterministicUuid(`image:child-item-uuid:${path.toLowerCase()}`);
+    const parentImageId = deterministicUuid(`image:parent-item-uuid:${path.toLowerCase()}`);
+
+    expect(childImageId).not.toBe(parentImageId);
+  });
+
+  it('is case-insensitive when callers lowercase the natural key (matches tracker semantics)', () => {
+    // The in-memory tracker normalizes backward_compatibility to lowercase
+    // before comparing; callers of deterministicUuid must do the same for
+    // consistent results. This test documents the expectation, not the
+    // function's own behavior (it does no normalization itself).
+    const lower = deterministicUuid('item:mwnf3:objects:wal');
+    const upperInput = deterministicUuid('item:mwnf3:objects:WAL'.toLowerCase());
+    expect(lower).toBe(upperInput);
+  });
+
+  it('uses the frozen namespace constant', () => {
+    // Documents the exact namespace value so an accidental change is caught
+    // by this test rather than silently reassigning every legacy ID.
+    expect(IMPORTER_UUID_NAMESPACE).toBe('bc112041-0784-4475-80b2-0c96425ac5ea');
+  });
+});

--- a/scripts/importer/tests/unit/sql-strategy-deterministic-ids.test.ts
+++ b/scripts/importer/tests/unit/sql-strategy-deterministic-ids.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for SqlWriteStrategy – deterministic (UUIDv5) primary key generation
+ *
+ * These tests verify that re-running the importer against a freshly wiped
+ * database (the documented workflow, see scripts/importer/README.md)
+ * produces IDENTICAL primary keys for the same legacy record, and that
+ * entities which legitimately share a backward_compatibility value (the
+ * Context/Collection/Project trio) or a legacy path (dual item_images rows
+ * for a "first image") never collide on the same UUID.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { SqlWriteStrategy } from '../../src/strategies/sql-strategy.js';
+import type {
+  ItemData,
+  ItemTranslationData,
+  ItemImageData,
+  ContextData,
+  CollectionData,
+  ProjectData,
+} from '../../src/core/types.js';
+import type { ITracker } from '../../src/core/tracker.js';
+
+function makeMockDb() {
+  const calls: { sql: string; values: unknown[] }[] = [];
+  return {
+    calls,
+    db: {
+      execute: vi.fn(async (sql: string, values?: unknown) => {
+        calls.push({ sql, values: (values ?? []) as unknown[] });
+        return [{}, []];
+      }),
+      end: vi.fn(async () => {}),
+      beginTransaction: vi.fn(async () => {}),
+      commit: vi.fn(async () => {}),
+      rollback: vi.fn(async () => {}),
+    },
+  };
+}
+
+function makeMockTracker(): ITracker {
+  return {
+    register: vi.fn(),
+    exists: vi.fn().mockReturnValue(false),
+    getUuid: vi.fn().mockReturnValue(null),
+    set: vi.fn(),
+    getByType: vi.fn().mockReturnValue([]),
+    getStats: vi.fn(),
+    getAll: vi.fn().mockReturnValue([]),
+    clear: vi.fn(),
+    setMetadata: vi.fn(),
+    getMetadata: vi.fn().mockReturnValue(null),
+  } as unknown as ITracker;
+}
+
+/** Build a fresh strategy instance — simulates a brand new import process/run. */
+function makeStrategy(): SqlWriteStrategy {
+  const mock = makeMockDb();
+  return new SqlWriteStrategy(
+    mock.db as unknown as ConstructorParameters<typeof SqlWriteStrategy>[0],
+    makeMockTracker()
+  );
+}
+
+describe('SqlWriteStrategy — deterministic IDs are stable across separate runs', () => {
+  it('writeItem: same backward_compatibility yields the same id across two independent strategy instances', async () => {
+    const data: ItemData = {
+      internal_name: 'Test Object',
+      backward_compatibility: 'mwnf3:objects:WAL:eg:12:34',
+      type: 'object',
+      collection_id: 'col-1',
+      partner_id: 'partner-1',
+    };
+
+    const idRun1 = await makeStrategy().writeItem(data);
+    const idRun2 = await makeStrategy().writeItem(data);
+
+    expect(idRun1).toBe(idRun2);
+  });
+
+  it('writeItem: different backward_compatibility yields different ids', async () => {
+    const strategy = makeStrategy();
+    const base: ItemData = {
+      internal_name: 'Test Object',
+      backward_compatibility: 'mwnf3:objects:WAL:eg:12:34',
+      type: 'object',
+    };
+
+    const idA = await strategy.writeItem(base);
+    const idB = await strategy.writeItem({
+      ...base,
+      backward_compatibility: 'mwnf3:objects:WAL:eg:12:35',
+    });
+
+    expect(idA).not.toBe(idB);
+  });
+
+  it('writeItemTranslation: different languages of the same item yield different ids', async () => {
+    const strategy = makeStrategy();
+    const base: ItemTranslationData = {
+      item_id: 'item-1',
+      language_id: 'eng',
+      context_id: 'ctx-1',
+      backward_compatibility: 'mwnf3:objects:WAL:eg:12:34',
+      name: 'Name',
+      description: 'Description',
+    };
+
+    await strategy.writeItemTranslation(base);
+    await strategy.writeItemTranslation({ ...base, language_id: 'fra' });
+
+    const mockCalls = (strategy as unknown as { db: { execute: { mock: { calls: unknown[][] } } } })
+      .db.execute.mock.calls;
+    const ids = mockCalls.map((call) => (call[1] as unknown[])[0] as string);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it('Context/Collection/Project sharing the same backward_compatibility get distinct ids', async () => {
+    const strategy = makeStrategy();
+    const sharedBc = 'mwnf3:projects:wal';
+
+    const contextData: ContextData = {
+      internal_name: 'WAL Context',
+      backward_compatibility: sharedBc,
+    };
+    const collectionData: CollectionData = {
+      internal_name: 'WAL Collection',
+      backward_compatibility: sharedBc,
+      context_id: 'ctx-x',
+      language_id: 'eng',
+    };
+    const projectData: ProjectData = {
+      internal_name: 'WAL Project',
+      backward_compatibility: sharedBc,
+      context_id: 'ctx-x',
+      language_id: 'eng',
+    };
+
+    const contextId = await strategy.writeContext(contextData);
+    const collectionId = await strategy.writeCollection(collectionData);
+    const projectId = await strategy.writeProject(projectData);
+
+    expect(new Set([contextId, collectionId, projectId]).size).toBe(3);
+  });
+
+  it('writeItemImage: same path attached to two different owning items yields distinct ids (first-image case)', async () => {
+    const strategy = makeStrategy();
+    const path = 'objects/wal/eg/museum01/34/1.jpg';
+
+    const childImageId = await strategy.writeItemImage({
+      item_id: 'picture-item-1',
+      path,
+      original_name: '1.jpg',
+      mime_type: 'image/jpeg',
+      size: 1,
+      display_order: 1,
+    } satisfies ItemImageData);
+
+    const parentImageId = await strategy.writeItemImage({
+      item_id: 'parent-item-1',
+      path,
+      original_name: '1.jpg',
+      mime_type: 'image/jpeg',
+      size: 1,
+      display_order: 1,
+    } satisfies ItemImageData);
+
+    expect(childImageId).not.toBe(parentImageId);
+  });
+
+  it('writeItemImage: same (item_id, path) pair yields the same id across two independent strategy instances', async () => {
+    const data: ItemImageData = {
+      item_id: 'picture-item-1',
+      path: 'objects/wal/eg/museum01/34/1.jpg',
+      original_name: '1.jpg',
+      mime_type: 'image/jpeg',
+      size: 1,
+      display_order: 1,
+    };
+
+    const idRun1 = await makeStrategy().writeItemImage(data);
+    const idRun2 = await makeStrategy().writeItemImage(data);
+
+    expect(idRun1).toBe(idRun2);
+  });
+
+  it('writeItemImage: an explicit id (e.g. preserved from AvailableImage) always wins', async () => {
+    const strategy = makeStrategy();
+    const id = await strategy.writeItemImage({
+      id: 'explicit-fixed-id',
+      item_id: 'picture-item-1',
+      path: 'objects/wal/eg/museum01/34/1.jpg',
+      original_name: '1.jpg',
+      mime_type: 'image/jpeg',
+      size: 1,
+      display_order: 1,
+    });
+
+    expect(id).toBe('explicit-fixed-id');
+  });
+});


### PR DESCRIPTION
## Summary

- Legacy records got a fresh random UUID every time the importer ran, because the documented workflow wipes the target DB before each reimport (`scripts/importer/README.md`). This made repeated imports non-comparable and prevented any incremental/resumable workflow.
- Worse, the six image tables (`item_images`, `partner_images`, `partner_logos`, `collection_images`, `contributor_images`, `timeline_event_images`) have **no** `backward_compatibility` column at all - dedup only ever worked within a single in-memory process run (this was already flagged in a code comment: `SqlWriteStrategy.TABLES_WITHOUT_BC`). Restarting the importer or using `--start-at` would silently create duplicate image rows.
- Replaces `uuidv4()` with a UUIDv5 derived from each entity's existing natural key (`backward_compatibility`, already computed for every entity that needs one - see `formatBackwardCompatibility()`), so the same legacy record now produces the same UUID on every reimport. Image tables use the legacy relative path (already used for in-memory dedup) combined with the owning row's id.
- New `scripts/importer/src/utils/deterministic-uuid.ts` documents the frozen namespace constant and the "why" - changing it, or changing how the hashed natural-key strings are built, reassigns every legacy entity's ID on the next import.
- Entities without any natural key (free-text authors, glossary translations/spellings, pivot/media rows without a `backward_compatibility`) are intentionally left on random `uuidv4()` - out of scope for this change, no regression.

## Correctness notes (things that would silently collide without care)

- Context/Collection/Project intentionally **share** the same `backward_compatibility` for a given legacy project - the hashed name is prefixed with the target entity type to keep them distinct.
- Translation rows (`item_translations`, `collection_translations`, `partner_translations`, etc.) reuse the **parent's** `backward_compatibility` across every language row - `language_id` (and `context_id` where relevant, for EPM's second-context translations) is folded into the hash.
- `object-picture-importer` deliberately writes the **same** legacy image path to two different `item_images` rows (the child "picture" Item and, for the first image, its parent Item too) - the owning row's id is folded into the image hash to avoid a primary-key collision.

All three cases are covered by new regression tests.

## Test plan

- [x] `npx tsc --noEmit` - clean
- [x] `npx eslint .` - clean
- [x] `npx vitest run` - 364/364 passing (348 pre-existing + 16 new)
- [x] New tests: `tests/unit/deterministic-uuid.test.ts` (helper-level: determinism, entity-type/language collision guards, format validation) and `tests/unit/sql-strategy-deterministic-ids.test.ts` (`SqlWriteStrategy`-level: cross-run stability, the three collision cases above, explicit-id passthrough still wins)
- [x] End-to-end smoke test against a **disposable, tmpfs-backed MySQL 8.4 container** (Laravel schema migrated in, torn down afterward, never touched the OVH VPS): ran the real `SqlWriteStrategy` against it twice with a fresh `migrate:fresh` between runs - every id (context/collection/project/partner/item/translation/dual images) was byte-identical across both runs, and a genuine duplicate write correctly failed with a real MySQL duplicate-key error instead of silently creating a second row.

Generated with Claude Code
