### PR TITLE
feat(importer): local stage/ship modes, fix append/clean image-sync bug

### DIFF
--- a/scripts/import-tool/Dockerfile
+++ b/scripts/import-tool/Dockerfile
@@ -7,7 +7,9 @@
 
 FROM node:22-alpine
 
-RUN apk add --no-cache openssh-client rsync bash
+# mysql-client provides mysql/mysqldump — used only by `ship` mode, to dump
+# local-mysql (a `stage` build) and load it into OVH through the tunnel.
+RUN apk add --no-cache openssh-client rsync bash mysql-client
 
 WORKDIR /opt/import-tool/importer
 

--- a/scripts/import-tool/README.md
+++ b/scripts/import-tool/README.md
@@ -157,7 +157,8 @@ same `mysql:8.4` image the root dev `docker-compose.yml` uses), removing that
 per-row network cost entirely. It's a way to build and inspect a fully-populated
 copy of the import fast, and — later — a way to prepare data for a bulk
 `mysqldump` + `rsync` handoff to OVH instead of thousands of live inserts
-against production. **That handoff step is not implemented yet** — `stage`
+against production. **That handoff is a manual runbook, not automated
+yet** — see "Shipping a staged build to a server" below; `stage` itself
 only builds and holds the local copy.
 
 ```bash
@@ -197,6 +198,40 @@ Rerunning `stage` against an already-populated `local-mysql` is safe and
 fast — `import` and `image-sync` are both idempotent, so a rerun only adds
 what's missing (e.g. after new legacy data shows up) instead of redoing
 everything.
+
+## Shipping a staged build to a server (manual — not automated yet)
+
+Once `stage` has produced a fully-populated `local-mysql` + `local-images-data`,
+you can hand that off to a target server (OVH or otherwise) instead of
+running `append`/`clean` against it directly over the tunnel. There is no
+mode that does this for you yet — it's a manual runbook:
+
+1. **Dump the local DB:**
+   ```bash
+   docker exec inventory-import-tool-local-mysql-1 \
+     mysqldump -uinventory -psecret --single-transaction --routines inventory \
+     > inventory-staged.sql
+   ```
+2. **Copy the dump and the staged images to the server.** The dump is a
+   plain file, so `scp`/`rsync` it directly. The images live inside the
+   `local-images-data` *volume*, not a host directory — on Docker Desktop
+   (Windows/Mac) that volume is inside the Docker VM, so copy it out via a
+   throwaway container first, then rsync the resulting host directory:
+   ```bash
+   docker run --rm -v inventory-import-tool_local-images-data:/data -v <host-dir>:/out alpine cp -a /data/. /out/
+   rsync -az inventory-staged.sql deploy@<server>:/tmp/
+   rsync -az --stats <host-dir>/ deploy@<server>:/opt/inventory/shared/storage/app/public/pictures/
+   ```
+3. **Load the dump into the target DB on the server**, replacing its
+   contents — treat this exactly like `clean`'s wipe: it's a full
+   replacement, so back up first and schedule a maintenance window
+   (`php artisan down`) around it:
+   ```bash
+   ssh deploy@<server> "mysql -u<db_user> -p<db_pass> <db_name> < /tmp/inventory-staged.sql"
+   ```
+4. **Finish up on the server:** `php artisan storage:link` (if not already
+   linked) and `php artisan optimize:clear`, then bring it back up
+   (`php artisan up`).
 
 ## Testing against real OVH
 

--- a/scripts/import-tool/README.md
+++ b/scripts/import-tool/README.md
@@ -27,6 +27,7 @@ build` once beforehand) to be sure you're running current code.
 | `backup-permissions` | Snapshots users (incl. MFA columns), role assignments, direct permission assignments, and API tokens to an encrypted JSON on the OVH host, plus a redundant timestamped copy pulled back locally. No import, no writes to application data. |
 | `clean` | `db:wipe` → `migrate` → `db:seed` → `permission:sync` → restore users → the full `append` pipeline. **Destructive.** Requires `CONFIRM_WIPE=yes-really-wipe-production` or it refuses to run. Restores from a snapshot at `AUTH_SNAPSHOT_REMOTE` if one exists (run `backup-permissions` first to create it — `clean` does not take a fresh snapshot itself); if none exists **and** both `ADMIN_EMAIL`/`REGULAR_USER_EMAIL` are set, falls back to recreating just those two accounts instead. If neither applies, aborts before anything beyond the wipe itself is lost. |
 | `stage` | `import` → `image-sync`, writing straight to a local, persistent MySQL (`local-mysql`) instead of through the OVH tunnel. **No SSH, no OVH contact at all.** Builds a fully-populated local copy of the legacy import — DB rows in `local-mysql`, image files in the `local-images-data` volume — at local-network speed. Safe to run at any time, including while a real `append`/`clean` run is in progress against OVH (they hit the same legacy source DB, which comfortably handles concurrent readers). See "Local staging" below. |
+| `ship` | Ships an already-built `stage` copy to OVH: rebuilds the app layer on OVH exactly like `clean` (`db:wipe` → `migrate` → `db:seed` → `permission:sync` → restore/recreate users), then loads local-mysql's **content tables only** through the tunnel and pushes the already-staged images. **Destructive**, same `CONFIRM_WIPE` requirement as `clean`. See "Shipping a staged build to a server" below. |
 
 ## Build
 
@@ -155,11 +156,10 @@ tens of thousands of small round-trips at WAN latency, which is why a real
 `clean` run can take hours. `stage` writes to a local MySQL instead (`local-mysql`,
 same `mysql:8.4` image the root dev `docker-compose.yml` uses), removing that
 per-row network cost entirely. It's a way to build and inspect a fully-populated
-copy of the import fast, and — later — a way to prepare data for a bulk
-`mysqldump` + `rsync` handoff to OVH instead of thousands of live inserts
-against production. **That handoff is a manual runbook, not automated
-yet** — see "Shipping a staged build to a server" below; `stage` itself
-only builds and holds the local copy.
+copy of the import fast, and a way to prepare data for a bulk `mysqldump` +
+tunnel-load handoff to OVH instead of thousands of live inserts against
+production — see "Shipping a staged build to a server" below for the `ship`
+mode that does that handoff.
 
 ```bash
 docker compose -f scripts/import-tool/docker-compose.yml up -d local-mysql
@@ -176,62 +176,104 @@ Both the DB and the staged images persist in named Docker volumes
 and survive `docker compose down` (without `-v`) followed by `up`/`run` again.
 Only `docker compose down -v` (or `docker volume rm`) destroys them.
 
-`stage` intentionally differs from `append`/`clean` in two ways:
+`stage` intentionally differs from `append`/`clean` in one way: **migrations
+only, no seeders.** `local-migrate` runs `php artisan migrate --force` and
+nothing else — no roles, no permissions, no dev users. This container is
+never meant to be logged into; it exists purely to materialize a
+fully-populated dataset, so there's no reason to wire up auth for it. (The
+real auth layer is always built fresh on OVH itself when you `ship` — see
+below — never read from local-mysql.)
 
-- **Migrations only, no seeders.** `local-migrate` runs `php artisan migrate --force`
-  and nothing else — no roles, no permissions, no dev users. This container
-  is never meant to be logged into; it exists purely to materialize a
-  fully-populated dataset, so there's no reason to wire up auth for it.
-- **Non-fatal on partial errors.** The importer's `import` and `image-sync`
-  commands both exit non-zero whenever *any* row/file failed — which, for
-  this legacy dataset, is always true (a handful of genuinely bad legacy rows,
-  and some image paths referenced in the legacy DB that don't actually exist
-  under `LEGACY_IMAGES_HOST_PATH`). `append`/`clean` still treat that as fatal
-  (unchanged, on purpose — see `run_importer_import`/`run_image_sync_and_push`
-  in `entrypoint.sh`). `stage` uses tolerant variants that log a note and
-  continue instead, since the goal is "best complete copy possible," not
-  "abort over a known, already-summarized handful of legacy gaps." Every
-  skipped row/file is still listed in the run's own output and log file —
-  nothing is silently swallowed, just not treated as pipeline-fatal.
+Every mode is now tolerant of partial errors: the importer's `import` and
+`image-sync` commands both exit non-zero whenever *any* row/file failed,
+which for this legacy dataset is always true (a handful of genuinely bad
+legacy rows, and some image paths referenced in the legacy DB that don't
+actually exist under `LEGACY_IMAGES_HOST_PATH`). That used to be treated as
+pipeline-fatal in `append`/`clean` too — confirmed in practice: a real
+`clean` run against OVH completed the whole import (135343 rows, 385 known
+per-row errors) and then never ran image-sync or `glossary:resync` at all,
+because the old code killed the container right after the import summary
+printed. Fixed everywhere now — every mode logs a note and continues past
+per-row/per-file errors, since a handful of already-summarized legacy gaps
+shouldn't block the rest of a run. Nothing is silently swallowed: every
+skipped row/file is still listed in the run's own output and log file, just
+not treated as fatal. A genuine transport failure (rsync itself, the SQL
+load itself) is still fatal, as it should be.
+
+### Continuing a stage build vs. starting over
 
 Rerunning `stage` against an already-populated `local-mysql` is safe and
 fast — `import` and `image-sync` are both idempotent, so a rerun only adds
-what's missing (e.g. after new legacy data shows up) instead of redoing
-everything.
+what's missing instead of redoing everything. Concretely:
 
-## Shipping a staged build to a server (manual — not automated yet)
+- **New legacy data appeared, or some images were missing last time and are
+  now available:** just rerun `stage` again —
+  `docker compose -f scripts/import-tool/docker-compose.yml run --build --rm stage`.
+  Already-imported rows and already-copied images are detected and skipped;
+  only what's new or was missing gets added.
+- **`glossary:resync`:** there's nothing to "continue" locally — `stage`
+  never touches it (it's an OVH-only side effect, consumed by
+  `inventory-queue.service` running on OVH). It happens automatically as
+  part of `ship`, once you're ready to send the build to OVH.
+- **You actually want to rebuild from nothing** (e.g. to verify a truly
+  clean import from scratch): `docker compose -f scripts/import-tool/docker-compose.yml down -v`
+  destroys `local-mysql-data`/`local-images-data`/`local-app-vendor`, then
+  `run --build --rm stage` starts over completely empty. Not needed just to
+  pick up new data or missing images — only for an intentional full reset.
+
+## Shipping a staged build to a server
 
 Once `stage` has produced a fully-populated `local-mysql` + `local-images-data`,
-you can hand that off to a target server (OVH or otherwise) instead of
-running `append`/`clean` against it directly over the tunnel. There is no
-mode that does this for you yet — it's a manual runbook:
+`ship` sends that build to OVH instead of running `append`/`clean` against it
+directly over the tunnel:
 
-1. **Dump the local DB:**
-   ```bash
-   docker exec inventory-import-tool-local-mysql-1 \
-     mysqldump -uinventory -psecret --single-transaction --routines inventory \
-     > inventory-staged.sql
-   ```
-2. **Copy the dump and the staged images to the server.** The dump is a
-   plain file, so `scp`/`rsync` it directly. The images live inside the
-   `local-images-data` *volume*, not a host directory — on Docker Desktop
-   (Windows/Mac) that volume is inside the Docker VM, so copy it out via a
-   throwaway container first, then rsync the resulting host directory:
-   ```bash
-   docker run --rm -v inventory-import-tool_local-images-data:/data -v <host-dir>:/out alpine cp -a /data/. /out/
-   rsync -az inventory-staged.sql deploy@<server>:/tmp/
-   rsync -az --stats <host-dir>/ deploy@<server>:/opt/inventory/shared/storage/app/public/pictures/
-   ```
-3. **Load the dump into the target DB on the server**, replacing its
-   contents — treat this exactly like `clean`'s wipe: it's a full
-   replacement, so back up first and schedule a maintenance window
-   (`php artisan down`) around it:
-   ```bash
-   ssh deploy@<server> "mysql -u<db_user> -p<db_pass> <db_name> < /tmp/inventory-staged.sql"
-   ```
-4. **Finish up on the server:** `php artisan storage:link` (if not already
-   linked) and `php artisan optimize:clear`, then bring it back up
-   (`php artisan up`).
+```powershell
+$env:CONFIRM_WIPE='yes-really-wipe-production'
+docker compose -f scripts/import-tool/docker-compose.yml run --build --rm ship
+```
+
+What it actually does, in order:
+
+1. **Rebuilds the app layer on OVH** — `do_wipe_and_restore`, the *exact same*
+   `db:wipe` → `migrate` → `db:seed` → `permission:sync` → restore-or-recreate-users
+   sequence `clean` uses. This is why `ship` needs the same `CONFIRM_WIPE`
+   guard, and the same pre-flight advice as `clean` (see "Before your first
+   `clean`" above — the snapshot/fallback-account rules are identical).
+2. **Dumps local-mysql, excluding auth/infrastructure tables, and loads it
+   through the tunnel** — `mysqldump` against `local-mysql`, with
+   `--ignore-table` for every table in `SHIP_EXCLUDED_TABLES` (`users`,
+   `roles`, `permissions`, `model_has_roles`, `model_has_permissions`,
+   `role_has_permissions`, `personal_access_tokens`, `sessions`, `cache`,
+   `cache_locks`, `jobs`, `job_batches`, `failed_jobs`,
+   `email_two_factor_codes`, `password_reset_tokens`, `migrations`,
+   `settings`), then loaded via the importer's `load-sql` command (not the
+   `mysqldump`/`mysql` CLI pipe you'd expect — see the note below). **This
+   guarantee is the whole point:** `local-mysql` never has real data in any
+   of those tables (`stage` runs no seeders — see above), so loading them
+   wholesale would blank out OVH's real users, roles, permission
+   assignments, API tokens, and settings. Excluding them means step 1's
+   freshly-restored auth state is never touched by step 2 — only the actual
+   imported legacy content moves.
+3. **Pushes the already-staged images** from `local-images-data` — no
+   re-running image-sync, they're already there.
+4. **Resyncs the glossary** on OVH, same as `append`/`clean`.
+
+**Why not just pipe `mysqldump | mysql` through the tunnel directly?** This
+image's `mysql`/`mysqldump` are Alpine's MariaDB client, which can't
+authenticate to a modern MySQL 8 server's default `caching_sha2_password`
+plugin at all (`Plugin caching_sha2_password could not be loaded` — the
+plugin's `.so` isn't packaged, not an SSL/config issue) — and that's what
+both `local-mysql` and the real OVH database use. Works fine as the *source*
+of the dump once `local-mysql`'s app user is switched to the older,
+universally-supported `mysql_native_password` (see `mysql/init.sql` — a
+disposable local-only credential, safe to relax; OVH's real credentials are
+never touched). For the *destination* leg, `ship` instead pipes the dump
+through `import.ts load-sql`, which reuses the same `mysql2` driver the rest
+of this tool already relies on to talk to OVH everywhere else.
+
+No manual runbook needed — `ship` requires only that `stage` has already
+been run (`local-mysql` healthy, `local-images-data` populated) and that you
+treat it with the same care as `clean`: it wipes production first.
 
 ## Testing against real OVH
 

--- a/scripts/import-tool/README.md
+++ b/scripts/import-tool/README.md
@@ -26,6 +26,7 @@ build` once beforehand) to be sure you're running current code.
 | `append` (default) | `import` → `image-sync` → `glossary:resync`, no wipe. Safe to run any time — the importer is idempotent, this only adds what's missing. |
 | `backup-permissions` | Snapshots users (incl. MFA columns), role assignments, direct permission assignments, and API tokens to an encrypted JSON on the OVH host, plus a redundant timestamped copy pulled back locally. No import, no writes to application data. |
 | `clean` | `db:wipe` → `migrate` → `db:seed` → `permission:sync` → restore users → the full `append` pipeline. **Destructive.** Requires `CONFIRM_WIPE=yes-really-wipe-production` or it refuses to run. Restores from a snapshot at `AUTH_SNAPSHOT_REMOTE` if one exists (run `backup-permissions` first to create it — `clean` does not take a fresh snapshot itself); if none exists **and** both `ADMIN_EMAIL`/`REGULAR_USER_EMAIL` are set, falls back to recreating just those two accounts instead. If neither applies, aborts before anything beyond the wipe itself is lost. |
+| `stage` | `import` → `image-sync`, writing straight to a local, persistent MySQL (`local-mysql`) instead of through the OVH tunnel. **No SSH, no OVH contact at all.** Builds a fully-populated local copy of the legacy import — DB rows in `local-mysql`, image files in the `local-images-data` volume — at local-network speed. Safe to run at any time, including while a real `append`/`clean` run is in progress against OVH (they hit the same legacy source DB, which comfortably handles concurrent readers). See "Local staging" below. |
 
 ## Build
 
@@ -145,6 +146,57 @@ below).
    and that a forced failure in one parallel branch (image-sync/rsync vs
    glossary-resync) still lets the other complete and the container exits
    non-zero with a clear message either way.
+
+## Local staging
+
+`stage` exists because every operation `append`/`clean` perform against the
+real target DB goes over an SSH tunnel to OVH — for a full import, that's
+tens of thousands of small round-trips at WAN latency, which is why a real
+`clean` run can take hours. `stage` writes to a local MySQL instead (`local-mysql`,
+same `mysql:8.4` image the root dev `docker-compose.yml` uses), removing that
+per-row network cost entirely. It's a way to build and inspect a fully-populated
+copy of the import fast, and — later — a way to prepare data for a bulk
+`mysqldump` + `rsync` handoff to OVH instead of thousands of live inserts
+against production. **That handoff step is not implemented yet** — `stage`
+only builds and holds the local copy.
+
+```bash
+docker compose -f scripts/import-tool/docker-compose.yml up -d local-mysql
+docker compose -f scripts/import-tool/docker-compose.yml run --build --rm stage
+```
+
+`local-mysql` doesn't need to be started explicitly first — `run --rm stage`
+brings up its dependencies (`local-mysql`, then the one-shot `local-migrate`)
+automatically — but starting it yourself first lets you watch its healthcheck
+separately and keeps it running independently of any one `stage` invocation.
+
+Both the DB and the staged images persist in named Docker volumes
+(`local-mysql-data`, `local-images-data`) — they survive `docker restart`,
+and survive `docker compose down` (without `-v`) followed by `up`/`run` again.
+Only `docker compose down -v` (or `docker volume rm`) destroys them.
+
+`stage` intentionally differs from `append`/`clean` in two ways:
+
+- **Migrations only, no seeders.** `local-migrate` runs `php artisan migrate --force`
+  and nothing else — no roles, no permissions, no dev users. This container
+  is never meant to be logged into; it exists purely to materialize a
+  fully-populated dataset, so there's no reason to wire up auth for it.
+- **Non-fatal on partial errors.** The importer's `import` and `image-sync`
+  commands both exit non-zero whenever *any* row/file failed — which, for
+  this legacy dataset, is always true (a handful of genuinely bad legacy rows,
+  and some image paths referenced in the legacy DB that don't actually exist
+  under `LEGACY_IMAGES_HOST_PATH`). `append`/`clean` still treat that as fatal
+  (unchanged, on purpose — see `run_importer_import`/`run_image_sync_and_push`
+  in `entrypoint.sh`). `stage` uses tolerant variants that log a note and
+  continue instead, since the goal is "best complete copy possible," not
+  "abort over a known, already-summarized handful of legacy gaps." Every
+  skipped row/file is still listed in the run's own output and log file —
+  nothing is silently swallowed, just not treated as pipeline-fatal.
+
+Rerunning `stage` against an already-populated `local-mysql` is safe and
+fast — `import` and `image-sync` are both idempotent, so a rerun only adds
+what's missing (e.g. after new legacy data shows up) instead of redoing
+everything.
 
 ## Testing against real OVH
 

--- a/scripts/import-tool/docker-compose.yml
+++ b/scripts/import-tool/docker-compose.yml
@@ -73,11 +73,14 @@ services:
   # in the root dev docker-compose.yml), image files land in the
   # local-images-data volume. This exists to validate/stage the import at
   # local-network speed (no per-row SSH-tunnel round-trip to OVH) before ever
-  # touching production. Shipping the result to OVH (mysqldump + rsync +
-  # remote load) is a separate, not-yet-automated step — this mode only
-  # builds and holds the local copy.
+  # touching production. Shipping the result to OVH is the separate `ship`
+  # service below.
   local-mysql:
     image: mysql:8.4
+    # MySQL 8.4 ships mysql_native_password disabled server-side by default
+    # (Oracle is phasing it out) — needed to authenticate the Alpine-based
+    # MariaDB client `ship` uses for mysqldump; see mysql/init.sql.
+    command: ["--mysql-native-password=ON"]
     environment:
       MYSQL_ROOT_PASSWORD: rootsecret
       MYSQL_DATABASE: inventory
@@ -85,6 +88,10 @@ services:
       MYSQL_PASSWORD: secret
     volumes:
       - local-mysql-data:/var/lib/mysql
+      # Switches the inventory user to mysql_native_password so `ship`'s
+      # mysqldump (Alpine-based MariaDB client) can authenticate at all —
+      # see mysql/init.sql. Only runs on first-ever init of an empty volume.
+      - ./mysql/init.sql:/docker-entrypoint-initdb.d/10-native-password.sql:ro
     ports:
       - "127.0.0.1:3316:3306"
     healthcheck:
@@ -142,6 +149,32 @@ services:
     depends_on:
       local-migrate:
         condition: service_completed_successfully
+
+  # Ships an already-built `stage` copy to OVH. DESTRUCTIVE (same
+  # CONFIRM_WIPE requirement as `clean`) — see entrypoint.sh's do_ship and
+  # README.md "Shipping a staged build to a server". No LEGACY_IMAGES_HOST_PATH
+  # mount: images come from the already-staged local-images-data volume, not
+  # the legacy image source.
+  ship:
+    <<: *build
+    command: ["ship"]
+    volumes:
+      - ${OVH_SSH_KEY_HOST_PATH}:/run/secrets/deploy_key:ro
+      - ${AUTH_SNAPSHOT_BACKUP_HOST_PATH:-./auth-backups}:/backup
+      - local-images-data:/staging/images:ro
+    environment:
+      DRY_RUN: ${DRY_RUN:-0}
+      CONFIRM_WIPE: ${CONFIRM_WIPE:-}
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-}
+      REGULAR_USER_EMAIL: ${REGULAR_USER_EMAIL:-}
+      LOCAL_DB_HOST: local-mysql
+      LOCAL_DB_PORT: "3306"
+      LOCAL_DB_USERNAME: inventory
+      LOCAL_DB_PASSWORD: secret
+      LOCAL_DB_DATABASE: inventory
+    depends_on:
+      local-mysql:
+        condition: service_healthy
 
 volumes:
   local-mysql-data:

--- a/scripts/import-tool/docker-compose.yml
+++ b/scripts/import-tool/docker-compose.yml
@@ -66,3 +66,84 @@ services:
       CONFIRM_WIPE: ${CONFIRM_WIPE:-}
       ADMIN_EMAIL: ${ADMIN_EMAIL:-}
       REGULAR_USER_EMAIL: ${REGULAR_USER_EMAIL:-}
+
+  # --- Local staging (no OVH contact at all) ---------------------------------
+  # Builds a fully-populated local copy of the legacy import: DB rows land in
+  # local-mysql (a disposable-but-persistent MySQL matching the version used
+  # in the root dev docker-compose.yml), image files land in the
+  # local-images-data volume. This exists to validate/stage the import at
+  # local-network speed (no per-row SSH-tunnel round-trip to OVH) before ever
+  # touching production. Shipping the result to OVH (mysqldump + rsync +
+  # remote load) is a separate, not-yet-automated step — this mode only
+  # builds and holds the local copy.
+  local-mysql:
+    image: mysql:8.4
+    environment:
+      MYSQL_ROOT_PASSWORD: rootsecret
+      MYSQL_DATABASE: inventory
+      MYSQL_USER: inventory
+      MYSQL_PASSWORD: secret
+    volumes:
+      - local-mysql-data:/var/lib/mysql
+    ports:
+      - "127.0.0.1:3316:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      retries: 5
+      start_period: 30s
+
+  # One-shot: applies migrations to local-mysql. Deliberately migrations-only,
+  # no seeders — this container is never meant to be logged into, so roles,
+  # permissions, and dev users are intentionally not created here. Safe to
+  # rerun (migrate is idempotent); reruns each time `stage` starts, per the
+  # same depends_on pattern the root docker-compose.yml uses for its own
+  # migrate -> app sequencing.
+  local-migrate:
+    build:
+      context: ../..
+      dockerfile: .docker/Dockerfile.dev
+    command: ["/bin/sh", "-c", "[ -f vendor/autoload.php ] || composer install --no-interaction --quiet && php artisan migrate --force"]
+    volumes:
+      - ../..:/var/www/app
+      - local-app-vendor:/var/www/app/vendor
+      - ../../.docker/php.dev.ini:/usr/local/etc/php/conf.d/99-app.ini:ro
+    environment:
+      APP_ENV: local
+      APP_DEBUG: "true"
+      DB_CONNECTION: mysql
+      DB_HOST: local-mysql
+      DB_PORT: "3306"
+      DB_DATABASE: inventory
+      DB_USERNAME: inventory
+      DB_PASSWORD: secret
+    depends_on:
+      local-mysql:
+        condition: service_healthy
+
+  stage:
+    <<: *build
+    command: ["stage"]
+    volumes:
+      - ${LEGACY_IMAGES_HOST_PATH}:/legacy-images:ro
+      - local-images-data:/staging/images
+    environment:
+      LEGACY_IMAGES_ROOT: /legacy-images
+      DRY_RUN: ${DRY_RUN:-0}
+      # Overrides the OVH-tunnel DB_* values from .env — this mode writes
+      # straight to local-mysql over the compose network, never through a
+      # tunnel. LEGACY_DB_* still comes from .env unchanged (real legacy
+      # source, same as every other mode).
+      DB_HOST: local-mysql
+      DB_PORT: "3306"
+      DB_USERNAME: inventory
+      DB_PASSWORD: secret
+      DB_DATABASE: inventory
+    depends_on:
+      local-migrate:
+        condition: service_completed_successfully
+
+volumes:
+  local-mysql-data:
+  local-images-data:
+  local-app-vendor:

--- a/scripts/import-tool/entrypoint.sh
+++ b/scripts/import-tool/entrypoint.sh
@@ -25,8 +25,21 @@ set -euo pipefail
 #                       "local-mysql" service) instead of through the OVH
 #                       tunnel. No SSH, no OVH contact at all — builds a
 #                       fully-populated local copy (DB + staged images) at
-#                       local-network speed, to be shipped to OVH separately
-#                       later (mysqldump + rsync, not automated here).
+#                       local-network speed.
+#   ship                Ships an already-built `stage` copy to OVH: the same
+#                       db:wipe -> migrate -> seed -> permission:sync ->
+#                       auth:restore/fallback sequence as `clean` (so the app
+#                       layer — users, roles, permissions, tokens — is always
+#                       rebuilt fresh or restored from a real snapshot on OVH
+#                       itself, NEVER read from local-mysql), followed by
+#                       loading local-mysql's CONTENT tables only (legacy
+#                       import data — explicitly excluding
+#                       users/roles/permissions/tokens/sessions/etc., see
+#                       SHIP_EXCLUDED_TABLES below) through the tunnel, then
+#                       pushing the already-staged images and resyncing the
+#                       glossary. DESTRUCTIVE — same CONFIRM_WIPE requirement
+#                       as `clean`. Requires a `stage` run to have already
+#                       populated local-mysql/local-images-data.
 #
 # See README.md for the full list of required env vars and mounts.
 # ==============================================================================
@@ -35,10 +48,10 @@ IMPORTER_DIR=/opt/import-tool/importer
 
 MODE="${1:-${IMPORT_MODE:-append}}"
 
-# Only append/backup-permissions/clean touch OVH — stage writes straight to a
-# local DB_HOST and never dials out, so OVH_HOST has no reason to be required
-# for it. Checked explicitly per-mode in the dispatch at the bottom instead of
-# unconditionally here.
+# Only append/backup-permissions/clean/ship touch OVH — stage writes straight
+# to a local DB_HOST and never dials out, so OVH_HOST has no reason to be
+# required for it. Checked explicitly per-mode in the dispatch at the bottom
+# instead of unconditionally here.
 OVH_HOST="${OVH_HOST:-}"
 require_ovh_host() { [ -n "$OVH_HOST" ] || die "OVH_HOST is required for mode '$MODE'"; }
 OVH_USER="${OVH_USER:-deploy}"
@@ -48,6 +61,37 @@ OVH_SSH_KEY_PATH="${OVH_SSH_KEY_PATH:-/run/secrets/deploy_key}"
 
 TUNNEL_LOCAL_PORT="${TUNNEL_LOCAL_PORT:-3307}"
 STAGING_DIR="${IMAGE_STAGING_DIR:-/staging/images}"
+
+# `ship`-only: the LOCAL source DB built by a prior `stage` run. Distinct from
+# DB_HOST/DB_PORT/DB_USERNAME/DB_PASSWORD/DB_DATABASE, which for `ship` (unlike
+# `stage`) keep their normal append/clean meaning — the OVH target, reached
+# through the tunnel this container opens.
+LOCAL_DB_HOST="${LOCAL_DB_HOST:-local-mysql}"
+LOCAL_DB_PORT="${LOCAL_DB_PORT:-3306}"
+LOCAL_DB_USERNAME="${LOCAL_DB_USERNAME:-inventory}"
+LOCAL_DB_PASSWORD="${LOCAL_DB_PASSWORD:-secret}"
+LOCAL_DB_DATABASE="${LOCAL_DB_DATABASE:-inventory}"
+
+# Tables NEVER included in a `ship` data load — every table that stores app
+# identity/auth/session/queue/config state rather than imported legacy
+# content. `stage`'s local-mysql never has real data in any of these (no
+# seeders run there — see do_stage), so loading them wholesale onto OVH would
+# blank out its real users, roles, permission assignments, API tokens, and
+# settings. The real app-layer state is instead always (re)built directly on
+# OVH by do_wipe_and_restore, using OVH's own APP_KEY, exactly like `clean`
+# already does — never read from the local build. Reviewed against every
+# migration that creates a users/auth/session/queue/settings table as of this
+# writing; mysqldump --ignore-table is a no-op (not an error) for any of
+# these that don't exist in a given schema version, so this list is safe to
+# keep ahead of what's actually deployed.
+SHIP_EXCLUDED_TABLES=(
+  users password_reset_tokens sessions
+  cache cache_locks
+  jobs job_batches failed_jobs
+  personal_access_tokens email_two_factor_codes
+  permissions roles model_has_permissions model_has_roles role_has_permissions
+  migrations settings
+)
 
 AUTH_SNAPSHOT_REMOTE="${AUTH_SNAPSHOT_REMOTE:-${OVH_SHARED_DIR}/auth-snapshots/current.json.enc}"
 AUTH_SNAPSHOT_LOCAL_BACKUP_DIR="${AUTH_SNAPSHOT_LOCAL_BACKUP_DIR:-/backup}"
@@ -144,26 +188,18 @@ trap close_tunnel EXIT
 # Importer steps (run locally in the container against DB_HOST/DB_PORT, which
 # the caller must set to point at the tunnel — see README.md)
 # ------------------------------------------------------------------------------
+# The importer's `import` command exits 1 whenever totals.errors > 0 (see
+# src/cli/import.ts) — which this legacy dataset always has some of:
+# individual rows with genuinely bad/missing legacy data, already tracked and
+# summarized as warnings/errors in the run's own output, not a sign the whole
+# run failed. Every mode (append/clean/stage) needs image-sync/glossary-resync
+# to still run against whatever WAS imported rather than aborting the entire
+# pipeline over a handful of known, already-summarized per-row failures — this
+# used to die() here, which silently skipped image-sync and glossary:resync on
+# every real append/clean run (confirmed: the OVH `clean` run that produced
+# "135343 imported ... 385 errors" never reached either step, because this
+# function killed the container right after the import summary printed).
 run_importer_import() {
-  local extra_args=()
-  [ "$DRY_RUN" = "1" ] && extra_args+=(--dry-run)
-
-  log "Running importer: import ${extra_args[*]}"
-  (cd "$IMPORTER_DIR" && npx tsx src/cli/import.ts import "${extra_args[@]}") \
-    || die "importer 'import' step failed"
-}
-
-# Same as run_importer_import, but does not abort the pipeline on a non-zero
-# exit. The importer's `import` command exits 1 whenever totals.errors > 0
-# (see src/cli/import.ts), which this legacy dataset always has some of —
-# individual rows with genuinely bad/missing legacy data (tracked as
-# warnings/errors in its own summary), not a sign the whole run failed. For
-# `stage` specifically we still want image-sync to run against whatever WAS
-# imported rather than abort the entire local build over a handful of known,
-# already-summarized per-row failures. append/clean deliberately keep the
-# stricter die-on-any-error behavior via run_importer_import above — that
-# decision isn't changed here.
-run_importer_import_tolerant() {
   local extra_args=()
   [ "$DRY_RUN" = "1" ] && extra_args+=(--dry-run)
 
@@ -171,7 +207,7 @@ run_importer_import_tolerant() {
   local rc=0
   (cd "$IMPORTER_DIR" && npx tsx src/cli/import.ts import "${extra_args[@]}") || rc=$?
   if [ "$rc" -ne 0 ]; then
-    log "NOTE: importer 'import' exited non-zero (rc=$rc) — see the run's own summary above for the error count. Continuing to image-sync regardless; this is expected for this dataset, not treated as fatal in stage mode."
+    log "NOTE: importer 'import' exited non-zero (rc=$rc) — see the run's own summary above for the error count. Continuing to image-sync/glossary-resync regardless; this is expected for this dataset, not treated as fatal."
   fi
   return 0
 }
@@ -182,9 +218,17 @@ run_image_sync_and_push() {
 
   log "Running importer: image-sync --copy --target-dir $STAGING_DIR ${extra_args[*]}"
   mkdir -p "$STAGING_DIR"
-  if ! (cd "$IMPORTER_DIR" && npx tsx src/cli/import.ts image-sync --copy --target-dir "$STAGING_DIR" "${extra_args[@]}"); then
-    log "image-sync failed"
-    return 1
+  # Same reasoning as run_importer_import: image-sync exits 1 whenever any
+  # individual file failed (e.g. a legacy image path that doesn't exist on
+  # disk — this dataset always has a few hundred of these). Previously this
+  # returned early and skipped the rsync push entirely, discarding every
+  # image that WAS successfully staged, not just the ones that failed. Push
+  # whatever landed in $STAGING_DIR regardless; the run's own summary above
+  # already lists exactly what's missing.
+  local sync_rc=0
+  (cd "$IMPORTER_DIR" && npx tsx src/cli/import.ts image-sync --copy --target-dir "$STAGING_DIR" "${extra_args[@]}") || sync_rc=$?
+  if [ "$sync_rc" -ne 0 ]; then
+    log "NOTE: image-sync exited non-zero (rc=$sync_rc) — see the run's own summary above for what's missing. Pushing whatever was staged regardless."
   fi
 
   if [ "$DRY_RUN" = "1" ]; then
@@ -222,11 +266,11 @@ run_image_sync_local_only() {
   local rc=0
   (cd "$IMPORTER_DIR" && npx tsx src/cli/import.ts image-sync --copy --target-dir "$STAGING_DIR" "${extra_args[@]}") || rc=$?
   if [ "$rc" -ne 0 ]; then
-    # Same reasoning as run_importer_import_tolerant: image-sync exits 1
-    # whenever any file failed (e.g. "Legacy image not found" — broken links
-    # already present in the legacy image tree itself, not something this
-    # container can fix). Not treated as fatal here; the run's own summary
-    # above already lists exactly what's missing.
+    # Same reasoning as run_importer_import: image-sync exits 1 whenever any
+    # file failed (e.g. "Legacy image not found" — broken links already
+    # present in the legacy image tree itself, not something this container
+    # can fix). Not treated as fatal here; the run's own summary above
+    # already lists exactly what's missing.
     log "NOTE: image-sync exited non-zero (rc=$rc) — see the run's own summary above for what's missing. Not treated as fatal in stage mode."
   fi
   return 0
@@ -310,8 +354,80 @@ do_wipe_and_restore() {
 
 do_stage() {
   log "Stage mode: writing straight to DB_HOST=${DB_HOST:-<unset>} — no SSH, no OVH contact"
-  run_importer_import_tolerant
+  run_importer_import
   run_image_sync_local_only
+}
+
+# Dumps LOCAL_DB_* (local-mysql, built by a prior `stage` run), excluding
+# every table in SHIP_EXCLUDED_TABLES, and loads it through the already-open
+# OVH tunnel (DB_HOST/DB_PORT/etc., set up by do_wipe_and_restore + open_tunnel
+# before this runs).
+#
+# The load leg deliberately does NOT pipe mysqldump's output straight into
+# this image's own `mysql` CLI: that CLI is Alpine's MariaDB client, which
+# can't authenticate to a modern MySQL 8 server's default
+# caching_sha2_password plugin at all (confirmed: "Plugin caching_sha2_password
+# could not be loaded" — the plugin's .so isn't present in this package, not
+# an SSL configuration issue) — and that's exactly what both local-mysql and
+# the real OVH target use. Instead: dump to a temp file with mysqldump
+# (--ssl=0 needed even for the dump leg — local-mysql's self-signed cert isn't
+# trusted by this client either), then load that file via the importer's own
+# `load-sql` command, which uses the same mysql2 driver already proven to talk
+# to OVH throughout every other mode in this tool.
+load_staged_dump() {
+  local ignore_flags=()
+  local t
+  for t in "${SHIP_EXCLUDED_TABLES[@]}"; do
+    ignore_flags+=(--ignore-table="${LOCAL_DB_DATABASE}.${t}")
+  done
+
+  local dump_file="/tmp/staged-dump.sql"
+  log "Dumping local-mysql (excluding: ${SHIP_EXCLUDED_TABLES[*]}) to $dump_file"
+  mysqldump -h "$LOCAL_DB_HOST" -P "$LOCAL_DB_PORT" -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" --ssl=0 \
+    --single-transaction --routines --no-tablespaces "${ignore_flags[@]}" "$LOCAL_DB_DATABASE" \
+    > "$dump_file" \
+    || die "dumping local-mysql failed"
+
+  log "Loading $dump_file into ${DB_DATABASE}@${DB_HOST}:${DB_PORT} (through the tunnel)"
+  (cd "$IMPORTER_DIR" && npx tsx src/cli/import.ts load-sql --file "$dump_file") \
+    || die "loading staged dump into ${DB_DATABASE} failed"
+
+  rm -f "$dump_file"
+}
+
+# Pushes images already staged by a prior `stage` run (local-images-data,
+# mounted at $STAGING_DIR) to OVH. Unlike run_image_sync_and_push, this never
+# re-runs the importer's image-sync step — the images are already there.
+# --delete is always correct here: do_wipe_and_restore already wiped OVH, so
+# whatever is in $STAGING_DIR is the full, authoritative set.
+push_staged_images() {
+  if [ "$DRY_RUN" = "1" ]; then
+    log "DRY_RUN=1 — skipping rsync push to OVH"
+    return 0
+  fi
+  log "rsync -az --stats --delete $STAGING_DIR/ -> ${OVH_HOST}:${OVH_SHARED_DIR}/storage/app/public/pictures/"
+  rsync -az --stats --delete -e "ssh ${SSH_OPTS_BASE[*]} -i $SSH_KEY" \
+    "$STAGING_DIR"/ \
+    "${OVH_USER}@${OVH_HOST}:${OVH_SHARED_DIR}/storage/app/public/pictures/" \
+    || die "rsync push failed"
+}
+
+# Ships an already-built `stage` copy to OVH. The app layer (users, roles,
+# permissions, tokens) is always rebuilt fresh on OVH itself by
+# do_wipe_and_restore — reusing it here unchanged means `ship` restores real
+# users/roles from OVH's own snapshot (or the fallback accounts) exactly like
+# `clean` does, and never reads any of that from local-mysql (which has none
+# of it — see do_stage). Only the CONTENT tables (the actual imported legacy
+# data) come from the local build.
+do_ship() {
+  do_wipe_and_restore
+
+  open_tunnel
+  load_staged_dump
+  close_tunnel
+
+  push_staged_images
+  run_glossary_resync
 }
 
 do_backup_permissions() {
@@ -350,8 +466,14 @@ clean)
 stage)
   do_stage
   ;;
+ship)
+  require_ovh_host
+  [ "${CONFIRM_WIPE:-}" = "yes-really-wipe-production" ] \
+    || die "ship mode requires CONFIRM_WIPE=yes-really-wipe-production — refusing to wipe the database"
+  do_ship
+  ;;
 *)
-  die "unknown mode '$MODE' (expected: append | backup-permissions | clean | stage)"
+  die "unknown mode '$MODE' (expected: append | backup-permissions | clean | stage | ship)"
   ;;
 esac
 

--- a/scripts/import-tool/entrypoint.sh
+++ b/scripts/import-tool/entrypoint.sh
@@ -20,6 +20,13 @@ set -euo pipefail
 #                       just those two accounts instead. If neither applies,
 #                       aborts before anything is lost beyond the wipe
 #                       itself.
+#   stage               import -> image-sync, writing straight to DB_HOST
+#                       (expected to be a local MySQL, e.g. the compose
+#                       "local-mysql" service) instead of through the OVH
+#                       tunnel. No SSH, no OVH contact at all — builds a
+#                       fully-populated local copy (DB + staged images) at
+#                       local-network speed, to be shipped to OVH separately
+#                       later (mysqldump + rsync, not automated here).
 #
 # See README.md for the full list of required env vars and mounts.
 # ==============================================================================
@@ -28,7 +35,12 @@ IMPORTER_DIR=/opt/import-tool/importer
 
 MODE="${1:-${IMPORT_MODE:-append}}"
 
-OVH_HOST="${OVH_HOST:?OVH_HOST is required}"
+# Only append/backup-permissions/clean touch OVH — stage writes straight to a
+# local DB_HOST and never dials out, so OVH_HOST has no reason to be required
+# for it. Checked explicitly per-mode in the dispatch at the bottom instead of
+# unconditionally here.
+OVH_HOST="${OVH_HOST:-}"
+require_ovh_host() { [ -n "$OVH_HOST" ] || die "OVH_HOST is required for mode '$MODE'"; }
 OVH_USER="${OVH_USER:-deploy}"
 OVH_APP_DIR="${OVH_APP_DIR:-/opt/inventory/current}"
 OVH_SHARED_DIR="${OVH_SHARED_DIR:-/opt/inventory/shared}"
@@ -141,6 +153,29 @@ run_importer_import() {
     || die "importer 'import' step failed"
 }
 
+# Same as run_importer_import, but does not abort the pipeline on a non-zero
+# exit. The importer's `import` command exits 1 whenever totals.errors > 0
+# (see src/cli/import.ts), which this legacy dataset always has some of —
+# individual rows with genuinely bad/missing legacy data (tracked as
+# warnings/errors in its own summary), not a sign the whole run failed. For
+# `stage` specifically we still want image-sync to run against whatever WAS
+# imported rather than abort the entire local build over a handful of known,
+# already-summarized per-row failures. append/clean deliberately keep the
+# stricter die-on-any-error behavior via run_importer_import above — that
+# decision isn't changed here.
+run_importer_import_tolerant() {
+  local extra_args=()
+  [ "$DRY_RUN" = "1" ] && extra_args+=(--dry-run)
+
+  log "Running importer: import ${extra_args[*]}"
+  local rc=0
+  (cd "$IMPORTER_DIR" && npx tsx src/cli/import.ts import "${extra_args[@]}") || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    log "NOTE: importer 'import' exited non-zero (rc=$rc) — see the run's own summary above for the error count. Continuing to image-sync regardless; this is expected for this dataset, not treated as fatal in stage mode."
+  fi
+  return 0
+}
+
 run_image_sync_and_push() {
   local extra_args=()
   [ "$DRY_RUN" = "1" ] && extra_args+=(--dry-run)
@@ -176,6 +211,25 @@ run_image_sync_and_push() {
     log "rsync push failed"
     return 1
   fi
+}
+
+run_image_sync_local_only() {
+  local extra_args=()
+  [ "$DRY_RUN" = "1" ] && extra_args+=(--dry-run)
+
+  log "Running importer: image-sync --copy --target-dir $STAGING_DIR ${extra_args[*]} (local only, no OVH push)"
+  mkdir -p "$STAGING_DIR"
+  local rc=0
+  (cd "$IMPORTER_DIR" && npx tsx src/cli/import.ts image-sync --copy --target-dir "$STAGING_DIR" "${extra_args[@]}") || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    # Same reasoning as run_importer_import_tolerant: image-sync exits 1
+    # whenever any file failed (e.g. "Legacy image not found" — broken links
+    # already present in the legacy image tree itself, not something this
+    # container can fix). Not treated as fatal here; the run's own summary
+    # above already lists exactly what's missing.
+    log "NOTE: image-sync exited non-zero (rc=$rc) — see the run's own summary above for what's missing. Not treated as fatal in stage mode."
+  fi
+  return 0
 }
 
 run_glossary_resync() {
@@ -254,6 +308,12 @@ do_wipe_and_restore() {
   fi
 }
 
+do_stage() {
+  log "Stage mode: writing straight to DB_HOST=${DB_HOST:-<unset>} — no SSH, no OVH contact"
+  run_importer_import_tolerant
+  run_image_sync_local_only
+}
+
 do_backup_permissions() {
   prepare_ssh_key
   mkdir -p "$AUTH_SNAPSHOT_LOCAL_BACKUP_DIR"
@@ -275,17 +335,23 @@ do_backup_permissions() {
 # ------------------------------------------------------------------------------
 case "$MODE" in
 append)
+  require_ovh_host
   do_import_pipeline
   ;;
 backup-permissions)
+  require_ovh_host
   do_backup_permissions
   ;;
 clean)
+  require_ovh_host
   do_wipe_and_restore
   do_import_pipeline
   ;;
+stage)
+  do_stage
+  ;;
 *)
-  die "unknown mode '$MODE' (expected: append | backup-permissions | clean)"
+  die "unknown mode '$MODE' (expected: append | backup-permissions | clean | stage)"
   ;;
 esac
 

--- a/scripts/import-tool/mysql/init.sql
+++ b/scripts/import-tool/mysql/init.sql
@@ -1,0 +1,16 @@
+-- Only runs on first initialization of a fresh local-mysql volume (Docker's
+-- official mysql image only executes /docker-entrypoint-initdb.d/* when the
+-- data directory is empty). If local-mysql-data already has data, this file
+-- is not re-run — an existing volume that predates this file needs the same
+-- ALTER USER run manually once.
+--
+-- Why: MySQL 8's default caching_sha2_password auth plugin isn't supported
+-- by the Alpine-based MariaDB client used elsewhere in this tool's own image
+-- ("Plugin caching_sha2_password could not be loaded" — the plugin's .so
+-- isn't packaged, not an SSL/config issue). local-mysql is a disposable,
+-- local-only, non-production instance with hardcoded dev credentials, so
+-- switching its auth plugin to the older, universally-supported
+-- mysql_native_password is a safe, narrowly-scoped fix — it only affects this
+-- container's own throwaway user, never OVH's real database or credentials.
+ALTER USER 'inventory'@'%' IDENTIFIED WITH mysql_native_password BY 'secret';
+FLUSH PRIVILEGES;

--- a/scripts/importer/src/cli/import.ts
+++ b/scripts/importer/src/cli/import.ts
@@ -18,6 +18,7 @@
 
 import dotenv from 'dotenv';
 import { resolve } from 'path';
+import { readFileSync } from 'fs';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import mysql from 'mysql2/promise';
@@ -1614,6 +1615,62 @@ program
       console.log(chalk.red(`\n❌ Image sync failed: ${message}`));
       console.log(chalk.red(error instanceof Error ? error.stack : ''));
       process.exit(1);
+    }
+  });
+
+program
+  .command('load-sql')
+  .description(
+    'Execute a SQL file against the target DB (DB_HOST/DB_PORT/DB_USERNAME/DB_PASSWORD/DB_DATABASE). ' +
+      "Built for import-tool's `ship` mode, which loads a mysqldump of a local `stage` build " +
+      "through the OVH tunnel — mysqldump's own CLI can't authenticate to a modern MySQL 8 " +
+      "server's caching_sha2_password default from this project's Alpine-based tooling image, " +
+      'so this reuses the same mysql2 driver the rest of the importer already relies on.'
+  )
+  .requiredOption('--file <path>', 'Path to the .sql file to execute')
+  .action(async (options) => {
+    const filePath = options.file as string;
+    console.log(chalk.cyan(`Loading SQL file: ${filePath}`));
+
+    let sql: string;
+    try {
+      sql = readFileSync(filePath, 'utf8');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.log(chalk.red(`\n❌ Failed to read ${filePath}: ${message}`));
+      process.exit(1);
+    }
+
+    if (!sql.trim()) {
+      console.log(chalk.yellow('SQL file is empty — nothing to do.'));
+      return;
+    }
+
+    // multipleStatements is off everywhere else in this codebase deliberately
+    // (see LegacyDatabase) since it defeats single-statement SQL-injection
+    // protections when a query might carry untrusted input. This connection
+    // is the one narrow, intentional exception: it only ever executes a file
+    // WE generated ourselves via mysqldump immediately beforehand — never
+    // arbitrary or user-supplied SQL — and running a full dump in one round
+    // trip requires it.
+    const connection = await mysql.createConnection({
+      host: process.env['DB_HOST'] || 'localhost',
+      port: parseInt(process.env['DB_PORT'] || '3306', 10),
+      user: process.env['DB_USERNAME'] || 'root',
+      password: process.env['DB_PASSWORD'] || '',
+      database: process.env['DB_DATABASE'] || 'inventory',
+      multipleStatements: true,
+    });
+
+    try {
+      await connection.query(sql);
+      console.log(chalk.green('✓ SQL file loaded successfully'));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.log(chalk.red(`\n❌ Failed to load SQL file: ${message}`));
+      process.exit(1);
+    } finally {
+      await connection.end();
     }
   });
 


### PR DESCRIPTION
## Summary

- Adds a `stage` mode: builds a fully-populated local copy of the legacy import (DB in a persistent `local-mysql`, images in a persistent `local-images-data` volume) writing directly to a local MySQL instead of through the OVH SSH tunnel, removing the per-row WAN round-trip that makes real `clean` runs take hours. Validated end-to-end against the real legacy DB: 27,813 items / 54,773 translations / 434 partners / 27,042 item images, idempotent reruns confirmed, data/images confirmed to survive both `docker restart` and a full `docker compose down` (without `-v`) + recreate.
- Fixes a real bug shared by `append`/`clean`, confirmed in production: the importer's `import`/`image-sync` commands exit 1 whenever any individual row/file fails (expected for this dataset — a few hundred known-bad legacy rows/missing image paths), and `entrypoint.sh` treated that as pipeline-fatal — so a real OVH `clean` run completed the whole import (135343 rows) and then **never ran image-sync or `glossary:resync` at all**. Every mode now logs and continues past per-row/per-file errors instead; a genuine transport failure (rsync itself) is still fatal.
- Adds a `ship` mode: sends an already-built `stage` copy to OVH. Rebuilds the app layer on OVH exactly like `clean` (db:wipe → migrate → seed → permission:sync → restore/recreate users — real auth state always comes from OVH itself, never from the local build), then loads `local-mysql`'s content tables through the tunnel while explicitly excluding every auth/session/queue/settings table (`local-mysql` never has real data there, since `stage` runs no seeders — loading them wholesale would blank out OVH's real users/roles/tokens/settings). Verified locally: dumped with the exclusion list and confirmed zero rows for any excluded table, all 43 real content tables present.
- Fixes two MySQL-8-compatibility bugs found while building `ship`: local-mysql needs `mysql_native_password` (both server- and user-side — MySQL 8.4 disables it by default, and the Alpine MariaDB client added for `mysqldump` can't authenticate via `caching_sha2_password` at all), and the load-into-OVH leg uses a new `import.ts load-sql` command (reusing the already-proven `mysql2` driver) instead of piping into that same incompatible CLI.

## Test plan
- [x] `vitest run` (importer): 383/383 passing
- [x] `tsc --noEmit` (importer): clean
- [x] `eslint .` (importer): clean
- [x] `bash -n entrypoint.sh`: clean
- [x] `docker compose config`: clean
- [x] Full local `stage` run against the real legacy DB, validated idempotent reruns and volume persistence across restarts/recreation
- [x] `load-sql` smoke-tested against `local-mysql` (create/insert/verify/drop)
- [x] Ship's exclusion-list dump verified locally: 0 rows for any of the 17 excluded auth/infra tables, all 43 content tables present
- [ ] `ship` not yet run against real OVH as part of this PR (destructive — run separately, deliberately, outside CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)