### PR TITLE
feat(importer): add Dockerized import tool for OVH deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ Homestead.yaml
 # PowerShell Module Build Output
 scripts/MetaNull.LaravelUtils/build/
 
+# Import tool local secrets/backups (never committed)
+scripts/import-tool/.env.import-tool
+scripts/import-tool/auth-backups/
+
 # Task completion reports (temporary files)
 *_COMPLETE.md
 *_TESTING_COMPLETE.md
@@ -92,6 +96,7 @@ coverage
 !.env.local.example
 !.env.testing
 !.env.ci
+!scripts/import-tool/.env.import-tool.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ Homestead.yaml
 scripts/MetaNull.LaravelUtils/build/
 
 # Import tool local secrets/backups (never committed)
-scripts/import-tool/.env.import-tool
+# (scripts/import-tool/.env itself is already covered by the broader .env rule below)
 scripts/import-tool/auth-backups/
 
 # Task completion reports (temporary files)
@@ -96,7 +96,7 @@ coverage
 !.env.local.example
 !.env.testing
 !.env.ci
-!scripts/import-tool/.env.import-tool.example
+!scripts/import-tool/.env.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/scripts/import-tool/.env.example
+++ b/scripts/import-tool/.env.example
@@ -45,7 +45,23 @@ AUTH_SNAPSHOT_REMOTE=/opt/inventory/shared/auth-snapshots/current.json.enc
 # AUTH_SNAPSHOT_BACKUP_HOST_PATH (defaults to ./auth-backups if unset).
 # AUTH_SNAPSHOT_BACKUP_HOST_PATH=./auth-backups
 
+# --- clean mode: fallback account recreation --------------------------------
+# Only used if AUTH_SNAPSHOT_REMOTE does not exist on the OVH host when
+# "clean" runs (i.e. no prior backup-permissions run). Both must be set
+# together or clean refuses to proceed rather than partially creating one
+# account. user:create does not set a plaintext password — it emails a
+# password-reset invitation to that address, and each account gets exactly
+# one fixed role (ADMIN_EMAIL -> "Manager of Users", REGULAR_USER_EMAIL ->
+# "Regular User"). Leave both unset to keep today's behavior (clean fails
+# hard with no snapshot, nothing is created).
+# ADMIN_EMAIL=you@example.com
+# REGULAR_USER_EMAIL=you+regular@example.com
+
 # --- clean mode safety guard -------------------------------------------------
 # Required verbatim for "clean" mode to proceed. Left commented out on
 # purpose — uncomment only when you actually intend to wipe the database.
+# Better: don't set it here at all — pass it inline on the command line only
+# when you mean it (CONFIRM_WIPE=yes-really-wipe-production docker compose
+# ... run --rm clean), so it's a deliberate choice each time, not a standing
+# value that silently authorizes every future run.
 # CONFIRM_WIPE=yes-really-wipe-production

--- a/scripts/import-tool/.env.example
+++ b/scripts/import-tool/.env.example
@@ -1,6 +1,10 @@
-# Copy to .env.import-tool (gitignored) and fill in real values.
+# Copy to .env (gitignored) and fill in real values. Must be named exactly
+# `.env` — Compose only auto-loads that literal filename to resolve the
+# ${VAR} host paths in docker-compose.yml's volumes; a differently-named
+# file only reaches the container's own environment, too late for that.
 # Used by docker-compose.yml. All three modes (append/backup-permissions/clean)
-# read the same file; unused vars for a given mode are simply ignored.
+# read the same file; unused vars for a given mode are simply ignored
+# (backup-permissions doesn't mount LEGACY_IMAGES_HOST_PATH at all).
 
 # --- OVH connection --------------------------------------------------------
 OVH_HOST=51.75.246.163

--- a/scripts/import-tool/.env.import-tool.example
+++ b/scripts/import-tool/.env.import-tool.example
@@ -1,0 +1,47 @@
+# Copy to .env.import-tool (gitignored) and fill in real values.
+# Used by docker-compose.yml. All three modes (append/backup-permissions/clean)
+# read the same file; unused vars for a given mode are simply ignored.
+
+# --- OVH connection --------------------------------------------------------
+OVH_HOST=51.75.246.163
+OVH_USER=deploy
+OVH_APP_DIR=/opt/inventory/current
+OVH_SHARED_DIR=/opt/inventory/shared
+
+# Host path to the deploy SSH private key (Windows example shown).
+# Referenced by docker-compose.yml's volumes section as OVH_SSH_KEY_HOST_PATH.
+OVH_SSH_KEY_HOST_PATH=C:\users\phave\.ssh\inventory_deploy
+
+# --- Target database (reached through the SSH tunnel this container opens) -
+DB_HOST=127.0.0.1
+DB_PORT=3307
+DB_USERNAME=inventory
+DB_PASSWORD=
+DB_DATABASE=inventory
+
+# --- Legacy source ----------------------------------------------------------
+LEGACY_DB_HOST=192.168.255.157
+LEGACY_DB_PORT=3306
+LEGACY_DB_USER=havelpa
+LEGACY_DB_PASSWORD=
+LEGACY_DB_DATABASE=mwnf3
+
+# Host path to the legacy images source. Referenced by docker-compose.yml's
+# volumes section as LEGACY_IMAGES_HOST_PATH — mounted read-only at
+# /legacy-images inside the container (LEGACY_IMAGES_ROOT is set for you).
+LEGACY_IMAGES_HOST_PATH=Z:\mwnf\images
+
+# --- Auth/permissions snapshot ---------------------------------------------
+# Fixed "current" pointer on the OVH host (survives releases). Overwritten by
+# backup-permissions, read by clean's auth:restore step.
+AUTH_SNAPSHOT_REMOTE=/opt/inventory/shared/auth-snapshots/current.json.enc
+
+# Host directory for redundant local, timestamped copies of the snapshot.
+# Referenced by docker-compose.yml's volumes section as
+# AUTH_SNAPSHOT_BACKUP_HOST_PATH (defaults to ./auth-backups if unset).
+# AUTH_SNAPSHOT_BACKUP_HOST_PATH=./auth-backups
+
+# --- clean mode safety guard -------------------------------------------------
+# Required verbatim for "clean" mode to proceed. Left commented out on
+# purpose — uncomment only when you actually intend to wipe the database.
+# CONFIRM_WIPE=yes-really-wipe-production

--- a/scripts/import-tool/Dockerfile
+++ b/scripts/import-tool/Dockerfile
@@ -22,6 +22,17 @@ RUN npm ci
 COPY scripts/importer/tsconfig.json ./
 COPY scripts/importer/src ./src
 
+# language-importer.ts / country-importer.ts resolve these two files via a
+# relative path assuming the full repo checkout (5 levels up from their own
+# source file to the repo root, then database/seeders/data/*.json) — they
+# are NOT importer-owned data, but the importer reads them directly as its
+# single source of truth for reference data (same files a Laravel seeder
+# would use). Placed at /opt/database/seeders/data to land exactly where
+# that relative resolution expects, without pulling in the rest of
+# database/seeders/data (e.g. ~800KB of unrelated dev-seeder sample images).
+COPY database/seeders/data/languages.json /opt/database/seeders/data/languages.json
+COPY database/seeders/data/countries.json /opt/database/seeders/data/countries.json
+
 COPY scripts/import-tool/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/scripts/import-tool/Dockerfile
+++ b/scripts/import-tool/Dockerfile
@@ -1,0 +1,29 @@
+# Dedicated tool image for running the legacy-data import pipeline against
+# the OVH-hosted inventory-app over an SSH tunnel.
+#
+# Build from the REPO ROOT (not this directory), since it needs to copy
+# scripts/importer:
+#   docker build -f scripts/import-tool/Dockerfile -t import-tool:latest .
+
+FROM node:22-alpine
+
+RUN apk add --no-cache openssh-client rsync bash
+
+WORKDIR /opt/import-tool/importer
+
+# Install importer dependencies first (better layer caching on source changes).
+# NOT --omit=dev: tsx (the TypeScript runner this CLI is invoked through) is
+# a devDependency but genuinely needed at runtime here — omitting it forces
+# `npx tsx` to silently fetch an unpinned copy from the registry on every run.
+COPY scripts/importer/package.json scripts/importer/package-lock.json ./
+RUN npm ci
+
+# Importer source. tsx runs TypeScript directly — no build step.
+COPY scripts/importer/tsconfig.json ./
+COPY scripts/importer/src ./src
+
+COPY scripts/import-tool/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["append"]

--- a/scripts/import-tool/Dockerfile.dockerignore
+++ b/scripts/import-tool/Dockerfile.dockerignore
@@ -1,0 +1,11 @@
+# Docker BuildKit picks this up automatically for `-f scripts/import-tool/Dockerfile`
+# builds (in addition to the repo-root .dockerignore, which already excludes
+# node_modules/.git/.env). Only the importer's source is needed at runtime.
+scripts/importer/node_modules
+scripts/importer/dist
+scripts/importer/logs
+scripts/importer/gap_analysis
+scripts/importer/tests
+scripts/importer/temp_todo*.md
+scripts/importer/.env
+scripts/importer/.env.*

--- a/scripts/import-tool/README.md
+++ b/scripts/import-tool/README.md
@@ -1,15 +1,9 @@
 # Import Tool
 
-Dockerized replacement for the legacy-data import pipeline against the
-OVH-hosted `inventory-app`. Runs the [importer](../importer/README.md)
-(`import`, `image-sync`) over an SSH tunnel and drives the remote
-`artisan` commands over blocking SSH calls — no more fire-and-forget
-windows, no manual `scp`, no dependency on `rsync` existing on the
-operator's machine (it doesn't, on Windows; this container has it).
-
-Supersedes `scripts/ImportLegacy.ps1` (removed — it had a serious bug: it
-launched a sequence of dependent `artisan` commands via `Start-Process`
-with no `-Wait`, so they could run out of order or overlap).
+Dockerized legacy-data import pipeline against the OVH-hosted `inventory-app`.
+Runs the [importer](../importer/README.md) (`import`, `image-sync`) over an SSH
+tunnel and drives the remote `artisan` commands over blocking SSH calls, no 
+manual `scp`, no dependency on `rsync` existing on the operator's machine.
 
 ## Modes
 
@@ -31,12 +25,21 @@ docker build -f scripts/import-tool/Dockerfile -t import-tool:latest .
 ## Configure
 
 ```bash
-cp scripts/import-tool/.env.import-tool.example scripts/import-tool/.env.import-tool
-# edit scripts/import-tool/.env.import-tool with real credentials/paths
+cp scripts/import-tool/.env.example scripts/import-tool/.env
+# edit scripts/import-tool/.env with real credentials/paths
 ```
 
-`.env.import-tool` is gitignored. See the `.example` file for every
-variable and what it's for — the important ones:
+The file must be named exactly `.env` (not e.g. `.env.import-tool`) —
+Docker Compose only auto-loads a file with that literal name to resolve
+`${VAR}` placeholders while parsing `docker-compose.yml` itself (used
+below for the `volumes:` host paths), which is a separate step from
+`env_file:` injecting variables into the container. A differently-named
+file works for the container's own environment but silently leaves the
+volume paths empty, which Docker then rejects with something like
+`invalid spec: :/run/secrets/deploy_key:ro: empty section between colons`.
+
+`.env` is gitignored. See `.env.example` for every variable and what
+it's for — the important ones:
 
 - `OVH_SSH_KEY_HOST_PATH` — host path to the `deploy` SSH private key
 - `LEGACY_IMAGES_HOST_PATH` — host path to the legacy images source
@@ -48,7 +51,7 @@ variable and what it's for — the important ones:
 
 ## Run
 
-Via compose (recommended — reads `.env.import-tool` for you):
+Via compose (recommended — reads `.env` for you):
 
 ```bash
 docker compose -f scripts/import-tool/docker-compose.yml run --rm append

--- a/scripts/import-tool/README.md
+++ b/scripts/import-tool/README.md
@@ -11,7 +11,7 @@ manual `scp`, no dependency on `rsync` existing on the operator's machine.
 |---|---|
 | `append` (default) | `import` → `image-sync` → `glossary:resync`, no wipe. Safe to run any time — the importer is idempotent, this only adds what's missing. |
 | `backup-permissions` | Snapshots users (incl. MFA columns), role assignments, direct permission assignments, and API tokens to an encrypted JSON on the OVH host, plus a redundant timestamped copy pulled back locally. No import, no writes to application data. |
-| `clean` | `db:wipe` → `migrate` → `db:seed` → `permission:sync` → `auth:restore` → the full `append` pipeline. **Destructive.** Requires a snapshot already at `AUTH_SNAPSHOT_REMOTE` (run `backup-permissions` first — `clean` does not take a fresh snapshot itself) and requires `CONFIRM_WIPE=yes-really-wipe-production` or it refuses to run. |
+| `clean` | `db:wipe` → `migrate` → `db:seed` → `permission:sync` → restore users → the full `append` pipeline. **Destructive.** Requires `CONFIRM_WIPE=yes-really-wipe-production` or it refuses to run. Restores from a snapshot at `AUTH_SNAPSHOT_REMOTE` if one exists (run `backup-permissions` first to create it — `clean` does not take a fresh snapshot itself); if none exists **and** both `ADMIN_EMAIL`/`REGULAR_USER_EMAIL` are set, falls back to recreating just those two accounts instead. If neither applies, aborts before anything beyond the wipe itself is lost. |
 
 ## Build
 
@@ -74,12 +74,30 @@ docker run --rm \
 
 ## Before your first `clean`
 
-`clean` restores users/permissions from a snapshot that must already
-exist — it does not take one itself. Run `backup-permissions` at least
-once first. If no snapshot exists at `AUTH_SNAPSHOT_REMOTE`,
-`auth:restore` fails cleanly with "snapshot not found" and the whole
-pipeline aborts before the wipe does any further damage — but you still
-want a real snapshot, not just a clean failure.
+Best case: run `backup-permissions` at least once before your first
+`clean`, so there's a real snapshot to restore from — this preserves
+*every* existing user, MFA setup, and role/permission assignment exactly
+as they were.
+
+If you skip that (or the snapshot is missing for any other reason),
+`clean` checks whether `AUTH_SNAPSHOT_REMOTE` actually exists on the OVH
+host *before* calling `auth:restore` — it does not just let the restore
+fail and stop there. If nothing exists and both `ADMIN_EMAIL` and
+`REGULAR_USER_EMAIL` are set (see `.env.example`), it recreates exactly
+those two accounts instead — one with the `Manager of Users` role
+(admin panel + user/role/settings management), one with `Regular User`
+(data operations only). Neither account gets a plaintext password:
+`user:create` emails a password-reset invitation to that address, so you
+still need working outbound mail on OVH for this to be usable.
+
+If neither a snapshot nor both fallback emails are available, `clean`
+aborts right there — after the wipe, but before anything else happens —
+with a clear message telling you what's missing. **Note this means a
+`clean` run without a snapshot and without the fallback configured still
+leaves the `users` table empty** (`db:seed`'s `UserSeeder` only creates
+accounts when `APP_ENV=local`, i.e. never on production) — there is no
+way to log into `/admin` again until you either supply a snapshot or set
+the fallback emails and re-run.
 
 ## Dry runs
 

--- a/scripts/import-tool/README.md
+++ b/scripts/import-tool/README.md
@@ -49,14 +49,29 @@ it's for — the important ones:
 - `LEGACY_DB_*` — legacy source DB
 - `CONFIRM_WIPE` — leave commented out; only set for a real `clean` run
 
-## Run
+## Run (TL;DR)
 
-Via compose (recommended — reads `.env` for you):
+```powershell
+$env:CONFIRM_WIPE='yes-really-wipe-production'
+docker compose -f scripts/import-tool/docker-compose.yml run --build --rm clean
+```
+
+`--build` matters: `docker compose run` only builds the image if it
+doesn't exist yet — it does **not** notice that `entrypoint.sh` or the
+`importer` source changed since the last build, and will silently keep
+running the old one. Always include `--build` after pulling changes to
+this tool (or run `docker compose -f scripts/import-tool/docker-compose.yml
+build` once beforehand) to be sure you're running current code.
+
+## Run
+Via compose (recommended — reads `.env` for you). Include `--build` any
+time `entrypoint.sh` or the importer source has changed since your last
+build — `docker compose run` does not detect that on its own:
 
 ```bash
-docker compose -f scripts/import-tool/docker-compose.yml run --rm append
-docker compose -f scripts/import-tool/docker-compose.yml run --rm backup-permissions
-docker compose -f scripts/import-tool/docker-compose.yml run --rm clean
+docker compose -f scripts/import-tool/docker-compose.yml run --build --rm append
+docker compose -f scripts/import-tool/docker-compose.yml run --build --rm backup-permissions
+docker compose -f scripts/import-tool/docker-compose.yml run --build --rm clean
 ```
 
 Or raw `docker run` (Windows paths shown):

--- a/scripts/import-tool/README.md
+++ b/scripts/import-tool/README.md
@@ -5,6 +5,20 @@ Runs the [importer](../importer/README.md) (`import`, `image-sync`) over an SSH
 tunnel and drives the remote `artisan` commands over blocking SSH calls, no 
 manual `scp`, no dependency on `rsync` existing on the operator's machine.
 
+## Run (TL;DR)
+
+```powershell
+$env:CONFIRM_WIPE='yes-really-wipe-production'
+docker compose -f scripts/import-tool/docker-compose.yml run --build --rm clean
+```
+
+`--build` matters: `docker compose run` only builds the image if it
+doesn't exist yet — it does **not** notice that `entrypoint.sh` or the
+`importer` source changed since the last build, and will silently keep
+running the old one. Always include `--build` after pulling changes to
+this tool (or run `docker compose -f scripts/import-tool/docker-compose.yml
+build` once beforehand) to be sure you're running current code.
+
 ## Modes
 
 | Mode | What it does |
@@ -48,20 +62,6 @@ it's for — the important ones:
   (`DB_HOST=127.0.0.1`, `DB_PORT` matching `TUNNEL_LOCAL_PORT`, default `3307`)
 - `LEGACY_DB_*` — legacy source DB
 - `CONFIRM_WIPE` — leave commented out; only set for a real `clean` run
-
-## Run (TL;DR)
-
-```powershell
-$env:CONFIRM_WIPE='yes-really-wipe-production'
-docker compose -f scripts/import-tool/docker-compose.yml run --build --rm clean
-```
-
-`--build` matters: `docker compose run` only builds the image if it
-doesn't exist yet — it does **not** notice that `entrypoint.sh` or the
-`importer` source changed since the last build, and will silently keep
-running the old one. Always include `--build` after pulling changes to
-this tool (or run `docker compose -f scripts/import-tool/docker-compose.yml
-build` once beforehand) to be sure you're running current code.
 
 ## Run
 Via compose (recommended — reads `.env` for you). Include `--build` any

--- a/scripts/import-tool/README.md
+++ b/scripts/import-tool/README.md
@@ -1,0 +1,123 @@
+# Import Tool
+
+Dockerized replacement for the legacy-data import pipeline against the
+OVH-hosted `inventory-app`. Runs the [importer](../importer/README.md)
+(`import`, `image-sync`) over an SSH tunnel and drives the remote
+`artisan` commands over blocking SSH calls — no more fire-and-forget
+windows, no manual `scp`, no dependency on `rsync` existing on the
+operator's machine (it doesn't, on Windows; this container has it).
+
+Supersedes `scripts/ImportLegacy.ps1` (removed — it had a serious bug: it
+launched a sequence of dependent `artisan` commands via `Start-Process`
+with no `-Wait`, so they could run out of order or overlap).
+
+## Modes
+
+| Mode | What it does |
+|---|---|
+| `append` (default) | `import` → `image-sync` → `glossary:resync`, no wipe. Safe to run any time — the importer is idempotent, this only adds what's missing. |
+| `backup-permissions` | Snapshots users (incl. MFA columns), role assignments, direct permission assignments, and API tokens to an encrypted JSON on the OVH host, plus a redundant timestamped copy pulled back locally. No import, no writes to application data. |
+| `clean` | `db:wipe` → `migrate` → `db:seed` → `permission:sync` → `auth:restore` → the full `append` pipeline. **Destructive.** Requires a snapshot already at `AUTH_SNAPSHOT_REMOTE` (run `backup-permissions` first — `clean` does not take a fresh snapshot itself) and requires `CONFIRM_WIPE=yes-really-wipe-production` or it refuses to run. |
+
+## Build
+
+Build context must be the **repo root** (the Dockerfile copies
+`scripts/importer`):
+
+```bash
+docker build -f scripts/import-tool/Dockerfile -t import-tool:latest .
+```
+
+## Configure
+
+```bash
+cp scripts/import-tool/.env.import-tool.example scripts/import-tool/.env.import-tool
+# edit scripts/import-tool/.env.import-tool with real credentials/paths
+```
+
+`.env.import-tool` is gitignored. See the `.example` file for every
+variable and what it's for — the important ones:
+
+- `OVH_SSH_KEY_HOST_PATH` — host path to the `deploy` SSH private key
+- `LEGACY_IMAGES_HOST_PATH` — host path to the legacy images source
+  (whatever `Z:\mwnf\images` resolves to on your machine)
+- `DB_*` — target DB, reached through the tunnel this container opens
+  (`DB_HOST=127.0.0.1`, `DB_PORT` matching `TUNNEL_LOCAL_PORT`, default `3307`)
+- `LEGACY_DB_*` — legacy source DB
+- `CONFIRM_WIPE` — leave commented out; only set for a real `clean` run
+
+## Run
+
+Via compose (recommended — reads `.env.import-tool` for you):
+
+```bash
+docker compose -f scripts/import-tool/docker-compose.yml run --rm append
+docker compose -f scripts/import-tool/docker-compose.yml run --rm backup-permissions
+docker compose -f scripts/import-tool/docker-compose.yml run --rm clean
+```
+
+Or raw `docker run` (Windows paths shown):
+
+```bash
+docker run --rm \
+  -e OVH_HOST=51.75.246.163 -e OVH_USER=deploy \
+  -e DB_HOST=127.0.0.1 -e DB_PORT=3307 -e DB_USERNAME=inventory -e DB_PASSWORD=*** -e DB_DATABASE=inventory \
+  -e LEGACY_DB_HOST=192.168.255.157 -e LEGACY_DB_USER=havelpa -e LEGACY_DB_PASSWORD=*** -e LEGACY_DB_DATABASE=mwnf3 \
+  -v C:\users\phave\.ssh\inventory_deploy:/run/secrets/deploy_key:ro \
+  -v Z:\mwnf\images:/legacy-images:ro \
+  -v E:\inventory\auth-backups:/backup \
+  import-tool:latest append
+```
+
+## Before your first `clean`
+
+`clean` restores users/permissions from a snapshot that must already
+exist — it does not take one itself. Run `backup-permissions` at least
+once first. If no snapshot exists at `AUTH_SNAPSHOT_REMOTE`,
+`auth:restore` fails cleanly with "snapshot not found" and the whole
+pipeline aborts before the wipe does any further damage — but you still
+want a real snapshot, not just a clean failure.
+
+## Dry runs
+
+Set `DRY_RUN=1` to pass `--dry-run` through to the importer's `import`
+and `image-sync` steps and skip the `glossary:resync` SSH call and the
+rsync push entirely — nothing is written anywhere. Does not apply to
+`clean`'s wipe/restore steps (there is no dry-run for those; test wipe
+semantics against a disposable environment instead, see "Local testing"
+below).
+
+## Local testing (no OVH contact)
+
+1. Build the image and confirm it succeeds (the riskiest step is
+   `better-sqlite3`'s native build on Alpine's musl libc — if `npm ci`
+   fails here, switch the base image to `node:22-slim` and
+   `apt-get install -y openssh-client rsync` instead of `apk add`).
+2. Set `IMPORT_TOOL_SKIP_TUNNEL=1` and point `DB_HOST`/`DB_PORT` directly
+   at a disposable local MySQL container (see the `mysql` service in the
+   repo root `docker-compose.yml` for the pattern already used elsewhere
+   in this project) instead of opening a real SSH tunnel — exercises
+   `run_importer_import`/`run_image_sync_and_push` without any SSH
+   involved. `OVH_HOST` is still required to satisfy the entrypoint's
+   validation even in this mode; any placeholder value works since it's
+   never actually dialed.
+3. To check the `--delete` gating and per-branch exit-code handling in
+   `entrypoint.sh` without touching the importer at all, put stub
+   `ssh`/`rsync` scripts earlier in `$PATH` that log their arguments (or
+   exit non-zero to force a failure) and run the container for both
+   `append` and `clean` — confirm `--delete` shows up only for `clean`,
+   and that a forced failure in one parallel branch (image-sync/rsync vs
+   glossary-resync) still lets the other complete and the container exits
+   non-zero with a clear message either way.
+
+## Testing against real OVH
+
+Test in this order, each step safer than the next:
+
+1. `backup-permissions` — read-only against the DB, non-destructive.
+2. A tunnel-only smoke test with `DRY_RUN=1 append` — confirms the SSH
+   tunnel opens and `mysql2` can actually reach the real OVH-side MySQL,
+   without writing anything.
+3. `append` for real — safe next step since `import` is idempotent.
+4. `clean` — only after 1–3 are all clean, and only with a known-good
+   snapshot already at `AUTH_SNAPSHOT_REMOTE`.

--- a/scripts/import-tool/docker-compose.yml
+++ b/scripts/import-tool/docker-compose.yml
@@ -5,34 +5,48 @@
 #   docker compose -f scripts/import-tool/docker-compose.yml run --rm backup-permissions
 #   docker compose -f scripts/import-tool/docker-compose.yml run --rm clean
 #
-# Reads credentials from scripts/import-tool/.env.import-tool (gitignored —
-# see .env.import-tool.example). All three services share the same image and
-# mounts; only the command (mode) differs.
+# Reads credentials from scripts/import-tool/.env (gitignored — see
+# .env.example). Must be named exactly `.env`: Compose only auto-loads that
+# literal filename to resolve the ${VAR} host paths below while parsing this
+# file — a differently-named file only reaches the container via env_file,
+# too late for that.
 
 name: inventory-import-tool
 
-x-import-tool: &import-tool
+x-build: &build
   build:
     context: ../..
     dockerfile: scripts/import-tool/Dockerfile
   env_file:
-    - .env.import-tool
-  volumes:
-    - ${OVH_SSH_KEY_HOST_PATH}:/run/secrets/deploy_key:ro
-    - ${LEGACY_IMAGES_HOST_PATH}:/legacy-images:ro
-    - ${AUTH_SNAPSHOT_BACKUP_HOST_PATH:-./auth-backups}:/backup
-  environment:
-    LEGACY_IMAGES_ROOT: /legacy-images
+    - .env
 
 services:
-  append:
-    <<: *import-tool
-    command: ["append"]
-
+  # No legacy-images mount — this mode never touches image data, and
+  # requiring it here would fail the same way for anyone who hasn't set up
+  # legacy image access yet but only wants a permissions snapshot.
   backup-permissions:
-    <<: *import-tool
+    <<: *build
     command: ["backup-permissions"]
+    volumes:
+      - ${OVH_SSH_KEY_HOST_PATH}:/run/secrets/deploy_key:ro
+      - ${AUTH_SNAPSHOT_BACKUP_HOST_PATH:-./auth-backups}:/backup
+
+  append:
+    <<: *build
+    command: ["append"]
+    volumes:
+      - ${OVH_SSH_KEY_HOST_PATH}:/run/secrets/deploy_key:ro
+      - ${AUTH_SNAPSHOT_BACKUP_HOST_PATH:-./auth-backups}:/backup
+      - ${LEGACY_IMAGES_HOST_PATH}:/legacy-images:ro
+    environment:
+      LEGACY_IMAGES_ROOT: /legacy-images
 
   clean:
-    <<: *import-tool
+    <<: *build
     command: ["clean"]
+    volumes:
+      - ${OVH_SSH_KEY_HOST_PATH}:/run/secrets/deploy_key:ro
+      - ${AUTH_SNAPSHOT_BACKUP_HOST_PATH:-./auth-backups}:/backup
+      - ${LEGACY_IMAGES_HOST_PATH}:/legacy-images:ro
+    environment:
+      LEGACY_IMAGES_ROOT: /legacy-images

--- a/scripts/import-tool/docker-compose.yml
+++ b/scripts/import-tool/docker-compose.yml
@@ -1,0 +1,38 @@
+# Convenience wrapper around `docker run` for the import tool.
+#
+# Build context is the repo root — run compose commands from there, e.g.:
+#   docker compose -f scripts/import-tool/docker-compose.yml run --rm append
+#   docker compose -f scripts/import-tool/docker-compose.yml run --rm backup-permissions
+#   docker compose -f scripts/import-tool/docker-compose.yml run --rm clean
+#
+# Reads credentials from scripts/import-tool/.env.import-tool (gitignored —
+# see .env.import-tool.example). All three services share the same image and
+# mounts; only the command (mode) differs.
+
+name: inventory-import-tool
+
+x-import-tool: &import-tool
+  build:
+    context: ../..
+    dockerfile: scripts/import-tool/Dockerfile
+  env_file:
+    - .env.import-tool
+  volumes:
+    - ${OVH_SSH_KEY_HOST_PATH}:/run/secrets/deploy_key:ro
+    - ${LEGACY_IMAGES_HOST_PATH}:/legacy-images:ro
+    - ${AUTH_SNAPSHOT_BACKUP_HOST_PATH:-./auth-backups}:/backup
+  environment:
+    LEGACY_IMAGES_ROOT: /legacy-images
+
+services:
+  append:
+    <<: *import-tool
+    command: ["append"]
+
+  backup-permissions:
+    <<: *import-tool
+    command: ["backup-permissions"]
+
+  clean:
+    <<: *import-tool
+    command: ["clean"]

--- a/scripts/import-tool/docker-compose.yml
+++ b/scripts/import-tool/docker-compose.yml
@@ -40,6 +40,12 @@ services:
       - ${LEGACY_IMAGES_HOST_PATH}:/legacy-images:ro
     environment:
       LEGACY_IMAGES_ROOT: /legacy-images
+      # Forwarded from the shell that invokes `docker compose run` (e.g.
+      # PowerShell's $env:DRY_RUN='1'), NOT from .env — env_file: only
+      # injects the .env FILE's own contents, it doesn't also forward your
+      # shell's environment. ${VAR:-default} interpolation is Compose's
+      # separate mechanism that actually reads the invoking shell.
+      DRY_RUN: ${DRY_RUN:-0}
 
   clean:
     <<: *build
@@ -50,3 +56,13 @@ services:
       - ${LEGACY_IMAGES_HOST_PATH}:/legacy-images:ro
     environment:
       LEGACY_IMAGES_ROOT: /legacy-images
+      DRY_RUN: ${DRY_RUN:-0}
+      # Same as above — must come from ${VAR} interpolation, not env_file,
+      # to be settable from the invoking shell at run time. CONFIRM_WIPE is
+      # deliberately NOT read from .env in practice (leave it unset there);
+      # set it in your shell just before this one command instead, e.g.
+      # PowerShell: $env:CONFIRM_WIPE='yes-really-wipe-production'; docker
+      # compose -f scripts/import-tool/docker-compose.yml run --rm clean
+      CONFIRM_WIPE: ${CONFIRM_WIPE:-}
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-}
+      REGULAR_USER_EMAIL: ${REGULAR_USER_EMAIL:-}

--- a/scripts/import-tool/entrypoint.sh
+++ b/scripts/import-tool/entrypoint.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ==============================================================================
+# Entrypoint for the inventory-app legacy import tool container.
+#
+# Modes (first arg or $IMPORT_MODE, default "append"):
+#   append              import -> image-sync -> glossary-resync (idempotent,
+#                       safe to re-run any time, adds only what's missing)
+#   backup-permissions  snapshot users/MFA/roles/permissions to a fixed OVH
+#                       path + a redundant local copy. No import, no writes
+#                       to application data.
+#   clean               db:wipe -> migrate -> seed -> permission:sync ->
+#                       auth:restore -> [append pipeline]. DESTRUCTIVE.
+#                       Requires a snapshot already at $AUTH_SNAPSHOT_REMOTE
+#                       (run backup-permissions first) and requires
+#                       CONFIRM_WIPE=yes-really-wipe-production.
+#
+# See README.md for the full list of required env vars and mounts.
+# ==============================================================================
+
+IMPORTER_DIR=/opt/import-tool/importer
+
+MODE="${1:-${IMPORT_MODE:-append}}"
+
+OVH_HOST="${OVH_HOST:?OVH_HOST is required}"
+OVH_USER="${OVH_USER:-deploy}"
+OVH_APP_DIR="${OVH_APP_DIR:-/opt/inventory/current}"
+OVH_SHARED_DIR="${OVH_SHARED_DIR:-/opt/inventory/shared}"
+OVH_SSH_KEY_PATH="${OVH_SSH_KEY_PATH:-/run/secrets/deploy_key}"
+
+TUNNEL_LOCAL_PORT="${TUNNEL_LOCAL_PORT:-3307}"
+STAGING_DIR="${IMAGE_STAGING_DIR:-/staging/images}"
+
+AUTH_SNAPSHOT_REMOTE="${AUTH_SNAPSHOT_REMOTE:-${OVH_SHARED_DIR}/auth-snapshots/current.json.enc}"
+AUTH_SNAPSHOT_LOCAL_BACKUP_DIR="${AUTH_SNAPSHOT_LOCAL_BACKUP_DIR:-/backup}"
+
+DRY_RUN="${DRY_RUN:-0}"
+
+# Test-only escape hatch (see README.md "Local testing"): skips SSH entirely
+# and assumes DB_HOST/DB_PORT already point at a reachable target DB.
+# Never set this against a real OVH run.
+SKIP_TUNNEL="${IMPORT_TOOL_SKIP_TUNNEL:-0}"
+
+TUNNEL_PID=""
+SSH_KEY=""
+
+log() { printf '[import-tool] %s %s\n' "$(date -u +%FT%TZ)" "$*" >&2; }
+die() {
+  log "FATAL: $*"
+  exit 1
+}
+
+# ------------------------------------------------------------------------------
+# SSH key handling — bind-mounted files from a Windows host often arrive with
+# permissive perms that OpenSSH refuses to use. Copy to a private, container-
+# local path and lock it down before first use.
+# ------------------------------------------------------------------------------
+prepare_ssh_key() {
+  [ "$SKIP_TUNNEL" = "1" ] && return 0
+  [ -f "$OVH_SSH_KEY_PATH" ] \
+    || die "SSH key not found at $OVH_SSH_KEY_PATH (mount it with -v <host-key>:$OVH_SSH_KEY_PATH:ro)"
+  SSH_KEY=/tmp/deploy_key
+  cp "$OVH_SSH_KEY_PATH" "$SSH_KEY"
+  chmod 600 "$SSH_KEY"
+}
+
+SSH_OPTS_BASE=(-o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=10)
+
+# Blocking remote command. Fails the whole pipeline immediately on a non-zero
+# exit — replaces the old script's fire-and-forget Start-Process calls, which
+# had no ordering or completion guarantee at all.
+ssh_run() {
+  local cmd="$1"
+  log "SSH: $cmd"
+  ssh "${SSH_OPTS_BASE[@]}" -i "$SSH_KEY" "${OVH_USER}@${OVH_HOST}" \
+    "cd '$OVH_APP_DIR' && $cmd" \
+    || die "remote command failed: $cmd"
+}
+
+open_tunnel() {
+  if [ "$SKIP_TUNNEL" = "1" ]; then
+    log "IMPORT_TOOL_SKIP_TUNNEL=1 — skipping SSH tunnel, using DB_HOST/DB_PORT as-is"
+    return 0
+  fi
+
+  log "Opening SSH tunnel 127.0.0.1:${TUNNEL_LOCAL_PORT} -> ${OVH_HOST}:3306"
+  ssh "${SSH_OPTS_BASE[@]}" -i "$SSH_KEY" -f -N \
+    -L "${TUNNEL_LOCAL_PORT}:127.0.0.1:3306" \
+    -o ExitOnForwardFailure=yes \
+    "${OVH_USER}@${OVH_HOST}" \
+    || die "failed to establish SSH tunnel to ${OVH_HOST}"
+
+  TUNNEL_PID="$(pgrep -f "L ${TUNNEL_LOCAL_PORT}:127.0.0.1:3306" | head -n1 || true)"
+
+  # -f only confirms the forward was requested successfully, not that it's
+  # actually accepting connections yet — probe it before trusting it.
+  local attempt
+  # shellcheck disable=SC2034  # loop counter, not read in the body
+  for attempt in $(seq 1 10); do
+    if (exec 3<>"/dev/tcp/127.0.0.1/${TUNNEL_LOCAL_PORT}") 2>/dev/null; then
+      exec 3>&- 3<&- 2>/dev/null || true
+      log "Tunnel verified reachable on 127.0.0.1:${TUNNEL_LOCAL_PORT}"
+      return 0
+    fi
+    sleep 1
+  done
+  die "tunnel did not become reachable on 127.0.0.1:${TUNNEL_LOCAL_PORT} after 10s"
+}
+
+close_tunnel() {
+  if [ -n "$TUNNEL_PID" ]; then
+    kill "$TUNNEL_PID" 2>/dev/null || true
+    TUNNEL_PID=""
+  fi
+}
+trap close_tunnel EXIT
+
+# ------------------------------------------------------------------------------
+# Importer steps (run locally in the container against DB_HOST/DB_PORT, which
+# the caller must set to point at the tunnel — see README.md)
+# ------------------------------------------------------------------------------
+run_importer_import() {
+  local extra_args=()
+  [ "$DRY_RUN" = "1" ] && extra_args+=(--dry-run)
+
+  log "Running importer: import ${extra_args[*]}"
+  (cd "$IMPORTER_DIR" && npx tsx src/cli/import.ts import "${extra_args[@]}") \
+    || die "importer 'import' step failed"
+}
+
+run_image_sync_and_push() {
+  local extra_args=()
+  [ "$DRY_RUN" = "1" ] && extra_args+=(--dry-run)
+
+  log "Running importer: image-sync --copy --target-dir $STAGING_DIR ${extra_args[*]}"
+  mkdir -p "$STAGING_DIR"
+  if ! (cd "$IMPORTER_DIR" && npx tsx src/cli/import.ts image-sync --copy --target-dir "$STAGING_DIR" "${extra_args[@]}"); then
+    log "image-sync failed"
+    return 1
+  fi
+
+  if [ "$DRY_RUN" = "1" ]; then
+    log "DRY_RUN=1 — skipping rsync push to OVH"
+    return 0
+  fi
+
+  local rsync_flags=(-az --stats)
+  # --delete is only correct in "clean" mode: image-sync only stages NEWLY
+  # synced images (it skips any row whose size != 1, i.e. already synced), so
+  # in "append" mode the staging dir is a partial set, not a full mirror —
+  # --delete there would erase every image already on OVH from a prior run.
+  # In "clean" mode every row starts at size=1 after the fresh wipe, so the
+  # staging dir genuinely is a full mirror and --delete correctly prunes
+  # anything stale.
+  if [ "$MODE" = "clean" ]; then
+    rsync_flags+=(--delete)
+  fi
+
+  log "rsync ${rsync_flags[*]} $STAGING_DIR/ -> ${OVH_HOST}:${OVH_SHARED_DIR}/storage/app/public/pictures/"
+  if ! rsync "${rsync_flags[@]}" -e "ssh ${SSH_OPTS_BASE[*]} -i $SSH_KEY" \
+    "$STAGING_DIR"/ \
+    "${OVH_USER}@${OVH_HOST}:${OVH_SHARED_DIR}/storage/app/public/pictures/"; then
+    log "rsync push failed"
+    return 1
+  fi
+}
+
+run_glossary_resync() {
+  if [ "$DRY_RUN" = "1" ]; then
+    log "DRY_RUN=1 — skipping glossary:resync"
+    return 0
+  fi
+  log "Queuing glossary resync (inventory-queue.service consumes it; not waiting for drain)"
+  ssh_run "php artisan glossary:resync --remove-existing --force"
+}
+
+# ------------------------------------------------------------------------------
+# Mode implementations
+# ------------------------------------------------------------------------------
+do_import_pipeline() {
+  prepare_ssh_key
+  open_tunnel
+  run_importer_import
+
+  local pid_a pid_b rc_a=0 rc_b=0
+  run_image_sync_and_push &
+  pid_a=$!
+  run_glossary_resync &
+  pid_b=$!
+  wait "$pid_a" || rc_a=$?
+  wait "$pid_b" || rc_b=$?
+  close_tunnel
+
+  [ "$rc_a" -eq 0 ] || die "image-sync/rsync branch failed (exit $rc_a)"
+  [ "$rc_b" -eq 0 ] || die "glossary:resync branch failed (exit $rc_b)"
+}
+
+do_wipe_and_restore() {
+  [ "${CONFIRM_WIPE:-}" = "yes-really-wipe-production" ] \
+    || die "clean mode requires CONFIRM_WIPE=yes-really-wipe-production — refusing to wipe the database"
+
+  prepare_ssh_key
+  ssh_run "php artisan db:wipe --force"
+  ssh_run "php artisan migrate --force"
+  ssh_run "php artisan optimize:clear"
+  ssh_run "php artisan db:seed --class=MinimalDatabaseSeeder --force"
+  ssh_run "php artisan permission:sync"
+  # Requires a snapshot already at $AUTH_SNAPSHOT_REMOTE (from a prior
+  # backup-permissions run). If none exists, auth:restore fails cleanly with
+  # "snapshot not found" and this aborts the whole pipeline before anything
+  # further happens — the correct, safe failure mode.
+  ssh_run "php artisan auth:restore '$AUTH_SNAPSHOT_REMOTE' --force"
+}
+
+do_backup_permissions() {
+  prepare_ssh_key
+  mkdir -p "$AUTH_SNAPSHOT_LOCAL_BACKUP_DIR"
+  local ts
+  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+
+  ssh_run "php artisan auth:snapshot '$AUTH_SNAPSHOT_REMOTE' --force"
+
+  local local_copy="${AUTH_SNAPSHOT_LOCAL_BACKUP_DIR}/auth-snapshot-${ts}.json.enc"
+  log "Pulling redundant local copy to $local_copy"
+  scp "${SSH_OPTS_BASE[@]}" -i "$SSH_KEY" \
+    "${OVH_USER}@${OVH_HOST}:${AUTH_SNAPSHOT_REMOTE}" \
+    "$local_copy" \
+    || die "failed to pull local backup copy of snapshot"
+}
+
+# ------------------------------------------------------------------------------
+# Dispatch
+# ------------------------------------------------------------------------------
+case "$MODE" in
+append)
+  do_import_pipeline
+  ;;
+backup-permissions)
+  do_backup_permissions
+  ;;
+clean)
+  do_wipe_and_restore
+  do_import_pipeline
+  ;;
+*)
+  die "unknown mode '$MODE' (expected: append | backup-permissions | clean)"
+  ;;
+esac
+
+log "Mode '$MODE' completed successfully"

--- a/scripts/import-tool/entrypoint.sh
+++ b/scripts/import-tool/entrypoint.sh
@@ -12,9 +12,14 @@ set -euo pipefail
 #                       to application data.
 #   clean               db:wipe -> migrate -> seed -> permission:sync ->
 #                       auth:restore -> [append pipeline]. DESTRUCTIVE.
-#                       Requires a snapshot already at $AUTH_SNAPSHOT_REMOTE
-#                       (run backup-permissions first) and requires
-#                       CONFIRM_WIPE=yes-really-wipe-production.
+#                       Requires CONFIRM_WIPE=yes-really-wipe-production.
+#                       Restores from a snapshot at $AUTH_SNAPSHOT_REMOTE if
+#                       one exists (run backup-permissions first to create
+#                       it); if none exists AND both ADMIN_EMAIL and
+#                       REGULAR_USER_EMAIL are set, falls back to recreating
+#                       just those two accounts instead. If neither applies,
+#                       aborts before anything is lost beyond the wipe
+#                       itself.
 #
 # See README.md for the full list of required env vars and mounts.
 # ==============================================================================
@@ -34,6 +39,13 @@ STAGING_DIR="${IMAGE_STAGING_DIR:-/staging/images}"
 
 AUTH_SNAPSHOT_REMOTE="${AUTH_SNAPSHOT_REMOTE:-${OVH_SHARED_DIR}/auth-snapshots/current.json.enc}"
 AUTH_SNAPSHOT_LOCAL_BACKUP_DIR="${AUTH_SNAPSHOT_LOCAL_BACKUP_DIR:-/backup}"
+
+# clean-mode fallback, only used when no snapshot exists at AUTH_SNAPSHOT_REMOTE
+# (see do_wipe_and_restore). Both must be set for the fallback to engage — if
+# only one is set, or neither, clean fails with no snapshot the same way it
+# always has, rather than partially creating accounts.
+ADMIN_EMAIL="${ADMIN_EMAIL:-}"
+REGULAR_USER_EMAIL="${REGULAR_USER_EMAIL:-}"
 
 DRY_RUN="${DRY_RUN:-0}"
 
@@ -196,6 +208,32 @@ do_import_pipeline() {
   [ "$rc_b" -eq 0 ] || die "glossary:resync branch failed (exit $rc_b)"
 }
 
+# True if a snapshot file already exists on the OVH host. Checked with a
+# plain remote `test -f` rather than parsing auth:restore's error text —
+# more robust, and lets us distinguish "no snapshot, fall back" from any
+# OTHER auth:restore failure (wrong APP_KEY, missing roles, etc.), which
+# should still abort the pipeline hard rather than silently paper over it.
+snapshot_exists() {
+  ssh "${SSH_OPTS_BASE[@]}" -i "$SSH_KEY" "${OVH_USER}@${OVH_HOST}" \
+    "test -f '$AUTH_SNAPSHOT_REMOTE'"
+}
+
+# Recreates exactly two accounts (one "Manager of Users" admin, one
+# "Regular User") when no snapshot exists to restore instead. Requires
+# ADMIN_EMAIL/REGULAR_USER_EMAIL — never invented or defaulted. user:create
+# does not set a plaintext password; it emails a password-reset invitation
+# to that address.
+create_fallback_accounts() {
+  log "No snapshot to restore — recreating fallback accounts for ADMIN_EMAIL and REGULAR_USER_EMAIL instead"
+  ssh_run "php artisan user:create '$ADMIN_EMAIL' '$ADMIN_EMAIL'"
+  ssh_run "php artisan user:email-verification '$ADMIN_EMAIL' verify"
+  ssh_run "php artisan user:assign-role '$ADMIN_EMAIL' 'Manager of Users'"
+  ssh_run "php artisan user:create '$REGULAR_USER_EMAIL' '$REGULAR_USER_EMAIL'"
+  ssh_run "php artisan user:email-verification '$REGULAR_USER_EMAIL' verify"
+  ssh_run "php artisan user:assign-role '$REGULAR_USER_EMAIL' 'Regular User'"
+  log "Fallback accounts created — check $ADMIN_EMAIL and $REGULAR_USER_EMAIL for password-reset emails"
+}
+
 do_wipe_and_restore() {
   [ "${CONFIRM_WIPE:-}" = "yes-really-wipe-production" ] \
     || die "clean mode requires CONFIRM_WIPE=yes-really-wipe-production — refusing to wipe the database"
@@ -206,11 +244,14 @@ do_wipe_and_restore() {
   ssh_run "php artisan optimize:clear"
   ssh_run "php artisan db:seed --class=MinimalDatabaseSeeder --force"
   ssh_run "php artisan permission:sync"
-  # Requires a snapshot already at $AUTH_SNAPSHOT_REMOTE (from a prior
-  # backup-permissions run). If none exists, auth:restore fails cleanly with
-  # "snapshot not found" and this aborts the whole pipeline before anything
-  # further happens — the correct, safe failure mode.
-  ssh_run "php artisan auth:restore '$AUTH_SNAPSHOT_REMOTE' --force"
+
+  if snapshot_exists; then
+    ssh_run "php artisan auth:restore '$AUTH_SNAPSHOT_REMOTE' --force"
+  elif [ -n "$ADMIN_EMAIL" ] && [ -n "$REGULAR_USER_EMAIL" ]; then
+    create_fallback_accounts
+  else
+    die "no snapshot at $AUTH_SNAPSHOT_REMOTE and ADMIN_EMAIL/REGULAR_USER_EMAIL not both set — nothing to restore and no fallback configured. Run backup-permissions first, or set both in .env to allow account recreation as a fallback."
+  fi
 }
 
 do_backup_permissions() {

--- a/scripts/importer/README.md
+++ b/scripts/importer/README.md
@@ -192,6 +192,13 @@ Business logic is written once in transformers:
 
 ### Typical Workflow
 
+> **Running this against the OVH-hosted deployment?** Use
+> [`scripts/import-tool/`](../import-tool/README.md) — a Docker container
+> that automates the full workflow below (SSH tunnel, sequential
+> exit-code-checked `artisan` commands, rsync image push, auth
+> snapshot/restore) in three modes (`append`/`backup-permissions`/`clean`)
+> instead of running each step by hand.
+
 The importer is designed to run as part of a complete database initialization:
 
 1. **Create auth snapshot** - Preserve user accounts, MFA setup, role assignments, direct permissions, and API tokens (`php artisan auth:snapshot auth-snapshots/pre-import.json.enc --force`)


### PR DESCRIPTION
## Summary

Replaces `scripts/ImportLegacy.ps1` (untracked, never committed, and broken — see below) with a dedicated Docker "tool" container that automates the full legacy-data import pipeline against the OVH-hosted `inventory-app`.

**Why the old script needed replacing**: it launched a sequence of dependent `artisan` commands via `Start-Process ssh` with no `-Wait` — no ordering or completion guarantee between them, a real risk of leaving the OVH database in a broken, partially-migrated state. It also `scp`'d ~25,000+ synced images via glob expansion (known too slow/risky at that volume — needed `rsync`, unavailable on Windows), and manually spawned a `queue:work` process that duplicates the `inventory-queue.service` systemd unit already running continuously on OVH.

## What's in `scripts/import-tool/`

`Dockerfile` (Node 22 Alpine + `openssh-client` + `rsync` + `bash`, bundles the importer CLI) + `entrypoint.sh`, three modes:

- **`append`** (default) — `import` → `image-sync` → `glossary-resync`, no wipe. Safe to run any time since the importer is idempotent (see #1414/#1415).
- **`backup-permissions`** — snapshots users/MFA/roles/permissions to a fixed path on the OVH host plus a redundant local copy. No import.
- **`clean`** — `db:wipe` → `migrate` → `db:seed` → `permission:sync` → restore users → the full `append` pipeline. Destructive; requires `CONFIRM_WIPE=yes-really-wipe-production`.

`entrypoint.sh` fixes the old script's core bugs: every remote `artisan` command is a blocking, exit-code-checked SSH call; the SSH tunnel is actively probed before use; `image-sync`+rsync and `glossary-resync` run in parallel with per-branch exit-code capture; `rsync --delete` is gated strictly to `clean` mode (the `append`-mode staging dir is only newly-synced images, not a full mirror, so `--delete` there would erase images already on OVH).

## Fixes landed after the initial version, from real runs against OVH

This PR includes several follow-up fixes discovered while actually running the tool, each verified before merge:

1. **`.env` file naming** — Compose only auto-loads a file literally named `.env` to resolve `${VAR}` placeholders in `volumes:`; a differently-named `env_file:` target reaches the container but not Compose's own variable substitution, so credential paths silently resolved to empty strings and Docker rejected the mount spec. Renamed to `.env`/`.env.example`, split `backup-permissions` so it no longer requires the legacy-images mount at all.
2. **`clean` mode account-recovery fallback** — if no snapshot exists at `AUTH_SNAPSHOT_REMOTE` (e.g. no prior `backup-permissions` run), `clean` used to fail hard with no way to access the admin panel again (`MinimalDatabaseSeeder`'s `UserSeeder` only creates accounts when `APP_ENV=local`, never in production). `clean` now checks whether a snapshot actually exists via `test -f` (not error-text matching, so any *other* `auth:restore` failure still aborts hard) before calling `auth:restore`, and if both `ADMIN_EMAIL`/`REGULAR_USER_EMAIL` are set, falls back to recreating exactly those two accounts with the project's existing `Manager of Users`/`Regular User` role split. Opt-in by configuration — unset by default, and setting only one of the two still refuses rather than partially creating an account.
3. **Compose env-var forwarding** — `docker compose run` does not forward the invoking shell's environment into the container by default; only `env_file:`/explicit `${VAR}` interpolation in `environment:` does. `CONFIRM_WIPE`, `ADMIN_EMAIL`, `REGULAR_USER_EMAIL`, and `DRY_RUN` weren't declared anywhere, so setting them in the shell right before `docker compose run` (the documented, correct way to pass `CONFIRM_WIPE` without leaving it standing in `.env`) silently had no effect.
4. **`docker compose run --build`** — Compose only builds an image if one doesn't exist yet; it never notices `entrypoint.sh` or the importer source changed since the last build. Documented `--build` on every example invocation after a real run executed a stale, pre-fallback entrypoint despite the fix already being merged.
5. **Bundling `database/seeders/data/{languages,countries}.json`** — `LanguageImporter`/`CountryImporter` read these files directly via a path relative to their own source file, walking up to the repo root — self-sufficient by design, not dependent on any Laravel seeder. The Dockerfile only copied `scripts/importer/src`, so `readFileSync` threw `ENOENT` for both at runtime. This looked exactly like a missing reference-data seeder from the output (`Languages: 0 imported, 0 skipped, 1 errors`, then every later phase reporting "language not found") but wasn't — `MinimalDatabaseSeeder` correctly excludes Language/Country because the importer already owns creating them from this exact file. Fixed by copying just the two JSON files to the path the importers' existing resolution logic expects.

## Test plan

- [x] `docker build -f scripts/import-tool/Dockerfile .` — clean build
- [x] `shellcheck entrypoint.sh` — clean
- [x] Every control-flow path exercised locally with stubbed `ssh`/`rsync`/`npx` (no OVH contact): missing required env vars, missing SSH key, the `CONFIRM_WIPE` guard, tunnel-unreachable timeout, `--delete` present only for `clean`, forced failures in either parallel branch, and all four `clean`-mode snapshot/fallback paths (snapshot exists / fallback triggers / neither configured / only one email set)
- [x] Confirmed the container's own installed `mysql2` dependency connects successfully to a real disposable MySQL instance via the importer's `validate` command
- [x] Confirmed `docker compose config` resolves all host paths and shell-forwarded vars correctly after the naming/forwarding fixes
- [x] Confirmed the exact `path.join()` resolution `language-importer.ts`/`country-importer.ts` use finds both bundled JSON files inside the built image
- [x] Tested against the real OVH host across this session: `backup-permissions`, and `clean` through several iterations as the fixes above landed

Generated with Claude Code
