### PR TITLE
feat(viewer): Artistic Introduction pages + exporter data fixes

### DIFF
--- a/scripts/exporter/README.md
+++ b/scripts/exporter/README.md
@@ -1,0 +1,149 @@
+# Exporter
+
+Reads the `inventory-app` database directly and writes a set of denormalized,
+static JSON files for public-facing frontends to consume — no API server, no
+auth, no runtime database dependency. Optionally packages and publishes that
+output as a private npm package via GitHub Packages, which is how
+[`scripts/viewer`](../viewer/README.md) and the deployed Discover Islamic Art
+site actually consume it.
+
+## Run (TL;DR)
+
+```powershell
+cd scripts/exporter
+npm install                # first run only
+npm run export -- islamicart ISL `
+  --force `
+  --base-url https://inventory.metanull.eu `
+  --publish `
+  --package-name @metanull/islamicart-data `
+  --package-version 1.0.15
+cd output/islamicart && npm publish
+```
+
+(`--package-version` is optional — omit it to auto-increment instead; see
+[`NPM_PUBLISH.md`](NPM_PUBLISH.md).)
+
+## What it exports
+
+One JSON file per entity type, plus a manifest and per-language translation
+files, written to `output/<subdirectory>/data/`:
+
+| File | Exporter | Contents |
+|---|---|---|
+| `manifest.json` | `ManifestExporter` | Metadata about the export itself (project keys, generated-at timestamp, available languages) |
+| `languages.json` | `LanguageExporter` | Language reference data |
+| `countries.json` | `CountryExporter` | Country reference data + translations |
+| `dynasties.json` | `DynastyExporter` | Dynasty reference data + translations |
+| `timelines.json` | `TimelineExporter` | Timelines and their events |
+| `partners.json` | `PartnerExporter` | Museums/institutions + translations + images |
+| `items.json` | `ItemExporter` | Items (objects/monuments/details), with images, dynasty/tag links, related-item links |
+| `collections.json` | `CollectionExporter` | Collections (exhibitions/themes/galleries), with images and item membership |
+| `glossary.json` | `GlossaryExporter` | Glossary terms + translations |
+| `translations/items.<lang>.json` | `ItemExporter` | Per-language item translation fields, lazy-loadable separately from `items.json` |
+| `translations/collections.<lang>.json` | `CollectionExporter` | Per-language collection translation fields |
+
+Every JSON file is also written gzip-compressed (`.json.gz`) alongside the
+plain version — the compressed copies aren't part of the npm package (see
+below) but are there for CDN/static-hosting use.
+
+### Scoping to specific projects
+
+Export is always scoped to one or more legacy project keys (e.g. `ISL`,
+`WHS`), resolved against `projects.backward_compatibility` (`mwnf3:projects:
+{KEY}`) — not every project in the database gets exported by default. The
+same keys resolve a matching set of context IDs, used internally to exclude
+explore-context translations from overwriting the canonical project
+translations for items/collections.
+
+## Configure
+
+```bash
+cp .env.example .env
+# edit .env
+```
+
+- `DB_*` — the inventory database to read from (same variables/meaning as
+  the [importer](../importer/README.md)'s target-DB connection — point this
+  at a tunnel, a local dev DB, or [import-tool](../import-tool/README.md)'s
+  `local-mysql` interchangeably, since the exporter only ever reads)
+- `BASE_URL` — prepended to image paths in the exported JSON (defaults to
+  `./images`, relative to wherever the JSON is served from)
+- `PACKAGE_AUTHOR` / `PACKAGE_LICENSE` / `PACKAGE_REPO_URL` / `NPM_REGISTRY`
+  — npm package metadata, only used with `--publish`
+
+## Usage
+
+```bash
+npm run export -- <subdirectory> <project-key> [more-project-keys...] [options]
+```
+
+```bash
+# Export a single project
+npm run export -- islamicart ISL
+
+# Export multiple projects into one output
+npm run export -- combined ISL WHS
+
+# Custom output location and image base URL
+npm run export -- islamicart ISL --output-dir /tmp/export --base-url https://cdn.example.com/storage
+
+# Export, bump the package version, generate package.json/README.md, and publish
+npm run export -- islamicart ISL --publish
+```
+
+| Option | Description |
+|---|---|
+| `--force` | Overwrite the output directory if it already exists (refuses to run otherwise) |
+| `--output-dir <path>` | Base output directory (default: `output`, relative to cwd) |
+| `--base-url <url>` | Base URL prepended to image paths (default: `BASE_URL` env var, then `./images`) |
+| `--publish` | Bump version, generate `package.json`/`README.md`, and `npm publish` the output as an npm package |
+| `--package-name <name>` | Override the package name (default: `@mwnf/{subdirectory}-data`) |
+| `--package-version <semver>` | Set an explicit version instead of auto-incrementing |
+| `--npm-registry <url>` | Override the publish registry (default: `NPM_REGISTRY` env var, then GitHub Packages) |
+
+See [`NPM_PUBLISH.md`](NPM_PUBLISH.md) for the full publishing workflow —
+version-file mechanics, package structure, GitHub Packages authentication,
+and the consumer-side install/import story.
+
+## How this fits together
+
+```
+inventory-app DB
+      │  (exporter reads directly — no API involved)
+      ▼
+scripts/exporter  ──npm publish──▶  @metanull/islamicart-data (GitHub Packages)
+                                             │  npm install
+                                             ▼
+                                     scripts/viewer (or any consumer)
+```
+
+The exporter and the viewer are decoupled entirely through the published
+package — the viewer never talks to the exporter or the database directly,
+it just depends on whatever version of the data package is installed.
+Routine content updates mean: re-export with `--publish --force`, `npm
+publish`, then either let the viewer's deploy workflow pick up `@latest`
+automatically (see [`scripts/viewer/README.md`](../viewer/README.md)) or
+bump it manually for other consumers. `@metanull/islamicart-data` is the
+package actually deployed today; the code's own default naming
+(`@mwnf/{subdirectory}-data`, see the option table above) is there for
+anyone exporting a differently-scoped or differently-named package.
+
+## Troubleshooting
+
+**`Output directory already exists`** — pass `--force` to overwrite it, or
+pick a different `--output-dir`/subdirectory.
+
+**Export completes with `EXPORT COMPLETED WITH ERRORS`** — one or more
+exporters failed independently (the CLI continues through all exporters
+regardless, then reports every failure at the end); `--publish` is skipped
+entirely if any exporter errored. Check the per-exporter error line in the
+final summary for which one failed and why.
+
+**`npm publish` fails with "not authorized"** — GitHub Packages
+authentication isn't configured; see [`NPM_PUBLISH.md`](NPM_PUBLISH.md#github-packages-authentication).
+
+**Database connection fails** — same `DB_*` variables and troubleshooting as
+the [importer](../importer/README.md#troubleshooting); this exporter has no
+`validate` command of its own, so a quick `--force` export against a small
+single project is the fastest way to confirm connectivity.

--- a/scripts/exporter/src/exporters/collection-exporter.ts
+++ b/scripts/exporter/src/exporters/collection-exporter.ts
@@ -169,6 +169,7 @@ export class CollectionExporter extends BaseExporter {
       id: c.id,
       type: c.type,
       internal_name: c.internal_name,
+      backward_compatibility: c.backward_compatibility,
       parent_id: c.parent_id,
       country_id: c.country_id,
       display_order: c.display_order,

--- a/scripts/exporter/src/exporters/collection-exporter.ts
+++ b/scripts/exporter/src/exporters/collection-exporter.ts
@@ -34,6 +34,12 @@ const CAPTION_FIELD_MAP: Record<string, keyof CollectionItemCaption> = {
   detail_justification: 'justification',
 }
 
+/** One selectable detail sub-image of an item (e.g. a close-up of one part of a monument). */
+interface CollectionItemDetailEntry {
+  image_url: string | null
+  caption?: Record<string, CollectionItemCaption>
+}
+
 interface CollectionTranslationRow {
   collection_id: string
   language_id: string
@@ -159,10 +165,11 @@ export class CollectionExporter extends BaseExporter {
     }
 
     // collection_id -> items[]
+    const imageUrlFn = (path: string) => this.imageUrl(path)
     const itemMap = new Map<string, ReturnType<typeof buildCollectionItemEntry>[]>()
     for (const link of itemLinks) {
       if (!itemMap.has(link.collection_id)) itemMap.set(link.collection_id, [])
-      itemMap.get(link.collection_id)!.push(buildCollectionItemEntry(link))
+      itemMap.get(link.collection_id)!.push(buildCollectionItemEntry(link, imageUrlFn))
     }
 
     const output = collections.map(c => ({
@@ -187,33 +194,57 @@ export class CollectionExporter extends BaseExporter {
 }
 
 /**
+ * Pivots caption/override fields (item_name, item_date, item_dynasty,
+ * item_location, item_museum, detail_name, detail_justification — each a
+ * language-keyed map) into a per-language caption record.
+ */
+function extractCaptions(fields: Record<string, unknown>): Record<string, CollectionItemCaption> {
+  const caption: Record<string, CollectionItemCaption> = {}
+  for (const [legacyField, outField] of Object.entries(CAPTION_FIELD_MAP)) {
+    const langMap = fields[legacyField]
+    if (!langMap || typeof langMap !== 'object') continue
+    for (const [lang, text] of Object.entries(langMap as Record<string, string>)) {
+      if (!text) continue
+      if (!caption[lang]) caption[lang] = {}
+      caption[lang]![outField] = text
+    }
+  }
+  return caption
+}
+
+/**
  * Builds one collections.json item entry from a collection_item pivot row.
  *
  * `extra` holds legacy placement metadata: `n`/`n2` (grid row/column — items
  * sharing the same row can have several selectable variants at different
- * columns, mirroring the legacy artintro thumbnail-grid UI) and per-language
- * caption overrides (item_name, item_date, item_dynasty, item_location,
- * item_museum, detail_name, detail_justification).
+ * columns, mirroring the legacy artintro/exhibition thumbnail-grid UI),
+ * per-language caption overrides, and — for exhibitions only — a `details`
+ * array of additional selectable sub-images of the same item (e.g. a
+ * close-up of one part of a monument), each with its own image and caption.
  */
-function buildCollectionItemEntry(link: CollectionItemRow): {
+function buildCollectionItemEntry(
+  link: CollectionItemRow,
+  imageUrlFn: (path: string) => string
+): {
   id: string
   display_order: number | null
   variant_order: number | null
   caption?: Record<string, CollectionItemCaption>
+  details?: CollectionItemDetailEntry[]
 } {
   const extra = parseJson(link.extra) as Record<string, unknown> | null
   const variantOrder = extra && typeof extra.n2 === 'number' ? extra.n2 : null
+  const caption = extra ? extractCaptions(extra) : {}
 
-  const caption: Record<string, CollectionItemCaption> = {}
-  if (extra) {
-    for (const [legacyField, outField] of Object.entries(CAPTION_FIELD_MAP)) {
-      const langMap = extra[legacyField]
-      if (!langMap || typeof langMap !== 'object') continue
-      for (const [lang, text] of Object.entries(langMap as Record<string, string>)) {
-        if (!text) continue
-        if (!caption[lang]) caption[lang] = {}
-        caption[lang]![outField] = text
-      }
+  const details: CollectionItemDetailEntry[] = []
+  if (extra && Array.isArray(extra.details)) {
+    for (const raw of extra.details as Record<string, unknown>[]) {
+      const picture = typeof raw.picture_details === 'string' ? raw.picture_details : null
+      const detailCaption = extractCaptions(raw)
+      details.push({
+        image_url: picture ? imageUrlFn(picture) : null,
+        ...(Object.keys(detailCaption).length > 0 ? { caption: detailCaption } : {}),
+      })
     }
   }
 
@@ -222,6 +253,7 @@ function buildCollectionItemEntry(link: CollectionItemRow): {
     display_order: link.display_order,
     variant_order: variantOrder,
     ...(Object.keys(caption).length > 0 ? { caption } : {}),
+    ...(details.length > 0 ? { details } : {}),
   }
 }
 

--- a/scripts/exporter/src/exporters/collection-exporter.ts
+++ b/scripts/exporter/src/exporters/collection-exporter.ts
@@ -13,6 +13,27 @@ interface CollectionRow {
   longitude: string | null
 }
 
+/** Per-item caption/override fields, as pivoted from legacy EAV placement metadata. */
+interface CollectionItemCaption {
+  name?: string
+  date?: string
+  dynasty?: string
+  location?: string
+  museum?: string
+  detail_name?: string
+  justification?: string
+}
+
+const CAPTION_FIELD_MAP: Record<string, keyof CollectionItemCaption> = {
+  item_name: 'name',
+  item_date: 'date',
+  item_dynasty: 'dynasty',
+  item_location: 'location',
+  item_museum: 'museum',
+  detail_name: 'detail_name',
+  detail_justification: 'justification',
+}
+
 interface CollectionTranslationRow {
   collection_id: string
   language_id: string
@@ -20,7 +41,7 @@ interface CollectionTranslationRow {
   description: string | null
   quote: string | null
   url: string | null
-  extra: string | null
+  extra: unknown
 }
 
 interface CollectionImageRow {
@@ -34,6 +55,7 @@ interface CollectionItemRow {
   collection_id: string
   item_id: string
   display_order: number | null
+  extra: unknown
 }
 
 export class CollectionExporter extends BaseExporter {
@@ -86,7 +108,7 @@ export class CollectionExporter extends BaseExporter {
       ),
       // Items in these collections, restricted to non-picture items from the project
       this.db.query<CollectionItemRow>(
-        `SELECT ci.collection_id, ci.item_id, ci.display_order
+        `SELECT ci.collection_id, ci.item_id, ci.display_order, ci.extra
          FROM collection_item ci
          JOIN items i ON i.id = ci.item_id
          WHERE ci.collection_id IN (${colPh})
@@ -136,23 +158,24 @@ export class CollectionExporter extends BaseExporter {
       })
     }
 
-    // collection_id -> item_ids[]
-    const itemMap = new Map<string, string[]>()
+    // collection_id -> items[]
+    const itemMap = new Map<string, ReturnType<typeof buildCollectionItemEntry>[]>()
     for (const link of itemLinks) {
       if (!itemMap.has(link.collection_id)) itemMap.set(link.collection_id, [])
-      itemMap.get(link.collection_id)!.push(link.item_id)
+      itemMap.get(link.collection_id)!.push(buildCollectionItemEntry(link))
     }
 
     const output = collections.map(c => ({
       id: c.id,
       type: c.type,
+      internal_name: c.internal_name,
       parent_id: c.parent_id,
       country_id: c.country_id,
       display_order: c.display_order,
       latitude: c.latitude !== null ? parseFloat(c.latitude) : null,
       longitude: c.longitude !== null ? parseFloat(c.longitude) : null,
       images: imageMap.get(c.id) ?? [],
-      item_ids: itemMap.get(c.id) ?? [],
+      items: itemMap.get(c.id) ?? [],
     }))
 
     await this.writeJson('collections.json', output)
@@ -162,10 +185,55 @@ export class CollectionExporter extends BaseExporter {
   }
 }
 
-function parseJson(raw: string | null): unknown | null {
-  if (!raw) return null
+/**
+ * Builds one collections.json item entry from a collection_item pivot row.
+ *
+ * `extra` holds legacy placement metadata: `n`/`n2` (grid row/column — items
+ * sharing the same row can have several selectable variants at different
+ * columns, mirroring the legacy artintro thumbnail-grid UI) and per-language
+ * caption overrides (item_name, item_date, item_dynasty, item_location,
+ * item_museum, detail_name, detail_justification).
+ */
+function buildCollectionItemEntry(link: CollectionItemRow): {
+  id: string
+  display_order: number | null
+  variant_order: number | null
+  caption?: Record<string, CollectionItemCaption>
+} {
+  const extra = parseJson(link.extra) as Record<string, unknown> | null
+  const variantOrder = extra && typeof extra.n2 === 'number' ? extra.n2 : null
+
+  const caption: Record<string, CollectionItemCaption> = {}
+  if (extra) {
+    for (const [legacyField, outField] of Object.entries(CAPTION_FIELD_MAP)) {
+      const langMap = extra[legacyField]
+      if (!langMap || typeof langMap !== 'object') continue
+      for (const [lang, text] of Object.entries(langMap as Record<string, string>)) {
+        if (!text) continue
+        if (!caption[lang]) caption[lang] = {}
+        caption[lang]![outField] = text
+      }
+    }
+  }
+
+  return {
+    id: link.item_id,
+    display_order: link.display_order,
+    variant_order: variantOrder,
+    ...(Object.keys(caption).length > 0 ? { caption } : {}),
+  }
+}
+
+/**
+ * Parses a MySQL JSON column value. mysql2 auto-decodes native JSON columns
+ * into JS objects already, so `raw` is usually an object/array, not a string
+ * — only fall back to JSON.parse for the (defensive) string case.
+ */
+function parseJson(raw: unknown): unknown | null {
+  if (raw == null) return null
+  if (typeof raw === 'object') return raw
   try {
-    return JSON.parse(raw) as unknown
+    return JSON.parse(raw as string) as unknown
   } catch {
     return null
   }

--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -39,7 +39,7 @@ interface ItemTranslationRow {
   provenance: string | null
   obtention: string | null
   bibliography: string | null
-  extra: string | null
+  extra: unknown
   author_name: string | null
   copy_editor_name: string | null
   translator_name: string | null
@@ -58,7 +58,7 @@ interface PictureTranslationRow {
   picture_id: string
   language_id: string
   caption: string | null // description field on picture item translations
-  extra: string | null // JSON: { photographer, copyright }
+  extra: unknown // JSON: { photographer, copyright }
 }
 
 interface ItemDynastyRow {
@@ -367,10 +367,16 @@ interface ImageEntry {
   copyright: string | null
 }
 
-function parseJson(raw: string | null): unknown | null {
-  if (!raw) return null
+/**
+ * Parses a MySQL JSON column value. mysql2 auto-decodes native JSON columns
+ * into JS objects already, so `raw` is usually an object/array, not a string
+ * — only fall back to JSON.parse for the (defensive) string case.
+ */
+function parseJson(raw: unknown): unknown | null {
+  if (raw == null) return null
+  if (typeof raw === 'object') return raw
   try {
-    return JSON.parse(raw) as unknown
+    return JSON.parse(raw as string) as unknown
   } catch {
     return null
   }

--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -23,7 +23,7 @@ interface PartnerTranslationRow {
   contact_website: string | null
   contact_phone: string | null
   contact_email_general: string | null
-  extra: string | null
+  extra: unknown
 }
 
 interface ContactPerson {
@@ -49,7 +49,7 @@ interface PartnerImageRow {
   path: string
   alt_text: string | null
   display_order: number
-  extra: string | null
+  extra: unknown
 }
 
 interface PartnerLogoRow {
@@ -267,9 +267,16 @@ export class PartnerExporter extends BaseExporter {
   }
 }
 
-function parseJson<T>(raw: string): T | null {
+/**
+ * Parses a MySQL JSON column value. mysql2 auto-decodes native JSON columns
+ * into JS objects already, so `raw` is usually an object/array, not a string
+ * — only fall back to JSON.parse for the (defensive) string case.
+ */
+function parseJson<T>(raw: unknown): T | null {
+  if (raw == null) return null
+  if (typeof raw === 'object') return raw as T
   try {
-    return JSON.parse(raw) as T
+    return JSON.parse(raw as string) as T
   } catch {
     return null
   }

--- a/scripts/importer/README.md
+++ b/scripts/importer/README.md
@@ -1,8 +1,28 @@
 # Unified Legacy Importer
 
-A unified import tool for migrating data from the legacy MWNF database to the new Inventory Management System.
+A CLI tool that migrates data from the legacy MWNF databases into the new
+Inventory Management System's database.
 
-**Current Status**: Completes import of the **mwnf3** database (projects, partners, items, images). Other legacy databases (travels, sh, thg, explore) remain to be implemented.
+> **Running this against the OVH-hosted deployment, or want to build a full
+> local copy fast (no SSH tunnel round-trip per row)?** Use
+> [`scripts/import-tool/`](../import-tool/README.md) — a Docker container
+> that drives this importer for you across five modes (`append` / `clean` /
+> `stage` / `ship` / `backup-permissions`), handles the SSH tunnel, sequential
+> exit-code-checked `artisan` commands, image push, and auth snapshot/restore.
+> Everything below is about running the importer directly/standalone —
+> useful for development, debugging a specific importer, or understanding
+> what `import-tool` is actually orchestrating.
+
+**Current status**: Covers the full legacy data model — the core `mwnf3`
+database (projects, partners, objects, monuments, images) plus every
+secondary legacy database this content set has: Sharing History
+(`mwnf3_sharing_history`), Explore (`mwnf3_explore`), Travels
+(`mwnf3_travels`), and Thematic Galleries (`mwnf3_thematic_gallery`), along
+with timelines/HCR and glossary linking. Run `npx tsx src/cli/import.ts
+import --list-importers` for the exact, current, numbered list — well over
+100 importers across 10 phases — rather than relying on this document to
+enumerate them (it won't stay in sync; see "Import Phases" below for the
+shape instead).
 
 ## Architecture
 
@@ -39,9 +59,16 @@ interface ILegacyDatabase {
 
 **Important Notes:**
 
-- Queries must use actual legacy table names (e.g., `mwnf3.objects`, `mwnf3.museums`)
-- The legacy schema differs from the new schema - transformers handle mapping
+- Queries must use actual legacy table names, schema-qualified where the
+  table lives outside the core `mwnf3` schema (e.g. `mwnf3.objects`,
+  `mwnf3_sharing_history.sh_objects`, `mwnf3_explore.exploremonument`,
+  `mwnf3_travels.tr_monuments`, `mwnf3_thematic_gallery.thg_gallery`)
+- Each legacy schema has its own naming quirks and structure — transformers
+  handle mapping all of them to the new, unified schema
 - Languages and countries are loaded from JSON files, NOT from the legacy database
+- `LegacyDatabase`/`ResilientConnection` race every query against a 30s
+  timeout and auto-reconnect on connection loss — a legacy MySQL connection
+  dropping mid-run is expected on long imports, not treated as fatal
 
 ### Data Flow
 
@@ -98,36 +125,28 @@ src/
 │   ├── file-logger.ts     # Dual console/file logging
 │   └── base-importer.ts   # Base importer class
 ├── domain/
-│   ├── types/             # Legacy data types
-│   │   └── legacy.ts      # LegacyObject, LegacyMuseum, etc.
-│   └── transformers/      # Business logic (pure functions)
-│       ├── language-transformer.ts
-│       ├── country-transformer.ts
-│       ├── project-transformer.ts
-│       ├── museum-transformer.ts
-│       ├── institution-transformer.ts
-│       ├── object-transformer.ts
-│       ├── monument-transformer.ts
-│       └── monument-detail-transformer.ts
-├── strategies/             # Write strategy implementations
-│   └── sql-strategy.ts    # SQL-based write strategy
-├── helpers/                # Shared helper classes
-│   ├── tag-helper.ts
-│   ├── author-helper.ts
-│   └── artist-helper.ts
-├── importers/              # Importer implementations
-│   ├── phase-00/          # Reference data (languages, countries, default context)
-│   ├── phase-01/          # Core data (projects, partners, items)
-│   └── phase-02/          # Images (item pictures, partner pictures)
-├── tools/                  # Utility tools
-│   └── image-sync.ts      # Image file synchronization
-├── utils/                  # Utility functions
-│   ├── backward-compatibility.ts
-│   ├── code-mappings.ts
-│   ├── html-to-markdown.ts
-│   └── image-sync.ts      # Image sync utilities
-└── cli/                    # CLI entry points
-    └── import.ts
+│   ├── types/              # Legacy data types (per legacy schema)
+│   └── transformers/       # Business logic (pure functions, per entity)
+├── strategies/
+│   └── sql-strategy.ts     # SQL-based write strategy
+├── helpers/                 # Shared helper classes (tags, authors, artists)
+├── importers/                # Importer implementations, one directory per phase
+│   ├── phase-00/            # Reference data (languages, countries, default context)
+│   ├── phase-01/            # Core mwnf3 data (projects, partners, items, authors, dynasties)
+│   ├── phase-02/            # Core mwnf3 images
+│   ├── phase-03/            # Sharing History (mwnf3_sharing_history)
+│   ├── phase-04/            # Glossary
+│   ├── phase-05/            # Timelines (HCR)
+│   ├── phase-06/            # Explore (mwnf3_explore)
+│   ├── phase-07/            # Travels (mwnf3_travels)
+│   ├── phase-08/            # Media & documents
+│   ├── phase-10/            # Thematic Galleries (mwnf3_thematic_gallery) + cross-schema links
+│   └── phase-11/            # Post-import linking & cleanup (needs everything else imported first)
+├── tools/
+│   └── image-sync.ts       # Image file synchronization
+├── utils/                    # HTML→Markdown, code mappings, backward-compatibility helpers
+└── cli/
+    └── import.ts            # CLI entry point (import, validate, image-sync, load-sql)
 ```
 
 ## Key Design Principles
@@ -140,8 +159,6 @@ All transformation logic is in the `domain/transformers/` directory. These are *
 - Return transformed data ready for persistence
 - Have no side effects
 - Can be easily tested in isolation
-
-**Example**: `monument-detail-transformer.ts` converts legacy monument details into Items with proper type='detail' and parent relationships.
 
 ### 2. Strategy Pattern for Write Operations
 
@@ -163,11 +180,15 @@ The `ITracker` interface provides a consistent way to track imported entities:
 
 ### 4. Resilient Connections
 
-The importer uses `ResilientConnection` with automatic retry logic:
+`LegacyDatabase` and `ResilientConnection` (the target-DB wrapper) both:
 
-- Reconnects on connection loss
-- Retries failed queries up to 3 times
-- Handles database timeouts gracefully
+- Reconnect automatically on connection loss
+- Retry failed queries up to 5 times with backoff
+- Race every query against a 30-second timeout — needed because attaching
+  a custom `'error'` listener to the underlying `mysql2` connection (for
+  reconnect handling) means a socket dying mid-query can otherwise leave
+  the query's own promise hanging forever, silently, with the retry loop
+  never getting a chance to run
 
 ### 5. Comprehensive Logging
 
@@ -184,7 +205,6 @@ Business logic is written once in transformers:
 
 - HTML to Markdown conversion
 - Field truncation and validation
-- EPM description2 handling
 - Tag parsing logic
 - Artist extraction
 
@@ -192,24 +212,22 @@ Business logic is written once in transformers:
 
 ### Typical Workflow
 
-> **Running this against the OVH-hosted deployment?** Use
-> [`scripts/import-tool/`](../import-tool/README.md) — a Docker container
-> that automates the full workflow below (SSH tunnel, sequential
-> exit-code-checked `artisan` commands, rsync image push, auth
-> snapshot/restore) in three modes (`append`/`backup-permissions`/`clean`)
-> instead of running each step by hand.
-
 The importer is designed to run as part of a complete database initialization:
 
 1. **Create auth snapshot** - Preserve user accounts, MFA setup, role assignments, direct permissions, and API tokens (`php artisan auth:snapshot auth-snapshots/pre-import.json.enc --force`)
 2. **Wipe database** - Create or empty the database schema (e.g. `php artisan db:wipe --force; php artisan migrate --force`)
 3. **Seed and sync permissions** - Run `php artisan db:seed --class=MinimalDatabaseSeeder --force` and `php artisan permissions:sync`
 4. **Restore auth snapshot** - Restore users after migrations and permission sync (`php artisan auth:restore auth-snapshots/pre-import.json.enc --force`)
-5. **Run the importer** - Import legacy data from mwnf3 database
+5. **Run the importer** - `import`, then `image-sync`
 6. **Glossary resync** - Re-link glossary spellings to imported translations (required post-import step)
 7. **Done** - Database is ready with both reference and legacy data
 
-Auth snapshots are encrypted with Laravel's current `APP_KEY`; the key is not written into the snapshot file. Restore the snapshot only into an application using the same `APP_KEY`, because Fortify MFA secrets are encrypted with that key.
+[`import-tool`](../import-tool/README.md) automates steps 1–6 end to end
+(and adds a way to build this all locally first, then ship it — see its
+`stage`/`ship` modes). Auth snapshots are encrypted with Laravel's current
+`APP_KEY`; the key is not written into the snapshot file. Restore the
+snapshot only into an application using the same `APP_KEY`, because Fortify
+MFA secrets are encrypted with that key.
 
 All operations are logged to timestamped files in the `logs/` directory for later review.
 
@@ -241,68 +259,74 @@ npx tsx src/cli/import.ts import
 
 ### Available Commands
 
-The importer CLI provides three main commands: import, validate, image-sync.
-
-#### Quick Reference
-
 ```bash
-# Get help on the importer
 npx tsx src/cli/import.ts --help
-
-# Show command-specific help
-npx tsx src/cli/import.ts import --help
-npx tsx src/cli/import.ts validate --help
-npx tsx src/cli/import.ts image-sync --help
 ```
 
-#### 1. Import Command - Import legacy data
+#### 1. `import` — Import legacy data
 
 ```bash
-# Run all importers
 npx tsx src/cli/import.ts import
+npx tsx src/cli/import.ts import --list-importers   # numbered list of every importer, in run order
+npx tsx src/cli/import.ts import --only partner      # run a single importer
+npx tsx src/cli/import.ts import --start-at project  # resume from a given point
+npx tsx src/cli/import.ts import --stop-at partner   # run up to and including a given point
 ```
 
-**Additional paramters:**
+- `--dry-run` - Simulate without writing data
+- `--only <importer>` / `--start-at <importer>` / `--stop-at <importer>` -
+  target a subset; respects the dependency order shown by `--list-importers`
+- `--list-importers` - the authoritative, current list — use this instead of
+  looking for a hardcoded list in this document
 
-- `--help` - Syntax help
-- `--list-importers` - List available importers
-- `--dry-run` - Dry run (simulate without writing)
-- `--only {importer}` - Run specific importer only (e.g. `--only partner`)
-- `--start-at {importer}` - Run from a specific point onwards (e.g. `--start-at project`)
-- `--stop-at {importer}` - Run up to and including a specific point (e.g. `--stop-at partner`)
+Exits with code 1 whenever any individual row failed to import (tracked as
+a warning/error in its own summary, not necessarily a sign the whole run
+failed) — see [`import-tool`](../import-tool/README.md)'s note on this for
+how downstream automation handles it.
 
-#### 2. Validate Command - Test database connections
+#### 2. `validate` — Test database connections
 
 ```bash
-# Validate database connections
 npx tsx src/cli/import.ts validate
 ```
 
-#### 3. Image Sync Command - Synchronize legacy images
+#### 3. `image-sync` — Synchronize legacy images
 
 ```bash
-# Synchronize legacy images to new storage
 npx tsx src/cli/import.ts image-sync
 ```
 
-**Additional parameters:**
-
-- `--help` - Syntax help
 - `--copy` - Copy files instead of symlinking (symlink is the default)
 - `--clear-destination` - Clear destination image folder before synchronization starts
 - `--target-dir <path>` - Target image directory (overrides `NEW_IMAGES_ROOT` env var and artisan fallback)
-- `--dry-run` - Dry run (simulate without making changes)
-
-> ⚠️ **Default mode changed:** `image-sync` now uses **symlinks by default**.
-> To preserve previous behavior, pass `--copy` explicitly.
+- `--dry-run` - Simulate without making changes
 
 **Image Sync Details:**
 
-- Finds ItemImage and PartnerImage records with `size=1` (legacy placeholders)
+- Finds ItemImage/PartnerImage/etc. records with `size=1` (legacy placeholders)
 - Copies or symlinks actual image files from legacy storage
 - Updates database records with correct path, size, and metadata
 - Only connects to the new database (not the legacy database)
 - Requires `LEGACY_IMAGES_ROOT` environment variable
+- Same exit-code behavior as `import`: nonzero whenever any individual file
+  failed (e.g. a legacy path that doesn't exist on disk), not necessarily a
+  sign the whole sync failed
+
+#### 4. `load-sql` — Execute a SQL file against the target DB
+
+```bash
+npx tsx src/cli/import.ts load-sql --file /path/to/dump.sql
+```
+
+Internal plumbing for [`import-tool`](../import-tool/README.md)'s `ship`
+mode — loads a `mysqldump` of a locally-`stage`d build through the OVH
+tunnel, using the same `mysql2` driver the rest of this tool relies on
+(`mysqldump`/`mysql` CLIs can't authenticate to a modern MySQL 8 server's
+`caching_sha2_password` from `import-tool`'s Alpine-based image). Splits the
+file into individual statements and executes them inside one transaction —
+not something you'd typically run by hand; see `import-tool`'s README for
+the full `ship` mode story, including exactly which tables are (and are
+never) included in what it loads.
 
 ### Logging
 
@@ -330,38 +354,27 @@ logs/
 - Phase headers and summaries
 - Final success/failure status
 
-## Import Order
+## Import Phases
 
-Importers run in strict sequence to satisfy dependencies. Each importer logs detailed information to timestamped files in the `logs/` directory.
+Importers run in strict dependency order — each depends on its listed
+`dependencies` in the CLI registry, resolved automatically via
+`orderConfigsByDependencies`, not on the order they happen to be declared in.
+Run `--list-importers` for the definitive, numbered, current list. Shape,
+not an exhaustive enumeration:
 
-### **Phase 0: Reference Data**
-
-Foundation data loaded from JSON files and legacy database translations:
-
-- `default-context` - Create default context (is_default=true)
-- `language` - Languages from JSON file
-- `language-translation` - Language name translations from legacy DB
-- `country` - Countries from JSON file
-- `country-translation` - Country name translations from legacy DB
-
-### **Phase 1: Core Data**
-
-Primary entities imported from legacy mwnf3 database:
-
-- `project` - Projects (creates Context, Collection, and Project)
-- `partner` - Partners (Museums + Institutions)
-- `object` - Object items
-- `monument` - Monument items
-- `monument-detail` - Monument detail items (children of monuments)
-
-### **Phase 2: Images**
-
-Image records with metadata (ItemImages and PartnerImages):
-
-- `object-picture` - Object pictures (ItemImages + child picture Items)
-- `monument-picture` - Monument pictures (ItemImages + child picture Items)
-- `monument-detail-picture` - Monument detail pictures (ItemImages + child picture Items)
-- `partner-picture` - Partner pictures (PartnerImages only)
+| Phase | Legacy source | Covers |
+|---|---|---|
+| 0 | JSON files + `mwnf3` translations | Reference data: default context, languages, countries |
+| 1 | `mwnf3` | Core data: projects, partners (museums/institutions/schools), objects, monuments, monument details, authors, dynasties, item-item links, the mwnf3 exhibition system |
+| 2 | `mwnf3` | Images for the above (object/monument/monument-detail pictures, partner pictures/logos) |
+| 3 | `mwnf3_sharing_history` | Sharing History: projects, partners, objects, monuments, monument details, images, exhibitions, national context, bibliography |
+| 4 | `mwnf3` | Glossary terms, translations, spellings |
+| 5 | (HCR) | Timelines and timeline events |
+| 6 | `mwnf3_explore` | Explore: contexts, countries, regions, locations, monuments, itineraries, thematic cycles, cross-references, filters, and their images/translations |
+| 7 | `mwnf3_travels` | Travels: contexts, trails, itineraries, locations, monuments, and their images/translations |
+| 8 | `mwnf3` | Item media and documents |
+| 10 | `mwnf3_thematic_gallery` | Thematic Galleries: galleries, themes, contributors, tags, timelines, gallery content, and cross-schema links from galleries to items originating in every other legacy schema above |
+| 11 | (post-import) | Collection media (needs THG collections), partner-monument linking, project cleanup (drops projects left with no items) |
 
 ## Environment Variables
 
@@ -390,15 +403,21 @@ LEGACY_IMAGES_ROOT=C:\mwnf-server\pictures\images
 NEW_IMAGES_ROOT=C:\path\to\inventory-app\storage\app\pictures
 ```
 
+Note: only `LEGACY_DB_DATABASE` (the core `mwnf3` schema) is configurable —
+the secondary legacy schemas (`mwnf3_sharing_history`, `mwnf3_explore`,
+`mwnf3_travels`, `mwnf3_thematic_gallery`) are referenced schema-qualified
+directly in each phase's queries and are expected to exist alongside it on
+the same `LEGACY_DB_HOST`.
+
 ### Required Environment Variables
 
 | Variable             | Description                                        | Default                                           |
-| -------------------- | -------------------------------------------------- | ------------------------------------------------- |
+| -------------------- | -------------------------------------------------- | -------------------------------------------------- |
 | `LEGACY_DB_HOST`     | Legacy database hostname                           | `localhost`                                       |
 | `LEGACY_DB_PORT`     | Legacy database port                               | `3306`                                            |
 | `LEGACY_DB_USER`     | Legacy database username                           | `root`                                            |
 | `LEGACY_DB_PASSWORD` | Legacy database password                           | (empty)                                           |
-| `LEGACY_DB_DATABASE` | Legacy database name                               | `mwnf3`                                           |
+| `LEGACY_DB_DATABASE` | Legacy database name (core `mwnf3` schema)         | `mwnf3`                                           |
 | `DB_HOST`            | Target database hostname                           | `localhost`                                       |
 | `DB_PORT`            | Target database port                               | `3306`                                            |
 | `DB_USERNAME`        | Target database username                           | `root`                                            |
@@ -428,30 +447,22 @@ Languages and countries are **NOT** imported from the legacy database. Instead, 
 
 These files are the same sources used by Laravel seeders and the API importer.
 
-### Legacy Database Data
+### Legacy Database Schemas
 
-The following entities are imported from the legacy **mwnf3** database:
-
-- **Projects**: `mwnf3.projects`, `mwnf3.projectnames`
-- **Museums**: `mwnf3.museums`, `mwnf3.museumnames`
-- **Institutions**: `mwnf3.institutions`, `mwnf3.institutionnames`
-- **Objects**: `mwnf3.objects`
-- **Monuments**: `mwnf3.monuments`
-- **Monument Details**: `mwnf3.monument_details`
-- **Object Pictures**: `mwnf3.objects_pictures`
-- **Monument Pictures**: `mwnf3.monuments_pictures`
-- **Monument Detail Pictures**: `mwnf3.monument_detail_pictures`
-- **Museum Pictures**: `mwnf3.museum_pictures`
-- **Institution Pictures**: `mwnf3.institution_pictures`
-
-**Note**: The mwnf3 database import is complete. Other legacy databases (travels, sh, thg, etc.) remain to be implemented in future phases.
+| Schema | What it holds |
+|---|---|
+| `mwnf3` | Core content: projects, partners, objects, monuments, monument details, pictures, glossary, exhibitions, media/documents |
+| `mwnf3_sharing_history` | The Sharing History sub-site's own parallel project/partner/object/monument/exhibition data |
+| `mwnf3_explore` | The Explore sub-site: countries, regions, locations, monuments, itineraries, thematic cycles |
+| `mwnf3_travels` | The Travels sub-site: trails, itineraries, locations, monuments |
+| `mwnf3_thematic_gallery` | Thematic Galleries: curated cross-cutting collections linking back to items from every schema above |
 
 ## Adding New Importers
 
-1. Create legacy type in `domain/types/legacy.ts`
+1. Create legacy type in `domain/types/`
 2. Create transformer in `domain/transformers/`
-3. Create importer in `importers/phase-XX/`
-4. Add to CLI registry in `cli/import.ts`
+3. Create importer in `importers/phase-XX/` (existing phase, or a new one if it's a genuinely new stage)
+4. Add to the CLI registry in `cli/import.ts`, with accurate `dependencies`
 
 ## Special Transformations
 
@@ -489,10 +500,6 @@ All legacy HTML content is converted to Markdown:
 - Strips unsupported HTML tags
 - Handles malformed HTML gracefully
 
-## Sample Collection
-
-**Note:** Sample collection for test fixtures is not currently implemented in this unified importer. The interface `ISampleCollector` exists in `core/base-importer.ts` but is not active.
-
 ## Extending with API Strategy
 
 To add API-based imports:
@@ -500,19 +507,6 @@ To add API-based imports:
 1. Create `strategies/api-strategy.ts` implementing `IWriteStrategy`
 2. Create CLI option to select strategy
 3. Importers automatically work with new strategy
-
-## Benefits of This Architecture
-
-✅ **Single Source of Truth** - Business logic in one place  
-✅ **Easy Testing** - Mock strategies, test transformers separately  
-✅ **Flexible** - Switch strategies at runtime  
-✅ **Extensible** - New strategies without touching business logic  
-✅ **DRY** - No code duplication between API/SQL approaches  
-✅ **KISS** - Simple, focused components  
-✅ **Single Responsibility** - Each component does one thing well  
-✅ **Resilient** - Automatic retry logic for database operations  
-✅ **Traceable** - Comprehensive logging to timestamped files  
-✅ **Type-Safe** - TypeScript ensures correctness at compile time
 
 ## Troubleshooting
 
@@ -524,19 +518,19 @@ To add API-based imports:
 ### Import Failures Mid-Process
 
 **Error**: Import stops partway through  
-**Solution**: Check the log file in `logs/` directory. The resilient connection should handle temporary issues. For persistent errors, fix the data issue and restart from the failing importer using `--start-at`.
+**Solution**: Check the log file in `logs/` directory. `LegacyDatabase`/`ResilientConnection` retry and reconnect automatically on connection loss. For a genuine data issue on one row, fix it and restart from the failing importer using `--start-at`.
 
 ### Duplicate Key Violations
 
 **Error**: `Duplicate entry for key 'backward_compatibility'`  
-**Solution**: Wipe the database before re-running. The importer is designed for clean imports, not incremental updates.
+**Solution**: This importer is idempotent by design (safe to re-run without wiping — it detects already-imported rows via `backward_compatibility` and skips them). A duplicate-key error despite that usually means the *target* schema state doesn't match what the importer expects; wiping and re-running from scratch is the reliable fallback.
 
 ### Missing Dependencies
 
 **Error**: Importer complains about missing entities  
-**Solution**: Ensure importers run in order. Use `--start-at` and `--stop-at` carefully, respecting dependencies listed in the CLI registry.
+**Solution**: Ensure importers run in order — `--list-importers` reflects the real, resolved dependency order. Use `--start-at`/`--stop-at`/`--only` carefully; skipping an importer that a later one depends on will surface as a "not found" error partway through.
 
 ### Image Sync Issues
 
 **Error**: Image files not found  
-**Solution**: Verify `LEGACY_IMAGES_ROOT` path in `.env` points to the correct legacy images directory.
+**Solution**: Verify `LEGACY_IMAGES_ROOT` path in `.env` points to the correct legacy images directory. Some legacy image paths referenced in the source database genuinely don't exist on disk — `image-sync` reports these individually rather than aborting the whole run; check its summary for the exact list.

--- a/scripts/importer/src/cli/import.ts
+++ b/scripts/importer/src/cli/import.ts
@@ -134,6 +134,7 @@ import {
   ThgGalleryContentImporter,
   PartnerHierarchyImporter,
   InstitutionHierarchyImporter,
+  ArtintroRootCollectionImporter,
   Mwnf3ExhibitionImporter,
   Mwnf3ExhibitionTranslationImporter,
   Mwnf3ExhibitionItemImporter,
@@ -424,11 +425,19 @@ const ALL_IMPORTERS: ImporterConfig[] = [
   },
   // Phase 1: mwnf3 Exhibition System
   {
+    key: 'artintro-root-collection',
+    name: 'Artistic Introduction Root Collection',
+    description:
+      'Create the "Artistic Introduction" marker collection (child of the ISL project collection) that the artintro hierarchy nests under',
+    importerClass: ArtintroRootCollectionImporter,
+    dependencies: ['project', 'language'],
+  },
+  {
     key: 'mwnf3-exhibition',
     name: 'MWNF3 Exhibitions',
     description: 'Import mwnf3 exhibition + artintro hierarchy as nested collections',
     importerClass: Mwnf3ExhibitionImporter,
-    dependencies: ['project', 'language'],
+    dependencies: ['project', 'language', 'artintro-root-collection'],
   },
   {
     key: 'mwnf3-exhibition-translation',

--- a/scripts/importer/src/cli/import.ts
+++ b/scripts/importer/src/cli/import.ts
@@ -135,6 +135,7 @@ import {
   PartnerHierarchyImporter,
   InstitutionHierarchyImporter,
   ArtintroRootCollectionImporter,
+  ExhibitionsRootCollectionImporter,
   Mwnf3ExhibitionImporter,
   Mwnf3ExhibitionTranslationImporter,
   Mwnf3ExhibitionItemImporter,
@@ -433,11 +434,19 @@ const ALL_IMPORTERS: ImporterConfig[] = [
     dependencies: ['project', 'language'],
   },
   {
+    key: 'exhibitions-root-collection',
+    name: 'Exhibitions Root Collection',
+    description:
+      'Create the "Exhibitions" marker collection (child of the ISL project collection) that ISL exhibitions nest under',
+    importerClass: ExhibitionsRootCollectionImporter,
+    dependencies: ['project', 'language'],
+  },
+  {
     key: 'mwnf3-exhibition',
     name: 'MWNF3 Exhibitions',
     description: 'Import mwnf3 exhibition + artintro hierarchy as nested collections',
     importerClass: Mwnf3ExhibitionImporter,
-    dependencies: ['project', 'language', 'artintro-root-collection'],
+    dependencies: ['project', 'language', 'artintro-root-collection', 'exhibitions-root-collection'],
   },
   {
     key: 'mwnf3-exhibition-translation',

--- a/scripts/importer/src/importers/index.ts
+++ b/scripts/importer/src/importers/index.ts
@@ -19,6 +19,7 @@ export { AuthorImporter } from './phase-01/index.js';
 export { SchoolImporter } from './phase-01/index.js';
 export { PartnerHierarchyImporter } from './phase-01/index.js';
 export { InstitutionHierarchyImporter } from './phase-01/index.js';
+export { ArtintroRootCollectionImporter } from './phase-01/index.js';
 export { Mwnf3ExhibitionImporter } from './phase-01/index.js';
 export { Mwnf3ExhibitionTranslationImporter } from './phase-01/index.js';
 export { Mwnf3ExhibitionItemImporter } from './phase-01/index.js';

--- a/scripts/importer/src/importers/index.ts
+++ b/scripts/importer/src/importers/index.ts
@@ -20,6 +20,7 @@ export { SchoolImporter } from './phase-01/index.js';
 export { PartnerHierarchyImporter } from './phase-01/index.js';
 export { InstitutionHierarchyImporter } from './phase-01/index.js';
 export { ArtintroRootCollectionImporter } from './phase-01/index.js';
+export { ExhibitionsRootCollectionImporter } from './phase-01/index.js';
 export { Mwnf3ExhibitionImporter } from './phase-01/index.js';
 export { Mwnf3ExhibitionTranslationImporter } from './phase-01/index.js';
 export { Mwnf3ExhibitionItemImporter } from './phase-01/index.js';

--- a/scripts/importer/src/importers/phase-01/artintro-root-collection-importer.ts
+++ b/scripts/importer/src/importers/phase-01/artintro-root-collection-importer.ts
@@ -1,0 +1,132 @@
+/**
+ * Artistic Introduction Root Collection Importer
+ *
+ * Creates a single "Artistic Introduction" marker collection as a child of
+ * the Islamic Art (ISL) project collection. This gives Artistic Introduction
+ * data (artintro root, themes, pages) an unambiguous parent to hang off of,
+ * the same pattern already used to identify other exhibition-like
+ * categories (THG galleries/exhibitions roots, Explore roots, Travels
+ * root): a dedicated collection with a stable backward_compatibility key,
+ * rather than internal_name string matching.
+ *
+ * Mwnf3ExhibitionImporter nests the existing artintro root
+ * ("mwnf3:artintros:{id}") under this collection instead of directly under
+ * the ISL project collection.
+ *
+ * Legacy schema:
+ * - No direct equivalent (we create a root container)
+ *
+ * New schema:
+ * - collections (id, context_id, language_id, parent_id, type, internal_name, backward_compatibility, ...)
+ * - collection_translations (collection_id, language_id, context_id, title, description, ...)
+ *
+ * Mapping:
+ * - internal_name = 'artintro_root'
+ * - type = 'collection'
+ * - parent_id = ISL project collection
+ * - backward_compatibility = 'mwnf3:artintro:root'
+ *
+ * Dependencies:
+ * - ProjectImporter (ISL project + context must exist)
+ * - LanguageImporter (for default language)
+ */
+
+import { BaseImporter } from '../../core/base-importer.js';
+import type { ImportResult } from '../../core/types.js';
+
+const MWNF3_SCHEMA = 'mwnf3';
+const ISL_PROJECT_KEY = 'ISL';
+
+export class ArtintroRootCollectionImporter extends BaseImporter {
+  getName(): string {
+    return 'ArtintroRootCollectionImporter';
+  }
+
+  async import(): Promise<ImportResult> {
+    const result = this.createResult();
+
+    try {
+      const backwardCompat = `${MWNF3_SCHEMA}:artintro:root`;
+
+      if (await this.entityExistsAsync(backwardCompat, 'collection')) {
+        this.logInfo('Artistic Introduction root collection already exists, skipping');
+        result.skipped++;
+        this.showSkipped();
+        return result;
+      }
+
+      this.logInfo('Looking up ISL project collection...');
+      const projectBackwardCompat = `${MWNF3_SCHEMA}:projects:${ISL_PROJECT_KEY}`;
+      const parentCollectionId = await this.getEntityUuidAsync(projectBackwardCompat, 'collection');
+      if (!parentCollectionId) {
+        throw new Error(
+          `ISL project collection not found (${projectBackwardCompat}). Run ProjectImporter first.`
+        );
+      }
+
+      const contextId = await this.getEntityUuidAsync(projectBackwardCompat, 'context');
+      if (!contextId) {
+        throw new Error(`ISL project context not found (${projectBackwardCompat}).`);
+      }
+
+      const defaultLanguageId = await this.getDefaultLanguageIdAsync();
+      const internalName = 'artintro_root';
+
+      this.collectSample(
+        'artintro_root_collection',
+        { internal_name: internalName, backward_compatibility: backwardCompat },
+        'foundation',
+        'Artistic Introduction root collection'
+      );
+
+      if (this.isDryRun || this.isSampleOnlyMode) {
+        this.logInfo(
+          `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create root collection: ${internalName}`
+        );
+        this.registerEntity('', backwardCompat, 'collection');
+        result.imported++;
+        this.showProgress();
+        return result;
+      }
+
+      const collectionId = await this.context.strategy.writeCollection({
+        internal_name: internalName,
+        backward_compatibility: backwardCompat,
+        context_id: contextId,
+        language_id: defaultLanguageId,
+        parent_id: parentCollectionId,
+        type: 'collection',
+        latitude: null,
+        longitude: null,
+        map_zoom: null,
+        country_id: null,
+      });
+
+      this.registerEntity(collectionId, backwardCompat, 'collection');
+
+      const translationBackwardCompat = `${backwardCompat}:translation:${defaultLanguageId}`;
+
+      await this.context.strategy.writeCollectionTranslation({
+        collection_id: collectionId,
+        language_id: defaultLanguageId,
+        context_id: contextId,
+        backward_compatibility: translationBackwardCompat,
+        title: 'Artistic Introduction',
+        description:
+          'Curated introductions to the major artistic traditions of Islamic art, illustrated with monuments and objects from the collection.',
+      });
+
+      this.logInfo(`Created Artistic Introduction root collection: ${collectionId}`);
+      result.imported++;
+      this.showProgress();
+    } catch (error) {
+      result.success = false;
+      const message = error instanceof Error ? error.message : String(error);
+      result.errors.push(`Error creating Artistic Introduction root collection: ${message}`);
+      this.logError('ArtintroRootCollectionImporter', message);
+      this.showError();
+    }
+
+    return result;
+  }
+}

--- a/scripts/importer/src/importers/phase-01/exhibitions-root-collection-importer.ts
+++ b/scripts/importer/src/importers/phase-01/exhibitions-root-collection-importer.ts
@@ -1,0 +1,133 @@
+/**
+ * Exhibitions Root Collection Importer
+ *
+ * Creates a single "Exhibitions" marker collection as a child of the Islamic
+ * Art (ISL) project collection. This mirrors ArtintroRootCollectionImporter:
+ * `type='exhibition'` (and even the `mwnf3:exhibitions:{id}` backward_compatibility
+ * key) is not project-scoped — the mwnf3 legacy schema shares its exhibitions
+ * table across multiple projects (ISL, BAR, SH, ...), so neither field alone
+ * can identify "the ISL exhibitions". This collection gives them an
+ * unambiguous, stable anchor.
+ *
+ * Mwnf3ExhibitionImporter nests ISL exhibitions ("mwnf3:exhibitions:{id}")
+ * under this collection instead of directly under the ISL project
+ * collection. Exhibitions belonging to other projects are unaffected —
+ * they keep nesting directly under their own project collection.
+ *
+ * Legacy schema:
+ * - No direct equivalent (we create a root container)
+ *
+ * New schema:
+ * - collections (id, context_id, language_id, parent_id, type, internal_name, backward_compatibility, ...)
+ * - collection_translations (collection_id, language_id, context_id, title, description, ...)
+ *
+ * Mapping:
+ * - internal_name = 'exhibitions_root'
+ * - type = 'collection'
+ * - parent_id = ISL project collection
+ * - backward_compatibility = 'mwnf3:exhibitions:root'
+ *
+ * Dependencies:
+ * - ProjectImporter (ISL project + context must exist)
+ * - LanguageImporter (for default language)
+ */
+
+import { BaseImporter } from '../../core/base-importer.js';
+import type { ImportResult } from '../../core/types.js';
+
+const MWNF3_SCHEMA = 'mwnf3';
+const ISL_PROJECT_KEY = 'ISL';
+
+export class ExhibitionsRootCollectionImporter extends BaseImporter {
+  getName(): string {
+    return 'ExhibitionsRootCollectionImporter';
+  }
+
+  async import(): Promise<ImportResult> {
+    const result = this.createResult();
+
+    try {
+      const backwardCompat = `${MWNF3_SCHEMA}:exhibitions:root`;
+
+      if (await this.entityExistsAsync(backwardCompat, 'collection')) {
+        this.logInfo('Exhibitions root collection already exists, skipping');
+        result.skipped++;
+        this.showSkipped();
+        return result;
+      }
+
+      this.logInfo('Looking up ISL project collection...');
+      const projectBackwardCompat = `${MWNF3_SCHEMA}:projects:${ISL_PROJECT_KEY}`;
+      const parentCollectionId = await this.getEntityUuidAsync(projectBackwardCompat, 'collection');
+      if (!parentCollectionId) {
+        throw new Error(
+          `ISL project collection not found (${projectBackwardCompat}). Run ProjectImporter first.`
+        );
+      }
+
+      const contextId = await this.getEntityUuidAsync(projectBackwardCompat, 'context');
+      if (!contextId) {
+        throw new Error(`ISL project context not found (${projectBackwardCompat}).`);
+      }
+
+      const defaultLanguageId = await this.getDefaultLanguageIdAsync();
+      const internalName = 'exhibitions_root';
+
+      this.collectSample(
+        'exhibitions_root_collection',
+        { internal_name: internalName, backward_compatibility: backwardCompat },
+        'foundation',
+        'Exhibitions root collection'
+      );
+
+      if (this.isDryRun || this.isSampleOnlyMode) {
+        this.logInfo(
+          `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would create root collection: ${internalName}`
+        );
+        this.registerEntity('', backwardCompat, 'collection');
+        result.imported++;
+        this.showProgress();
+        return result;
+      }
+
+      const collectionId = await this.context.strategy.writeCollection({
+        internal_name: internalName,
+        backward_compatibility: backwardCompat,
+        context_id: contextId,
+        language_id: defaultLanguageId,
+        parent_id: parentCollectionId,
+        type: 'collection',
+        latitude: null,
+        longitude: null,
+        map_zoom: null,
+        country_id: null,
+      });
+
+      this.registerEntity(collectionId, backwardCompat, 'collection');
+
+      const translationBackwardCompat = `${backwardCompat}:translation:${defaultLanguageId}`;
+
+      await this.context.strategy.writeCollectionTranslation({
+        collection_id: collectionId,
+        language_id: defaultLanguageId,
+        context_id: contextId,
+        backward_compatibility: translationBackwardCompat,
+        title: 'Exhibitions',
+        description:
+          'Curated virtual exhibitions exploring themes, monuments, and objects from the Islamic art collection.',
+      });
+
+      this.logInfo(`Created Exhibitions root collection: ${collectionId}`);
+      result.imported++;
+      this.showProgress();
+    } catch (error) {
+      result.success = false;
+      const message = error instanceof Error ? error.message : String(error);
+      result.errors.push(`Error creating Exhibitions root collection: ${message}`);
+      this.logError('ExhibitionsRootCollectionImporter', message);
+      this.showError();
+    }
+
+    return result;
+  }
+}

--- a/scripts/importer/src/importers/phase-01/index.ts
+++ b/scripts/importer/src/importers/phase-01/index.ts
@@ -14,6 +14,7 @@ export { SchoolImporter } from './school-importer.js';
 export { PartnerHierarchyImporter } from './partner-hierarchy-importer.js';
 export { InstitutionHierarchyImporter } from './institution-hierarchy-importer.js';
 export { ArtintroRootCollectionImporter } from './artintro-root-collection-importer.js';
+export { ExhibitionsRootCollectionImporter } from './exhibitions-root-collection-importer.js';
 export { Mwnf3ExhibitionImporter } from './mwnf3-exhibition-importer.js';
 export { Mwnf3ExhibitionTranslationImporter } from './mwnf3-exhibition-translation-importer.js';
 export { Mwnf3ExhibitionItemImporter } from './mwnf3-exhibition-item-importer.js';

--- a/scripts/importer/src/importers/phase-01/index.ts
+++ b/scripts/importer/src/importers/phase-01/index.ts
@@ -13,6 +13,7 @@ export { AuthorImporter } from './author-importer.js';
 export { SchoolImporter } from './school-importer.js';
 export { PartnerHierarchyImporter } from './partner-hierarchy-importer.js';
 export { InstitutionHierarchyImporter } from './institution-hierarchy-importer.js';
+export { ArtintroRootCollectionImporter } from './artintro-root-collection-importer.js';
 export { Mwnf3ExhibitionImporter } from './mwnf3-exhibition-importer.js';
 export { Mwnf3ExhibitionTranslationImporter } from './mwnf3-exhibition-translation-importer.js';
 export { Mwnf3ExhibitionItemImporter } from './mwnf3-exhibition-item-importer.js';

--- a/scripts/importer/src/importers/phase-01/mwnf3-exhibition-importer.ts
+++ b/scripts/importer/src/importers/phase-01/mwnf3-exhibition-importer.ts
@@ -2,7 +2,12 @@
  * MWNF3 Exhibition Importer
  *
  * Imports the mwnf3 exhibition hierarchy as nested Collections:
- * - exhibitions (27) → Collection (type='exhibition'), child of project collection
+ * - exhibitions (27, across ISL/BAR/SH/...) → Collection (type='exhibition').
+ *   ISL exhibitions (18) nest under the "Exhibitions" marker collection
+ *   created by ExhibitionsRootCollectionImporter (child of the ISL project
+ *   collection), since neither type='exhibition' nor the
+ *   mwnf3:exhibitions:{id} key are project-scoped. Every other project's
+ *   exhibitions keep nesting directly under their own project collection.
  * - exhibition_themes (~171) → Collection (type='theme'), child of exhibition
  * - exhibition_pages (200+) → Collection (type='theme'), nested child of theme
  *
@@ -29,6 +34,8 @@
  * - ProjectImporter (must run first to create project collections/contexts)
  * - ArtintroRootCollectionImporter (must run first to create the Artistic
  *   Introduction marker collection that the artintro root nests under)
+ * - ExhibitionsRootCollectionImporter (must run first to create the
+ *   Exhibitions marker collection that ISL exhibitions nest under)
  */
 
 import { BaseImporter } from '../../core/base-importer.js';
@@ -84,19 +91,30 @@ export class Mwnf3ExhibitionImporter extends BaseImporter {
             continue;
           }
 
-          // Resolve parent: the project collection
+          // Resolve parent: for ISL, nest under the "Exhibitions" marker
+          // collection (created by ExhibitionsRootCollectionImporter) so ISL
+          // exhibitions can be identified unambiguously by parent_id —
+          // neither type='exhibition' nor the mwnf3:exhibitions:{id}
+          // backward_compatibility key are project-scoped (the legacy schema
+          // shares this table across ISL, BAR, SH, ...). Other projects keep
+          // nesting directly under their own project collection, unchanged.
+          const isIsl = legacy.project_id.toUpperCase() === 'ISL';
           const projectBackwardCompat = `${MWNF3_SCHEMA}:projects:${legacy.project_id.toUpperCase()}`;
+          const parentBackwardCompat = isIsl
+            ? `${MWNF3_SCHEMA}:exhibitions:root`
+            : projectBackwardCompat;
           const parentCollectionId = await this.getEntityUuidAsync(
-            projectBackwardCompat,
+            parentBackwardCompat,
             'collection'
           );
           if (!parentCollectionId) {
+            const label = isIsl ? 'Exhibitions root collection' : 'Project collection';
             result.errors.push(
-              `Exhibition ${legacy.exhibition_id}: Project collection not found (${projectBackwardCompat})`
+              `Exhibition ${legacy.exhibition_id}: ${label} not found (${parentBackwardCompat})`
             );
             this.logError(
               `Exhibition ${legacy.exhibition_id}`,
-              `Project collection not found (${projectBackwardCompat})`
+              `${label} not found (${parentBackwardCompat})`
             );
             this.showError();
             continue;

--- a/scripts/importer/src/importers/phase-01/mwnf3-exhibition-importer.ts
+++ b/scripts/importer/src/importers/phase-01/mwnf3-exhibition-importer.ts
@@ -6,8 +6,13 @@
  * - exhibition_themes (~171) → Collection (type='theme'), child of exhibition
  * - exhibition_pages (200+) → Collection (type='theme'), nested child of theme
  *
- * Also imports the artintro hierarchy (identical structure):
- * - artintros (1) → Collection (type='collection'), child of ISL project collection
+ * Also imports the artintro hierarchy (identical structure), nested under the
+ * "Artistic Introduction" marker collection created by
+ * ArtintroRootCollectionImporter (child of the ISL project collection) so
+ * artintro data can be identified unambiguously by parent_id instead of
+ * internal_name matching:
+ * - artintros (1) → Collection (type='collection'), child of the Artistic
+ *   Introduction marker collection
  * - artintro_themes (10) → Collection (type='theme'), child of artintro
  * - artintro_pages (19) → Collection (type='theme'), nested child of artintro theme
  *
@@ -22,6 +27,8 @@
  *
  * Dependencies:
  * - ProjectImporter (must run first to create project collections/contexts)
+ * - ArtintroRootCollectionImporter (must run first to create the Artistic
+ *   Introduction marker collection that the artintro root nests under)
  */
 
 import { BaseImporter } from '../../core/base-importer.js';
@@ -368,17 +375,23 @@ export class Mwnf3ExhibitionImporter extends BaseImporter {
         }
 
         const projectBackwardCompat = `${MWNF3_SCHEMA}:projects:${legacy.project_id.toUpperCase()}`;
+
+        // Nest under the "Artistic Introduction" marker collection (created by
+        // ArtintroRootCollectionImporter) instead of directly under the project
+        // collection, so artintro data can be identified unambiguously by
+        // parent_id/backward_compatibility rather than internal_name matching.
+        const artintroRootBackwardCompat = `${MWNF3_SCHEMA}:artintro:root`;
         const parentCollectionId = await this.getEntityUuidAsync(
-          projectBackwardCompat,
+          artintroRootBackwardCompat,
           'collection'
         );
         if (!parentCollectionId) {
           result.errors.push(
-            `Artintro ${legacy.artintro_id}: Project collection not found (${projectBackwardCompat})`
+            `Artintro ${legacy.artintro_id}: Artistic Introduction root collection not found (${artintroRootBackwardCompat}). Run ArtintroRootCollectionImporter first.`
           );
           this.logError(
             `Artintro ${legacy.artintro_id}`,
-            `Project collection not found (${projectBackwardCompat})`
+            `Artistic Introduction root collection not found (${artintroRootBackwardCompat})`
           );
           this.showError();
           continue;

--- a/scripts/viewer/README.md
+++ b/scripts/viewer/README.md
@@ -13,12 +13,16 @@ scripts/viewer/
 │   ├── main.js         # Creates and mounts the Vue app
 │   └── App.vue         # Entire application: data loading, list, detail view
 ├── vite.config.js      # Resolves the data package path; sets @inventory-data alias
-├── .npmrc              # Scopes @metanull to https://npm.pkg.github.com
 └── package.json        # Dependencies: vue + the data package
 ```
 
 The application is intentionally contained in a single component (`App.vue`) to keep
 it easy to read top-to-bottom.
+
+Scoping `@metanull` to `https://npm.pkg.github.com` (with the auth token)
+happens in the repo-**root** `.npmrc` (gitignored, not this directory) —
+`npm install`/`npm ci` from anywhere under this repo picks it up
+automatically via npm's normal upward config-file resolution.
 
 ## How it uses `@metanull/islamicart-data`
 
@@ -61,3 +65,44 @@ npm run dev          # development server at http://localhost:5173
 npm run build        # production build → dist/
 npm run preview      # serve the production build locally
 ```
+
+## Deployment (OVH)
+
+[`.github/workflows/deploy-viewer-ovh.yml`](../../.github/workflows/deploy-viewer-ovh.yml)
+builds and deploys this viewer to `https://inventory.metanull.eu/islamicart/`
+automatically. It triggers on:
+
+- Any push to `main` that touches `scripts/viewer/**`
+- Manual dispatch (`workflow_dispatch`), e.g. to redeploy after a new data
+  package version is published without changing any viewer code
+
+Steps, in order:
+
+1. Checkout, set up Node with the `@metanull` scope pointed at
+   `npm.pkg.github.com`
+2. `npm ci` (installs whatever's pinned in `package-lock.json`)
+3. **`npm install @metanull/islamicart-data@latest`** — always pulls the
+   newest published data package regardless of what's pinned in the
+   lockfile, since the whole point of a deploy is to reflect current content
+4. `npm run build -- --base=/islamicart/` (the `--base` matters: the site is
+   served from a subpath, not the domain root)
+5. Set up the deploy SSH key, verify the VPS is reachable and the key
+   authenticates *before* attempting the actual deploy (fails fast with a
+   clear error instead of a confusing mid-deploy failure)
+6. `scp` the built `dist/` contents to `/opt/islamicart/` on the VPS
+7. Clean up the SSH key (`if: always()`, runs even if a prior step failed)
+
+Runs with `concurrency: cancel-in-progress: false` — a second push while a
+deploy is in flight queues behind it rather than cancelling the first.
+
+**Required repository secrets:** `VPS_SSH_KEY` (private key), `VPS_HOST`,
+`VPS_SSH_USER`. **Required permission:** `packages: read`, to pull
+`@metanull/islamicart-data` from GitHub Packages using the workflow's own
+`GITHUB_TOKEN` — no separate PAT needed in CI (unlike local development,
+which needs a real PAT in `~/.npmrc`).
+
+This workflow only builds and ships the *viewer* — it never runs the
+exporter or touches the database. Publishing a new data package version is
+a separate, manual step (see [`scripts/exporter/README.md`](../exporter/README.md));
+this workflow just needs to be triggered (a push, or manually) afterward to
+pick it up.

--- a/scripts/viewer/package-lock.json
+++ b/scripts/viewer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "inventory-viewer",
       "version": "1.0.0",
       "dependencies": {
-        "@metanull/islamicart-data": "^1.0.9",
+        "@metanull/islamicart-data": "^1.0.16",
         "marked": "^18.0.5",
         "vue": "^3.5.39",
         "vue-router": "^4.6.4"
@@ -105,9 +105,9 @@
       "license": "MIT"
     },
     "node_modules/@metanull/islamicart-data": {
-      "version": "1.0.10",
-      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.10/d3cd2d47795481d366216459360675dbb1fd5dc1",
-      "integrity": "sha512-frvjXvsRq3mFgbuU7LfAakXEVp1b/OZZylbkCzYCFF8QsyIW0I1W7sCnn5QSMZrW6SAiyAsRaBF14tY332xM0Q==",
+      "version": "1.0.16",
+      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.16/6e43eecd5a17a4d0ff1cfffff8efdadd9cc96ace",
+      "integrity": "sha512-Thnbp/0qDBXw9NKbtjv0OSS3Lu4l1JnToyViK4PGx3IffqbzdVUW9Q2S91F8+5DwmDpvSsYNoBO+CEkQx/YFqA==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=16.0.0",

--- a/scripts/viewer/package.json
+++ b/scripts/viewer/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@metanull/islamicart-data": "^1.0.9",
+    "@metanull/islamicart-data": "^1.0.16",
     "marked": "^18.0.5",
     "vue": "^3.5.39",
     "vue-router": "^4.6.4"

--- a/scripts/viewer/src/App.vue
+++ b/scripts/viewer/src/App.vue
@@ -22,6 +22,7 @@ import { RouterView, RouterLink } from 'vue-router'
         <RouterLink to="/partners" active-class="nav-active">Partners</RouterLink>
         <RouterLink to="/dynasties" active-class="nav-active">Dynasties</RouterLink>
         <RouterLink to="/artistic-introduction" active-class="nav-active">Artistic Introduction</RouterLink>
+        <RouterLink to="/exhibitions" active-class="nav-active">Exhibitions</RouterLink>
       </div>
     </nav>
 

--- a/scripts/viewer/src/App.vue
+++ b/scripts/viewer/src/App.vue
@@ -21,6 +21,7 @@ import { RouterView, RouterLink } from 'vue-router'
         <RouterLink to="/timeline" active-class="nav-active">Timeline</RouterLink>
         <RouterLink to="/partners" active-class="nav-active">Partners</RouterLink>
         <RouterLink to="/dynasties" active-class="nav-active">Dynasties</RouterLink>
+        <RouterLink to="/artistic-introduction" active-class="nav-active">Artistic Introduction</RouterLink>
       </div>
     </nav>
 

--- a/scripts/viewer/src/composables/useInventoryData.js
+++ b/scripts/viewer/src/composables/useInventoryData.js
@@ -7,6 +7,7 @@ import partnersData from '@inventory-data/partners.json'
 import dynastiesData from '@inventory-data/dynasties.json'
 import timelinesData from '@inventory-data/timelines.json'
 import timelineEventsData from '@inventory-data/timeline_events.json'
+import collectionsData from '@inventory-data/collections.json'
 
 // Module-level singletons — loaded once, shared across all views
 const items = ref(itemsData)
@@ -15,6 +16,7 @@ const partners = ref(partnersData)
 const dynasties = ref(dynastiesData)
 const timelines = ref(timelinesData)
 const timelineEvents = ref(timelineEventsData)
+const collections = ref(collectionsData)
 const availableLangs = ref(manifestData.languages ?? [])
 const defaultLang = (manifestData.languages ?? []).includes('en')
   ? 'en'
@@ -25,6 +27,7 @@ const enCountryTranslations = ref({})
 const enDynastyTranslations = ref({})
 const enPartnerTranslations = ref({})
 const enTimelineEventTranslations = ref({})
+const enCollectionTranslations = ref({})
 const translationsCache = ref({}) // lang -> item translations (for detail view)
 
 let enLoaded = false
@@ -43,6 +46,8 @@ async function loadEnglishTranslations() {
       .then(m => { enPartnerTranslations.value = m.default }),
     import('@inventory-data/translations/timeline_events.en.json')
       .then(m => { enTimelineEventTranslations.value = m.default }),
+    import('@inventory-data/translations/collections.en.json')
+      .then(m => { enCollectionTranslations.value = m.default }),
   ])
   // Seed English into the detail-view cache too
   if (!translationsCache.value['en']) {
@@ -95,6 +100,40 @@ const itemById = computed(() => {
   return m
 })
 
+// ── Artistic Introduction (legacy "gai") ──────────────────────────────────
+//
+// Imported as generic Collections, identified by internal_name prefix:
+// root "mwnf3_artintro_{id}", themes "mwnf3_artintro_theme_{id}"
+// (e.g. "The Umayyads"), pages "mwnf3_artintro_page_{id}" (tabs within a
+// theme, e.g. "Monuments" / "Objects"). Reconstructed here into a tree since
+// collections.json only carries parent_id, not the theme/page distinction.
+
+const artIntroRoot = computed(() =>
+  collections.value.find(
+    c => c.internal_name?.startsWith('mwnf3_artintro_') &&
+      !c.internal_name.startsWith('mwnf3_artintro_theme_') &&
+      !c.internal_name.startsWith('mwnf3_artintro_page_')
+  ) ?? null
+)
+
+const artIntroThemes = computed(() => {
+  const root = artIntroRoot.value
+  if (!root) return []
+  const themes = collections.value
+    .filter(c => c.internal_name?.startsWith('mwnf3_artintro_theme_') && c.parent_id === root.id)
+    .sort((a, b) => (a.display_order ?? 9999) - (b.display_order ?? 9999))
+  return themes.map(theme => ({
+    ...theme,
+    pages: collections.value
+      .filter(c => c.internal_name?.startsWith('mwnf3_artintro_page_') && c.parent_id === theme.id)
+      .sort((a, b) => (a.display_order ?? 9999) - (b.display_order ?? 9999)),
+  }))
+})
+
+function artIntroThemeById(id) {
+  return artIntroThemes.value.find(t => t.id === id) ?? null
+}
+
 // ── Markdown helpers ───────────────────────────────────────────────────────
 
 // Full block markdown → HTML (for prose sections)
@@ -133,6 +172,7 @@ export function useInventoryData() {
     dynasties,
     timelines,
     timelineEvents,
+    collections,
     availableLangs,
     defaultLang,
     enItemTranslations,
@@ -140,6 +180,7 @@ export function useInventoryData() {
     enDynastyTranslations,
     enPartnerTranslations,
     enTimelineEventTranslations,
+    enCollectionTranslations,
     translationsCache,
     loadEnglishTranslations,
     loadLangTranslations,
@@ -148,6 +189,9 @@ export function useInventoryData() {
     dynastyLabel,
     partnerLabel,
     itemById,
+    artIntroRoot,
+    artIntroThemes,
+    artIntroThemeById,
     md,
     mdInline,
     mdStrip,

--- a/scripts/viewer/src/composables/useInventoryData.js
+++ b/scripts/viewer/src/composables/useInventoryData.js
@@ -102,30 +102,31 @@ const itemById = computed(() => {
 
 // ── Artistic Introduction (legacy "gai") ──────────────────────────────────
 //
-// Imported as generic Collections, identified by internal_name prefix:
-// root "mwnf3_artintro_{id}", themes "mwnf3_artintro_theme_{id}"
-// (e.g. "The Umayyads"), pages "mwnf3_artintro_page_{id}" (tabs within a
-// theme, e.g. "Monuments" / "Objects"). Reconstructed here into a tree since
-// collections.json only carries parent_id, not the theme/page distinction.
+// Imported as generic Collections, nested under a dedicated "Artistic
+// Introduction" marker collection (backward_compatibility
+// "mwnf3:artintro:root", a child of the Islamic Art project collection).
+// From that single, unambiguous anchor the rest of the tree — root, themes
+// (e.g. "The Umayyads"), pages (tabs within a theme, e.g. "Monuments" /
+// "Objects") — is just parent_id lookups, no internal_name guessing.
 
-const artIntroRoot = computed(() =>
-  collections.value.find(
-    c => c.internal_name?.startsWith('mwnf3_artintro_') &&
-      !c.internal_name.startsWith('mwnf3_artintro_theme_') &&
-      !c.internal_name.startsWith('mwnf3_artintro_page_')
-  ) ?? null
-)
+const ARTINTRO_MARKER_BC = 'mwnf3:artintro:root'
+
+const artIntroRoot = computed(() => {
+  const marker = collections.value.find(c => c.backward_compatibility === ARTINTRO_MARKER_BC)
+  if (!marker) return null
+  return collections.value.find(c => c.parent_id === marker.id) ?? null
+})
 
 const artIntroThemes = computed(() => {
   const root = artIntroRoot.value
   if (!root) return []
   const themes = collections.value
-    .filter(c => c.internal_name?.startsWith('mwnf3_artintro_theme_') && c.parent_id === root.id)
+    .filter(c => c.parent_id === root.id)
     .sort((a, b) => (a.display_order ?? 9999) - (b.display_order ?? 9999))
   return themes.map(theme => ({
     ...theme,
     pages: collections.value
-      .filter(c => c.internal_name?.startsWith('mwnf3_artintro_page_') && c.parent_id === theme.id)
+      .filter(c => c.parent_id === theme.id)
       .sort((a, b) => (a.display_order ?? 9999) - (b.display_order ?? 9999)),
   }))
 })

--- a/scripts/viewer/src/composables/useInventoryData.js
+++ b/scripts/viewer/src/composables/useInventoryData.js
@@ -135,6 +135,49 @@ function artIntroThemeById(id) {
   return artIntroThemes.value.find(t => t.id === id) ?? null
 }
 
+// ── Exhibitions ────────────────────────────────────────────────────────────
+//
+// Imported as generic Collections, nested under a dedicated "Exhibitions"
+// marker collection (backward_compatibility "mwnf3:exhibitions:root", a
+// child of the Islamic Art project collection) — needed because neither
+// type='exhibition' nor the mwnf3:exhibitions:{id} backward_compatibility
+// key are project-scoped in the legacy schema (shared with Baroque Art,
+// Sharing History, etc). From that anchor: exhibitions are its children,
+// themes are an exhibition's children, pages are a theme's children (tabs).
+// "Introduction" is not a theme — it's the exhibition's own translation
+// (extra.intro_header / extra.intro_text) plus items attached directly to
+// the exhibition collection itself (not to any theme/page).
+
+const EXHIBITIONS_MARKER_BC = 'mwnf3:exhibitions:root'
+
+const exhibitions = computed(() => {
+  const marker = collections.value.find(c => c.backward_compatibility === EXHIBITIONS_MARKER_BC)
+  if (!marker) return []
+  return collections.value
+    .filter(c => c.parent_id === marker.id)
+    .sort((a, b) => (a.display_order ?? 9999) - (b.display_order ?? 9999))
+})
+
+function exhibitionById(id) {
+  return exhibitions.value.find(e => e.id === id) ?? null
+}
+
+function exhibitionThemes(exhibitionId) {
+  return collections.value
+    .filter(c => c.parent_id === exhibitionId)
+    .sort((a, b) => (a.display_order ?? 9999) - (b.display_order ?? 9999))
+    .map(theme => ({
+      ...theme,
+      pages: collections.value
+        .filter(c => c.parent_id === theme.id)
+        .sort((a, b) => (a.display_order ?? 9999) - (b.display_order ?? 9999)),
+    }))
+}
+
+function exhibitionThemeById(exhibitionId, themeId) {
+  return exhibitionThemes(exhibitionId).find(t => t.id === themeId) ?? null
+}
+
 // ── Markdown helpers ───────────────────────────────────────────────────────
 
 // Full block markdown → HTML (for prose sections)
@@ -193,6 +236,10 @@ export function useInventoryData() {
     artIntroRoot,
     artIntroThemes,
     artIntroThemeById,
+    exhibitions,
+    exhibitionById,
+    exhibitionThemes,
+    exhibitionThemeById,
     md,
     mdInline,
     mdStrip,

--- a/scripts/viewer/src/router/index.js
+++ b/scripts/viewer/src/router/index.js
@@ -14,6 +14,10 @@ import DynastyDetail from '../views/DynastyDetail.vue'
 import ItemDetail from '../views/ItemDetail.vue'
 import ArtIntroEntrance from '../views/ArtIntroEntrance.vue'
 import ArtIntroTheme from '../views/ArtIntroTheme.vue'
+import ExhibitionsEntrance from '../views/ExhibitionsEntrance.vue'
+import ExhibitionSplash from '../views/ExhibitionSplash.vue'
+import ExhibitionIntroduction from '../views/ExhibitionIntroduction.vue'
+import ExhibitionTheme from '../views/ExhibitionTheme.vue'
 
 const routes = [
   { path: '/', component: Home },
@@ -30,6 +34,10 @@ const routes = [
   { path: '/dynasty/:id', component: DynastyDetail },
   { path: '/artistic-introduction', component: ArtIntroEntrance },
   { path: '/artistic-introduction/:themeId', component: ArtIntroTheme },
+  { path: '/exhibitions', component: ExhibitionsEntrance },
+  { path: '/exhibitions/:exhibitionId', component: ExhibitionSplash },
+  { path: '/exhibitions/:exhibitionId/introduction', component: ExhibitionIntroduction },
+  { path: '/exhibitions/:exhibitionId/theme/:themeId', component: ExhibitionTheme },
   { path: '/item/:id', component: ItemDetail },
 ]
 

--- a/scripts/viewer/src/router/index.js
+++ b/scripts/viewer/src/router/index.js
@@ -12,6 +12,8 @@ import PartnerDetail from '../views/PartnerDetail.vue'
 import Dynasties from '../views/Dynasties.vue'
 import DynastyDetail from '../views/DynastyDetail.vue'
 import ItemDetail from '../views/ItemDetail.vue'
+import ArtIntroEntrance from '../views/ArtIntroEntrance.vue'
+import ArtIntroTheme from '../views/ArtIntroTheme.vue'
 
 const routes = [
   { path: '/', component: Home },
@@ -26,6 +28,8 @@ const routes = [
   { path: '/partner/:id', component: PartnerDetail },
   { path: '/dynasties', component: Dynasties },
   { path: '/dynasty/:id', component: DynastyDetail },
+  { path: '/artistic-introduction', component: ArtIntroEntrance },
+  { path: '/artistic-introduction/:themeId', component: ArtIntroTheme },
   { path: '/item/:id', component: ItemDetail },
 ]
 

--- a/scripts/viewer/src/views/ArtIntroEntrance.vue
+++ b/scripts/viewer/src/views/ArtIntroEntrance.vue
@@ -1,0 +1,109 @@
+<script setup>
+import { computed } from 'vue'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const { artIntroRoot, artIntroThemes, enCollectionTranslations, md, mdInline } = useInventoryData()
+
+const rootText = computed(() => {
+  const root = artIntroRoot.value
+  if (!root) return {}
+  return enCollectionTranslations.value[root.id] ?? {}
+})
+
+const themeList = computed(() =>
+  artIntroThemes.value.map(theme => ({
+    ...theme,
+    title: enCollectionTranslations.value[theme.id]?.title ?? theme.internal_name,
+  }))
+)
+</script>
+
+<template>
+  <div v-if="!artIntroRoot" class="content-box not-found">
+    <p>Artistic Introduction is not available.</p>
+  </div>
+
+  <div v-else>
+    <h1 class="section-heading">Artistic Introduction</h1>
+
+    <div class="content-box intro-box">
+      <h2 v-if="rootText.extra?.subtitle" class="intro-subtitle" v-html="mdInline(rootText.extra.subtitle)" />
+      <div v-if="rootText.description" class="prose" v-html="md(rootText.description)" />
+      <p v-if="rootText.extra?.credits" class="intro-credits" v-html="mdInline(rootText.extra.credits)" />
+    </div>
+
+    <div class="content-box">
+      <p class="intro-text">
+        Select a theme below to explore its monuments and objects.
+      </p>
+      <ul class="theme-list">
+        <li
+          v-for="theme in themeList"
+          :key="theme.id"
+          class="theme-row"
+          @click="$router.push(`/artistic-introduction/${encodeURIComponent(theme.id)}`)"
+        >
+          <span class="theme-name" v-html="mdInline(theme.title)" />
+          <span class="theme-arrow">→</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.not-found { color: var(--muted); font-family: 'Roboto', sans-serif; font-size: 13px; }
+
+.intro-box { border-top: 3px solid var(--gold-dark); }
+.intro-subtitle {
+  font-size: 16px;
+  font-weight: 400;
+  color: var(--heading);
+  margin-bottom: 12px;
+  font-family: 'Roboto', sans-serif;
+}
+.prose { font-size: 14px; line-height: 1.7; color: var(--text); font-family: 'Roboto', sans-serif; }
+.prose :deep(p) { margin: 0 0 .75em; }
+.prose :deep(p:last-child) { margin-bottom: 0; }
+
+.intro-credits {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  font-style: italic;
+  color: var(--muted);
+  font-family: 'Roboto', sans-serif;
+}
+
+.intro-text {
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--muted);
+  margin-bottom: 16px;
+  font-family: 'Roboto', sans-serif;
+}
+
+.theme-list { list-style: none; }
+.theme-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 4px;
+  border-bottom: 1px solid #e8dcc8;
+  cursor: pointer;
+}
+.theme-row:last-child { border-bottom: none; }
+.theme-row:hover .theme-name { color: var(--nav-active); }
+
+.theme-name {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--heading);
+  font-family: 'Roboto', sans-serif;
+}
+.theme-arrow {
+  color: var(--muted);
+  font-size: 14px;
+}
+</style>

--- a/scripts/viewer/src/views/ArtIntroTheme.vue
+++ b/scripts/viewer/src/views/ArtIntroTheme.vue
@@ -1,0 +1,345 @@
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const route = useRoute()
+const router = useRouter()
+const {
+  itemById, dynasties,
+  availableLangs, defaultLang,
+  translationsCache, loadLangTranslations,
+  dynastyLabel, partnerLabel,
+  artIntroThemeById,
+  enCollectionTranslations,
+  md, mdInline,
+} = useInventoryData()
+
+const theme = computed(() => artIntroThemeById(decodeURIComponent(route.params.themeId)) ?? null)
+const pages = computed(() => theme.value?.pages ?? [])
+
+// ── Active tab (page within the theme) ──────────────────────────────────
+
+const activeTabIndex = ref(0)
+
+function syncTabFromQuery() {
+  const idx = parseInt(route.query.tab ?? '0', 10)
+  activeTabIndex.value = Number.isFinite(idx) && idx >= 0 && idx < pages.value.length ? idx : 0
+}
+
+watch([theme, () => route.query.tab], syncTabFromQuery, { immediate: true })
+
+function selectTab(idx) {
+  router.push({ query: { ...route.query, tab: idx } })
+}
+
+const activePage = computed(() => pages.value[activeTabIndex.value] ?? null)
+
+// ── Language selector (collection text loaded on demand, per-lang) ──────
+
+const activeLang = ref(defaultLang)
+const collectionLangCache = ref({})
+
+async function loadCollectionLangTranslations(lang) {
+  if (collectionLangCache.value[lang]) return
+  try {
+    const m = await import(`@inventory-data/translations/collections.${lang}.json`)
+    collectionLangCache.value = { ...collectionLangCache.value, [lang]: m.default }
+  } catch {
+    collectionLangCache.value = { ...collectionLangCache.value, [lang]: {} }
+  }
+}
+
+onMounted(() => {
+  loadCollectionLangTranslations(activeLang.value)
+  loadLangTranslations(activeLang.value)
+})
+watch(activeLang, lang => {
+  loadCollectionLangTranslations(lang)
+  loadLangTranslations(lang)
+})
+
+function collectionText(collectionId) {
+  return collectionLangCache.value[activeLang.value]?.[collectionId] ?? {}
+}
+
+// The importer synthesizes a placeholder title ("Theme 5", "Artintro Page 17")
+// when the legacy source has no page_title/theme_title for a given language
+// (a handful of gaps in the legacy translation data). Treat that pattern as
+// "missing" and fall back to the English title rather than leaking it.
+const PLACEHOLDER_TITLE = /^(Artintro )?(Theme|Page) \d+$/
+
+function resolveTitle(collectionId, fallbackName) {
+  const local = collectionText(collectionId).title
+  if (local && !PLACEHOLDER_TITLE.test(local)) return local
+  const en = enCollectionTranslations.value[collectionId]?.title
+  if (en && !PLACEHOLDER_TITLE.test(en)) return en
+  return fallbackName
+}
+
+const themeTitle = computed(() => resolveTitle(theme.value?.id, theme.value?.internal_name ?? ''))
+
+// ── Thumbnail grid & detail panel for the active page ────────────────────
+
+const selectedItemId = ref(null)
+
+watch(activePage, page => {
+  selectedItemId.value = page?.items?.[0]?.id ?? null
+})
+
+const gridItems = computed(() => {
+  const page = activePage.value
+  if (!page) return []
+  return page.items
+    .map(entry => ({ entry, item: itemById.value[entry.id] }))
+    .filter(({ item }) => item)
+})
+
+const selected = computed(() => gridItems.value.find(g => g.item.id === selectedItemId.value) ?? gridItems.value[0] ?? null)
+
+function selectItem(itemId) {
+  selectedItemId.value = itemId
+}
+
+// Caption override (current language) merged with the item's own generic
+// translation, mirroring the legacy behaviour: artintro-context fields
+// override the main database record where present.
+const selectedDisplay = computed(() => {
+  const sel = selected.value
+  if (!sel) return null
+  const caption = sel.entry.caption?.[activeLang.value] ?? {}
+  const t = translationsCache.value[activeLang.value]?.[sel.item.id] ?? {}
+  return {
+    name: caption.name ?? t.name ?? sel.item.internal_name ?? sel.item.id,
+    date: caption.date ?? t.dates ?? '',
+    dynasty: caption.dynasty ?? (sel.item.dynasty_ids?.[0] ? dynastyLabel(sel.item.dynasty_ids[0]) : ''),
+    location: caption.location ?? t.location ?? '',
+    museum: caption.museum ?? (sel.item.partner_id ? partnerLabel(sel.item.partner_id) : ''),
+    justification: caption.justification ?? '',
+    image: sel.item.images?.[0]?.url ?? null,
+  }
+})
+
+function back() {
+  if (window.history.length > 2) {
+    router.back()
+  } else {
+    router.push('/artistic-introduction')
+  }
+}
+</script>
+
+<template>
+  <div v-if="!theme" class="content-box not-found">
+    <p>Theme not found.</p>
+    <router-link to="/artistic-introduction">← Return to Artistic Introduction</router-link>
+  </div>
+
+  <div v-else class="theme-wrap">
+    <a class="back-link" href="#" @click.prevent="back">← Back to Artistic Introduction</a>
+
+    <div v-if="availableLangs.length > 1" class="lang-selector">
+      <label class="lang-label">Text language:</label>
+      <select v-model="activeLang" class="lang-select">
+        <option v-for="lang in availableLangs" :key="lang" :value="lang">{{ lang.toUpperCase() }}</option>
+      </select>
+    </div>
+
+    <div class="content-box">
+      <h1 class="theme-title" v-html="mdInline(themeTitle)" />
+
+      <!-- Tabs -->
+      <div v-if="pages.length > 1" class="tab-row">
+        <button
+          v-for="(page, idx) in pages"
+          :key="page.id"
+          class="tab-btn"
+          :class="{ active: idx === activeTabIndex }"
+          @click="selectTab(idx)"
+        >
+          {{ resolveTitle(page.id, page.internal_name) }}
+        </button>
+      </div>
+
+      <div v-if="activePage" class="theme-grid">
+        <!-- Left: narrative text -->
+        <div class="theme-text-col">
+          <p v-if="collectionText(activePage.id).quote" class="page-quote" v-html="mdInline(collectionText(activePage.id).quote)" />
+          <div v-if="collectionText(activePage.id).description" class="prose" v-html="md(collectionText(activePage.id).description)" />
+        </div>
+
+        <!-- Right: detail panel + thumbnail grid -->
+        <div class="theme-side-col">
+          <div v-if="selectedDisplay" class="item-detail-panel">
+            <div class="item-detail-img-wrap">
+              <img v-if="selectedDisplay.image" :src="selectedDisplay.image" :alt="selectedDisplay.name" class="item-detail-img" />
+              <div v-else class="item-detail-img-placeholder" />
+            </div>
+            <h3 class="item-detail-name" v-html="mdInline(selectedDisplay.name)" />
+            <p v-if="selectedDisplay.dynasty" class="item-detail-meta">{{ selectedDisplay.dynasty }}</p>
+            <p v-if="selectedDisplay.date" class="item-detail-meta">{{ selectedDisplay.date }}</p>
+            <p v-if="selectedDisplay.location" class="item-detail-meta">{{ selectedDisplay.location }}</p>
+            <p v-if="selectedDisplay.museum" class="item-detail-meta">{{ selectedDisplay.museum }}</p>
+            <p v-if="selectedDisplay.justification" class="item-detail-justification" v-html="mdInline(selectedDisplay.justification)" />
+            <RouterLink :to="`/item/${encodeURIComponent(selected.item.id)}`" class="more-info-link">
+              More info →
+            </RouterLink>
+          </div>
+
+          <div class="thumb-grid">
+            <div
+              v-for="g in gridItems"
+              :key="g.item.id"
+              class="thumb-cell"
+              :class="{ active: g.item.id === selectedItemId }"
+              @click="selectItem(g.item.id)"
+            >
+              <img v-if="g.item.images?.length" :src="g.item.images[0].url" :alt="g.item.internal_name ?? ''" loading="lazy" />
+              <div v-else class="thumb-placeholder" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.not-found { color: var(--muted); font-family: 'Roboto', sans-serif; font-size: 13px; }
+
+.theme-wrap { display: flex; flex-direction: column; gap: 10px; }
+
+.lang-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+  justify-content: flex-end;
+}
+.lang-select { font-size: 12px; padding: 3px 6px; }
+
+.theme-title {
+  font-size: 22px;
+  font-weight: 400;
+  color: var(--heading);
+  margin-bottom: 14px;
+  line-height: 1.3;
+  font-family: 'Roboto', sans-serif;
+}
+
+/* Tabs */
+.tab-row {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 18px;
+  border-bottom: 1px solid var(--border);
+}
+.tab-btn {
+  font-family: 'Roboto', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 8px 16px;
+  background: none;
+  border: none;
+  border-bottom: 3px solid transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.tab-btn:hover { color: var(--heading); }
+.tab-btn.active {
+  color: var(--heading);
+  border-bottom-color: var(--gold-dark);
+}
+
+/* Two-column layout */
+.theme-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 24px;
+}
+@media (max-width: 700px) { .theme-grid { grid-template-columns: 1fr; } }
+
+.theme-text-col { min-width: 0; }
+.page-quote {
+  font-size: 15px;
+  font-style: italic;
+  color: var(--heading);
+  margin-bottom: 14px;
+  line-height: 1.5;
+  font-family: 'Roboto', sans-serif;
+}
+.prose { font-size: 14px; line-height: 1.7; color: var(--text); font-family: 'Roboto', sans-serif; }
+.prose :deep(p) { margin: 0 0 .75em; }
+.prose :deep(p:last-child) { margin-bottom: 0; }
+
+/* Detail panel */
+.theme-side-col { display: flex; flex-direction: column; gap: 14px; }
+
+.item-detail-panel {
+  border: 1px solid var(--border);
+  background: var(--section-bg);
+  padding: 14px;
+}
+.item-detail-img-wrap {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: #f0ebdc;
+  margin-bottom: 10px;
+}
+.item-detail-img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.item-detail-img-placeholder { width: 100%; height: 100%; }
+
+.item-detail-name {
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--heading);
+  margin-bottom: 6px;
+  line-height: 1.3;
+  font-family: 'Roboto', sans-serif;
+}
+.item-detail-meta {
+  font-size: 12px;
+  color: var(--muted);
+  font-family: 'Roboto', sans-serif;
+  margin-bottom: 2px;
+}
+.item-detail-justification {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text);
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  font-family: 'Roboto', sans-serif;
+}
+.more-info-link {
+  display: inline-block;
+  margin-top: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--nav-active);
+  font-family: 'Roboto', sans-serif;
+}
+
+/* Thumbnail grid */
+.thumb-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+.thumb-cell {
+  aspect-ratio: 1;
+  overflow: hidden;
+  border: 2px solid transparent;
+  cursor: pointer;
+  background: #f0ebdc;
+}
+.thumb-cell.active { border-color: var(--gold-dark); }
+.thumb-cell:hover { border-color: var(--gold-amber); }
+.thumb-cell img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.thumb-placeholder { width: 100%; height: 100%; }
+</style>

--- a/scripts/viewer/src/views/ExhibitionIntroduction.vue
+++ b/scripts/viewer/src/views/ExhibitionIntroduction.vue
@@ -1,0 +1,196 @@
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const route = useRoute()
+const router = useRouter()
+const {
+  itemById, dynastyLabel, partnerLabel,
+  availableLangs, defaultLang,
+  translationsCache, loadLangTranslations,
+  exhibitionById,
+  md, mdInline,
+} = useInventoryData()
+
+const exhibition = computed(() => exhibitionById(decodeURIComponent(route.params.exhibitionId)) ?? null)
+
+// ── Language selector (exhibition text + item captions loaded on demand) ──
+
+const activeLang = ref(defaultLang)
+const collectionLangCache = ref({})
+
+async function loadCollectionLangTranslations(lang) {
+  if (collectionLangCache.value[lang]) return
+  try {
+    const m = await import(`@inventory-data/translations/collections.${lang}.json`)
+    collectionLangCache.value = { ...collectionLangCache.value, [lang]: m.default }
+  } catch {
+    collectionLangCache.value = { ...collectionLangCache.value, [lang]: {} }
+  }
+}
+
+onMounted(() => {
+  loadCollectionLangTranslations(activeLang.value)
+  loadLangTranslations(activeLang.value)
+})
+watch(activeLang, lang => {
+  loadCollectionLangTranslations(lang)
+  loadLangTranslations(lang)
+})
+
+const text = computed(() => {
+  const e = exhibition.value
+  if (!e) return {}
+  return collectionLangCache.value[activeLang.value]?.[e.id] ?? {}
+})
+
+// ── Introduction items: attached directly to the exhibition collection ────
+
+const introItems = computed(() => {
+  const e = exhibition.value
+  if (!e) return []
+  return (e.items ?? [])
+    .map(entry => ({ entry, item: itemById.value[entry.id] }))
+    .filter(({ item }) => item)
+    .sort((a, b) => (a.entry.display_order ?? 9999) - (b.entry.display_order ?? 9999))
+    .map(({ entry, item }) => {
+      const caption = entry.caption?.[activeLang.value] ?? {}
+      const t = translationsCache.value[activeLang.value]?.[item.id] ?? {}
+      return {
+        item,
+        image: item.images?.[0]?.url ?? null,
+        name: caption.name ?? t.name ?? item.internal_name ?? item.id,
+        date: caption.date ?? t.dates ?? '',
+        dynasty: caption.dynasty ?? (item.dynasty_ids?.[0] ? dynastyLabel(item.dynasty_ids[0]) : ''),
+        location: caption.location ?? t.location ?? '',
+        museum: caption.museum ?? (item.partner_id ? partnerLabel(item.partner_id) : ''),
+      }
+    })
+})
+
+function back() {
+  if (window.history.length > 2) {
+    router.back()
+  } else if (exhibition.value) {
+    router.push(`/exhibitions/${exhibition.value.id}`)
+  } else {
+    router.push('/exhibitions')
+  }
+}
+</script>
+
+<template>
+  <div v-if="!exhibition" class="content-box not-found">
+    <p>Exhibition not found.</p>
+    <router-link to="/exhibitions">← Return to Exhibitions</router-link>
+  </div>
+
+  <div v-else class="intro-wrap">
+    <a class="back-link" href="#" @click.prevent="back">← Back to {{ text.title ?? exhibition.internal_name }}</a>
+
+    <div v-if="availableLangs.length > 1" class="lang-selector">
+      <label class="lang-label">Text language:</label>
+      <select v-model="activeLang" class="lang-select">
+        <option v-for="lang in availableLangs" :key="lang" :value="lang">{{ lang.toUpperCase() }}</option>
+      </select>
+    </div>
+
+    <div class="content-box">
+      <h1 class="intro-title" v-html="mdInline(text.extra?.intro_header ?? 'Introduction')" />
+
+      <div class="intro-grid">
+        <div class="intro-text-col">
+          <div v-if="text.extra?.intro_text" class="prose" v-html="md(text.extra.intro_text)" />
+        </div>
+
+        <div v-if="introItems.length" class="intro-items-col">
+          <div v-for="i in introItems" :key="i.item.id" class="intro-item-card" @click="$router.push(`/item/${encodeURIComponent(i.item.id)}`)">
+            <div class="intro-item-img-wrap">
+              <img v-if="i.image" :src="i.image" :alt="i.name" class="intro-item-img" />
+              <div v-else class="intro-item-img-placeholder" />
+            </div>
+            <h3 class="intro-item-name" v-html="mdInline(i.name)" />
+            <p v-if="i.dynasty" class="intro-item-meta">{{ i.dynasty }}</p>
+            <p v-if="i.date" class="intro-item-meta">{{ i.date }}</p>
+            <p v-if="i.location" class="intro-item-meta">{{ i.location }}</p>
+            <p v-if="i.museum" class="intro-item-meta">{{ i.museum }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.not-found { color: var(--muted); font-family: 'Roboto', sans-serif; font-size: 13px; }
+
+.intro-wrap { display: flex; flex-direction: column; gap: 10px; }
+
+.lang-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+  justify-content: flex-end;
+}
+.lang-select { font-size: 12px; padding: 3px 6px; }
+
+.intro-title {
+  font-size: 20px;
+  font-weight: 400;
+  color: var(--heading);
+  margin-bottom: 16px;
+  line-height: 1.3;
+  font-family: 'Roboto', sans-serif;
+}
+
+.intro-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 24px;
+}
+@media (max-width: 700px) { .intro-grid { grid-template-columns: 1fr; } }
+
+.intro-text-col { min-width: 0; }
+.prose { font-size: 14px; line-height: 1.7; color: var(--text); font-family: 'Roboto', sans-serif; }
+.prose :deep(p) { margin: 0 0 .75em; }
+.prose :deep(p:last-child) { margin-bottom: 0; }
+
+.intro-items-col { display: flex; flex-direction: column; gap: 14px; }
+.intro-item-card {
+  border: 1px solid var(--border);
+  background: var(--section-bg);
+  padding: 12px;
+  cursor: pointer;
+}
+.intro-item-card:hover .intro-item-name { color: var(--nav-active); }
+
+.intro-item-img-wrap {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: #f0ebdc;
+  margin-bottom: 8px;
+}
+.intro-item-img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.intro-item-img-placeholder { width: 100%; height: 100%; }
+
+.intro-item-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--heading);
+  margin-bottom: 4px;
+  line-height: 1.3;
+  font-family: 'Roboto', sans-serif;
+}
+.intro-item-meta {
+  font-size: 12px;
+  color: var(--muted);
+  font-family: 'Roboto', sans-serif;
+  margin-bottom: 2px;
+}
+</style>

--- a/scripts/viewer/src/views/ExhibitionSplash.vue
+++ b/scripts/viewer/src/views/ExhibitionSplash.vue
@@ -1,0 +1,135 @@
+<script setup>
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const route = useRoute()
+const router = useRouter()
+const { exhibitionById, exhibitionThemes, enCollectionTranslations, md, mdInline } = useInventoryData()
+
+const exhibition = computed(() => exhibitionById(decodeURIComponent(route.params.exhibitionId)) ?? null)
+
+const text = computed(() => {
+  const e = exhibition.value
+  return e ? (enCollectionTranslations.value[e.id] ?? {}) : {}
+})
+
+// "Introduction" is not a theme — it's the exhibition's own intro text plus
+// items attached directly to the exhibition collection (not to any theme/page).
+const hasIntroduction = computed(() => {
+  const e = exhibition.value
+  if (!e) return false
+  return (e.items?.length ?? 0) > 0 || !!text.value.extra?.intro_text || !!text.value.extra?.intro_header
+})
+
+const themeList = computed(() => {
+  const e = exhibition.value
+  if (!e) return []
+  return exhibitionThemes(e.id).map(t => ({
+    ...t,
+    title: enCollectionTranslations.value[t.id]?.title ?? t.internal_name,
+  }))
+})
+
+function back() {
+  if (window.history.length > 2) {
+    router.back()
+  } else {
+    router.push('/exhibitions')
+  }
+}
+</script>
+
+<template>
+  <div v-if="!exhibition" class="content-box not-found">
+    <p>Exhibition not found.</p>
+    <router-link to="/exhibitions">← Return to Exhibitions</router-link>
+  </div>
+
+  <div v-else>
+    <a class="back-link" href="#" @click.prevent="back">← Back to Exhibitions</a>
+
+    <h1 class="section-heading" v-html="mdInline(text.title ?? exhibition.internal_name)" />
+
+    <div class="content-box intro-box">
+      <h2 v-if="text.extra?.subtitle" class="intro-subtitle" v-html="mdInline(text.extra.subtitle)" />
+      <div v-if="text.description" class="prose" v-html="md(text.description)" />
+      <p v-if="text.extra?.credits" class="intro-credits" v-html="mdInline(text.extra.credits)" />
+    </div>
+
+    <div class="content-box">
+      <ul class="theme-list">
+        <li
+          v-if="hasIntroduction"
+          class="theme-row"
+          @click="$router.push(`/exhibitions/${exhibition.id}/introduction`)"
+        >
+          <span class="theme-name">Introduction</span>
+          <span class="theme-arrow">→</span>
+        </li>
+        <li
+          v-for="t in themeList"
+          :key="t.id"
+          class="theme-row"
+          @click="$router.push(`/exhibitions/${exhibition.id}/theme/${encodeURIComponent(t.id)}`)"
+        >
+          <span class="theme-name" v-html="mdInline(t.title)" />
+          <span class="theme-arrow">→</span>
+        </li>
+      </ul>
+      <p v-if="!hasIntroduction && !themeList.length" class="no-results">No content available for this exhibition yet.</p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.not-found { color: var(--muted); font-family: 'Roboto', sans-serif; font-size: 13px; }
+
+.intro-box { border-top: 3px solid var(--gold-dark); }
+.intro-subtitle {
+  font-size: 16px;
+  font-weight: 400;
+  color: var(--heading);
+  margin-bottom: 12px;
+  font-family: 'Roboto', sans-serif;
+}
+.prose { font-size: 14px; line-height: 1.7; color: var(--text); font-family: 'Roboto', sans-serif; }
+.prose :deep(p) { margin: 0 0 .75em; }
+.prose :deep(p:last-child) { margin-bottom: 0; }
+
+.intro-credits {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  font-style: italic;
+  color: var(--muted);
+  font-family: 'Roboto', sans-serif;
+  white-space: pre-line;
+}
+
+.no-results { color: var(--muted); font-family: 'Roboto', sans-serif; font-size: 13px; padding: 20px 0; }
+
+.theme-list { list-style: none; }
+.theme-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 4px;
+  border-bottom: 1px solid #e8dcc8;
+  cursor: pointer;
+}
+.theme-row:last-child { border-bottom: none; }
+.theme-row:hover .theme-name { color: var(--nav-active); }
+
+.theme-name {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--heading);
+  font-family: 'Roboto', sans-serif;
+}
+.theme-arrow {
+  color: var(--muted);
+  font-size: 14px;
+}
+</style>

--- a/scripts/viewer/src/views/ExhibitionTheme.vue
+++ b/scripts/viewer/src/views/ExhibitionTheme.vue
@@ -1,0 +1,421 @@
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const route = useRoute()
+const router = useRouter()
+const {
+  itemById,
+  availableLangs, defaultLang,
+  translationsCache, loadLangTranslations,
+  dynastyLabel, partnerLabel,
+  exhibitionById, exhibitionThemeById,
+  enCollectionTranslations,
+  md, mdInline,
+} = useInventoryData()
+
+const exhibition = computed(() => exhibitionById(decodeURIComponent(route.params.exhibitionId)) ?? null)
+const theme = computed(() => {
+  const e = exhibition.value
+  if (!e) return null
+  return exhibitionThemeById(e.id, decodeURIComponent(route.params.themeId)) ?? null
+})
+const pages = computed(() => theme.value?.pages ?? [])
+
+// ── Active tab (page within the theme) ──────────────────────────────────
+
+const activeTabIndex = ref(0)
+
+function syncTabFromQuery() {
+  const idx = parseInt(route.query.tab ?? '0', 10)
+  activeTabIndex.value = Number.isFinite(idx) && idx >= 0 && idx < pages.value.length ? idx : 0
+}
+
+watch([theme, () => route.query.tab], syncTabFromQuery, { immediate: true })
+
+function selectTab(idx) {
+  router.push({ query: { ...route.query, tab: idx } })
+}
+
+const activePage = computed(() => pages.value[activeTabIndex.value] ?? null)
+
+// ── Language selector (collection text loaded on demand, per-lang) ──────
+
+const activeLang = ref(defaultLang)
+const collectionLangCache = ref({})
+
+async function loadCollectionLangTranslations(lang) {
+  if (collectionLangCache.value[lang]) return
+  try {
+    const m = await import(`@inventory-data/translations/collections.${lang}.json`)
+    collectionLangCache.value = { ...collectionLangCache.value, [lang]: m.default }
+  } catch {
+    collectionLangCache.value = { ...collectionLangCache.value, [lang]: {} }
+  }
+}
+
+onMounted(() => {
+  loadCollectionLangTranslations(activeLang.value)
+  loadLangTranslations(activeLang.value)
+})
+watch(activeLang, lang => {
+  loadCollectionLangTranslations(lang)
+  loadLangTranslations(lang)
+})
+
+function collectionText(collectionId) {
+  return collectionLangCache.value[activeLang.value]?.[collectionId] ?? {}
+}
+
+// The importer synthesizes a placeholder title ("Theme 5", "Page 17") when
+// the legacy source has no page_title/theme_title for a given language.
+// Treat that pattern as "missing" and fall back to the English title.
+const PLACEHOLDER_TITLE = /^(Artintro )?(Theme|Page) \d+$/
+
+function resolveTitle(collectionId, fallbackName) {
+  const local = collectionText(collectionId).title
+  if (local && !PLACEHOLDER_TITLE.test(local)) return local
+  const en = enCollectionTranslations.value[collectionId]?.title
+  if (en && !PLACEHOLDER_TITLE.test(en)) return en
+  return fallbackName
+}
+
+const themeTitle = computed(() => resolveTitle(theme.value?.id, theme.value?.internal_name ?? ''))
+
+// ── Thumbnail grid, detail panel, and multi-variant "detail" selector ───
+
+const selectedItemId = ref(null)
+const selectedVariantIndex = ref(0) // 0 = item's own main image; N = details[N-1]
+
+watch(activePage, page => {
+  selectedItemId.value = page?.items?.[0]?.id ?? null
+  selectedVariantIndex.value = 0
+})
+
+const gridItems = computed(() => {
+  const page = activePage.value
+  if (!page) return []
+  return page.items
+    .map(entry => ({ entry, item: itemById.value[entry.id] }))
+    .filter(({ item }) => item)
+})
+
+const selected = computed(() => gridItems.value.find(g => g.item.id === selectedItemId.value) ?? gridItems.value[0] ?? null)
+
+const selectedVariants = computed(() => selected.value?.entry.details ?? [])
+
+function selectItem(itemId) {
+  selectedItemId.value = itemId
+  selectedVariantIndex.value = 0
+}
+
+function selectVariant(idx) {
+  selectedVariantIndex.value = idx
+}
+
+const selectedDisplay = computed(() => {
+  const sel = selected.value
+  if (!sel) return null
+
+  const variantIdx = selectedVariantIndex.value
+  const variant = variantIdx > 0 ? selectedVariants.value[variantIdx - 1] : null
+
+  if (variant) {
+    const caption = variant.caption?.[activeLang.value] ?? {}
+    return {
+      name: caption.detail_name ?? caption.name ?? '',
+      date: caption.date ?? '',
+      dynasty: caption.dynasty ?? '',
+      location: caption.location ?? '',
+      museum: caption.museum ?? '',
+      justification: caption.justification ?? '',
+      image: variant.image_url ?? sel.item.images?.[0]?.url ?? null,
+    }
+  }
+
+  // Main/default view: caption override (current language) merged with the
+  // item's own generic translation, mirroring the legacy behaviour.
+  const caption = sel.entry.caption?.[activeLang.value] ?? {}
+  const t = translationsCache.value[activeLang.value]?.[sel.item.id] ?? {}
+  return {
+    name: caption.name ?? t.name ?? sel.item.internal_name ?? sel.item.id,
+    date: caption.date ?? t.dates ?? '',
+    dynasty: caption.dynasty ?? (sel.item.dynasty_ids?.[0] ? dynastyLabel(sel.item.dynasty_ids[0]) : ''),
+    location: caption.location ?? t.location ?? '',
+    museum: caption.museum ?? (sel.item.partner_id ? partnerLabel(sel.item.partner_id) : ''),
+    justification: caption.justification ?? '',
+    image: sel.item.images?.[0]?.url ?? null,
+  }
+})
+
+function back() {
+  if (window.history.length > 2) {
+    router.back()
+  } else if (exhibition.value) {
+    router.push(`/exhibitions/${exhibition.value.id}`)
+  } else {
+    router.push('/exhibitions')
+  }
+}
+</script>
+
+<template>
+  <div v-if="!theme" class="content-box not-found">
+    <p>Theme not found.</p>
+    <router-link v-if="exhibition" :to="`/exhibitions/${exhibition.id}`">← Return to exhibition</router-link>
+    <router-link v-else to="/exhibitions">← Return to Exhibitions</router-link>
+  </div>
+
+  <div v-else class="theme-wrap">
+    <a class="back-link" href="#" @click.prevent="back">← Back to {{ exhibition.internal_name }}</a>
+
+    <div v-if="availableLangs.length > 1" class="lang-selector">
+      <label class="lang-label">Text language:</label>
+      <select v-model="activeLang" class="lang-select">
+        <option v-for="lang in availableLangs" :key="lang" :value="lang">{{ lang.toUpperCase() }}</option>
+      </select>
+    </div>
+
+    <div class="content-box">
+      <h1 class="theme-title" v-html="mdInline(themeTitle)" />
+
+      <!-- Tabs -->
+      <div v-if="pages.length > 1" class="tab-row">
+        <button
+          v-for="(page, idx) in pages"
+          :key="page.id"
+          class="tab-btn"
+          :class="{ active: idx === activeTabIndex }"
+          @click="selectTab(idx)"
+        >
+          {{ resolveTitle(page.id, page.internal_name) }}
+        </button>
+      </div>
+
+      <div v-if="activePage" class="theme-grid">
+        <!-- Left: narrative text -->
+        <div class="theme-text-col">
+          <p v-if="collectionText(activePage.id).quote" class="page-quote" v-html="mdInline(collectionText(activePage.id).quote)" />
+          <div v-if="collectionText(activePage.id).description" class="prose" v-html="md(collectionText(activePage.id).description)" />
+        </div>
+
+        <!-- Right: detail panel + thumbnail grid -->
+        <div class="theme-side-col">
+          <div v-if="selectedDisplay" class="item-detail-panel">
+            <div class="item-detail-img-wrap">
+              <img v-if="selectedDisplay.image" :src="selectedDisplay.image" :alt="selectedDisplay.name" class="item-detail-img" />
+              <div v-else class="item-detail-img-placeholder" />
+            </div>
+
+            <!-- Detail variant selector: small image buttons to switch between
+                 the item's main view and its curated "detail" close-ups -->
+            <div v-if="selectedVariants.length" class="variant-row">
+              <button
+                class="variant-btn"
+                :class="{ active: selectedVariantIndex === 0 }"
+                title="Main view"
+                @click="selectVariant(0)"
+              >
+                <img v-if="selected.item.images?.[0]?.url" :src="selected.item.images[0].url" alt="Main view" />
+              </button>
+              <button
+                v-for="(variant, idx) in selectedVariants"
+                :key="idx"
+                class="variant-btn"
+                :class="{ active: selectedVariantIndex === idx + 1 }"
+                title="Detail view"
+                @click="selectVariant(idx + 1)"
+              >
+                <img v-if="variant.image_url" :src="variant.image_url" alt="Detail view" />
+              </button>
+            </div>
+
+            <h3 class="item-detail-name" v-html="mdInline(selectedDisplay.name)" />
+            <p v-if="selectedDisplay.dynasty" class="item-detail-meta">{{ selectedDisplay.dynasty }}</p>
+            <p v-if="selectedDisplay.date" class="item-detail-meta">{{ selectedDisplay.date }}</p>
+            <p v-if="selectedDisplay.location" class="item-detail-meta">{{ selectedDisplay.location }}</p>
+            <p v-if="selectedDisplay.museum" class="item-detail-meta">{{ selectedDisplay.museum }}</p>
+            <p v-if="selectedDisplay.justification" class="item-detail-justification" v-html="mdInline(selectedDisplay.justification)" />
+            <RouterLink :to="`/item/${encodeURIComponent(selected.item.id)}`" class="more-info-link">
+              More info →
+            </RouterLink>
+          </div>
+
+          <div class="thumb-grid">
+            <div
+              v-for="g in gridItems"
+              :key="g.item.id"
+              class="thumb-cell"
+              :class="{ active: g.item.id === selectedItemId }"
+              @click="selectItem(g.item.id)"
+            >
+              <img v-if="g.item.images?.length" :src="g.item.images[0].url" :alt="g.item.internal_name ?? ''" loading="lazy" />
+              <div v-else class="thumb-placeholder" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.not-found { color: var(--muted); font-family: 'Roboto', sans-serif; font-size: 13px; }
+
+.theme-wrap { display: flex; flex-direction: column; gap: 10px; }
+
+.lang-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 12px;
+  color: var(--muted);
+  justify-content: flex-end;
+}
+.lang-select { font-size: 12px; padding: 3px 6px; }
+
+.theme-title {
+  font-size: 22px;
+  font-weight: 400;
+  color: var(--heading);
+  margin-bottom: 14px;
+  line-height: 1.3;
+  font-family: 'Roboto', sans-serif;
+}
+
+/* Tabs */
+.tab-row {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 18px;
+  border-bottom: 1px solid var(--border);
+}
+.tab-btn {
+  font-family: 'Roboto', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 8px 16px;
+  background: none;
+  border: none;
+  border-bottom: 3px solid transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.tab-btn:hover { color: var(--heading); }
+.tab-btn.active {
+  color: var(--heading);
+  border-bottom-color: var(--gold-dark);
+}
+
+/* Two-column layout */
+.theme-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 24px;
+}
+@media (max-width: 700px) { .theme-grid { grid-template-columns: 1fr; } }
+
+.theme-text-col { min-width: 0; }
+.page-quote {
+  font-size: 15px;
+  font-style: italic;
+  color: var(--heading);
+  margin-bottom: 14px;
+  line-height: 1.5;
+  font-family: 'Roboto', sans-serif;
+}
+.prose { font-size: 14px; line-height: 1.7; color: var(--text); font-family: 'Roboto', sans-serif; }
+.prose :deep(p) { margin: 0 0 .75em; }
+.prose :deep(p:last-child) { margin-bottom: 0; }
+
+/* Detail panel */
+.theme-side-col { display: flex; flex-direction: column; gap: 14px; }
+
+.item-detail-panel {
+  border: 1px solid var(--border);
+  background: var(--section-bg);
+  padding: 14px;
+}
+.item-detail-img-wrap {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: #f0ebdc;
+  margin-bottom: 10px;
+}
+.item-detail-img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.item-detail-img-placeholder { width: 100%; height: 100%; }
+
+/* Variant selector */
+.variant-row {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+.variant-btn {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: 2px solid transparent;
+  background: #f0ebdc;
+  cursor: pointer;
+  overflow: hidden;
+}
+.variant-btn.active { border-color: var(--gold-dark); }
+.variant-btn:hover { border-color: var(--gold-amber); }
+.variant-btn img { width: 100%; height: 100%; object-fit: cover; display: block; }
+
+.item-detail-name {
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--heading);
+  margin-bottom: 6px;
+  line-height: 1.3;
+  font-family: 'Roboto', sans-serif;
+}
+.item-detail-meta {
+  font-size: 12px;
+  color: var(--muted);
+  font-family: 'Roboto', sans-serif;
+  margin-bottom: 2px;
+}
+.item-detail-justification {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text);
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  font-family: 'Roboto', sans-serif;
+}
+.more-info-link {
+  display: inline-block;
+  margin-top: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--nav-active);
+  font-family: 'Roboto', sans-serif;
+}
+
+/* Thumbnail grid */
+.thumb-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+.thumb-cell {
+  aspect-ratio: 1;
+  overflow: hidden;
+  border: 2px solid transparent;
+  cursor: pointer;
+  background: #f0ebdc;
+}
+.thumb-cell.active { border-color: var(--gold-dark); }
+.thumb-cell:hover { border-color: var(--gold-amber); }
+.thumb-cell img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.thumb-placeholder { width: 100%; height: 100%; }
+</style>

--- a/scripts/viewer/src/views/ExhibitionsEntrance.vue
+++ b/scripts/viewer/src/views/ExhibitionsEntrance.vue
@@ -1,0 +1,75 @@
+<script setup>
+import { computed } from 'vue'
+import { useInventoryData } from '../composables/useInventoryData.js'
+
+const { exhibitions, enCollectionTranslations, mdInline } = useInventoryData()
+
+const exhibitionList = computed(() =>
+  exhibitions.value.map(e => ({
+    ...e,
+    title: enCollectionTranslations.value[e.id]?.title ?? e.internal_name,
+  }))
+)
+</script>
+
+<template>
+  <div v-if="!exhibitionList.length" class="content-box not-found">
+    <p>No exhibitions available.</p>
+  </div>
+
+  <div v-else>
+    <h1 class="section-heading">Exhibitions</h1>
+
+    <div class="content-box">
+      <p class="intro-text">
+        Select an exhibition below to explore its themes, monuments, and objects.
+      </p>
+      <ul class="theme-list">
+        <li
+          v-for="e in exhibitionList"
+          :key="e.id"
+          class="theme-row"
+          @click="$router.push(`/exhibitions/${encodeURIComponent(e.id)}`)"
+        >
+          <span class="theme-name" v-html="mdInline(e.title)" />
+          <span class="theme-arrow">→</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.not-found { color: var(--muted); font-family: 'Roboto', sans-serif; font-size: 13px; }
+
+.intro-text {
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--muted);
+  margin-bottom: 16px;
+  font-family: 'Roboto', sans-serif;
+}
+
+.theme-list { list-style: none; }
+.theme-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 4px;
+  border-bottom: 1px solid #e8dcc8;
+  cursor: pointer;
+}
+.theme-row:last-child { border-bottom: none; }
+.theme-row:hover .theme-name { color: var(--nav-active); }
+
+.theme-name {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--heading);
+  font-family: 'Roboto', sans-serif;
+}
+.theme-arrow {
+  color: var(--muted);
+  font-size: 14px;
+}
+</style>

--- a/scripts/viewer/src/views/Home.vue
+++ b/scripts/viewer/src/views/Home.vue
@@ -78,6 +78,16 @@ function goToItem(item) {
         </p>
         <span class="home-card-link">Explore →</span>
       </div>
+
+      <div class="home-card content-box" @click="$router.push('/artistic-introduction')">
+        <h2 class="home-card-title">Artistic Introduction</h2>
+        <p class="home-card-desc">
+          Read curated introductions to the major artistic traditions of
+          Islamic art, illustrated with monuments and objects from the
+          collection.
+        </p>
+        <span class="home-card-link">Explore →</span>
+      </div>
     </div>
 
     <!-- Featured item spotlight -->

--- a/scripts/viewer/src/views/Home.vue
+++ b/scripts/viewer/src/views/Home.vue
@@ -88,6 +88,15 @@ function goToItem(item) {
         </p>
         <span class="home-card-link">Explore →</span>
       </div>
+
+      <div class="home-card content-box" @click="$router.push('/exhibitions')">
+        <h2 class="home-card-title">Exhibitions</h2>
+        <p class="home-card-desc">
+          Discover curated virtual exhibitions exploring specific themes,
+          monuments, and objects from the Islamic art collection.
+        </p>
+        <span class="home-card-link">Explore →</span>
+      </div>
     </div>
 
     <!-- Featured item spotlight -->


### PR DESCRIPTION
## Summary
- Ports the legacy "Artistic Introduction" (gai) feature to the viewer: a splash page listing themes and a per-theme page with Monuments/Objects tabs, a thumbnail grid, and a detail panel with per-item captions/justification text linking to the item detail page.
- Fixes `collection-exporter.ts` to include `internal_name` (needed to identify artintro collections among the many other features sharing the same generic `type` values) and per-item caption/override data (`collection_item.extra`), previously dropped from `collections.json` entirely.
- Fixes a latent bug affecting `collection-exporter.ts`, `item-exporter.ts`, and `partner-exporter.ts`: `parseJson()` assumed MySQL JSON columns were returned as strings, but `mysql2` auto-decodes them to objects, so `JSON.parse(object)` silently threw and returned `null` -- this was dropping monument history/patrons, picture photographer/copyright, and partner contact-person data.
- Viewer works around a handful of pre-existing legacy translation gaps (missing `page_title` for a given language) where the importer synthesizes a placeholder like "Artintro Page 17" -- falls back to the English title instead of leaking it to end users.

## Test plan
- [x] Verified splash page (themes, subtitle, description, credits) matches the legacy site (islamicart.museumwnf.org/gai/ISL/)
- [x] Verified all 10 themes / 19 pages load with no console errors or failed network requests
- [x] Verified tab switching, thumbnail selection, and the "More info" link to item detail
- [x] Verified language switching (EN/FR/AR/ES) including the placeholder-title fallback fix
- [x] Verified mobile responsive layout
- [x] Verified 0 missing item references and 0 items without images across all 137 artintro item entries
- [x] npm run build clean for both exporter and viewer
- [x] Consumed the newly published @metanull/islamicart-data@1.0.16 package (containing the exporter fixes) and re-verified end-to-end

Generated with Claude Code