### PR TITLE
fix (importer): Renamed root collection for ISL Virtual Exhibitions

### DIFF
--- a/scripts/import-tool/README.md
+++ b/scripts/import-tool/README.md
@@ -173,8 +173,10 @@ separately and keeps it running independently of any one `stage` invocation.
 
 Both the DB and the staged images persist in named Docker volumes
 (`local-mysql-data`, `local-images-data`) — they survive `docker restart`,
-and survive `docker compose down` (without `-v`) followed by `up`/`run` again.
-Only `docker compose down -v` (or `docker volume rm`) destroys them.
+and survive `docker compose -f scripts/import-tool/docker-compose.yml down`
+(without `-v`) followed by `up`/`run` again. Only
+`docker compose -f scripts/import-tool/docker-compose.yml down -v` (or
+`docker volume rm`) destroys them.
 
 `stage` intentionally differs from `append`/`clean` in one way: **migrations
 only, no seeders.** `local-migrate` runs `php artisan migrate --force` and

--- a/scripts/importer/src/cli/import.ts
+++ b/scripts/importer/src/cli/import.ts
@@ -435,9 +435,9 @@ const ALL_IMPORTERS: ImporterConfig[] = [
   },
   {
     key: 'exhibitions-root-collection',
-    name: 'Exhibitions Root Collection',
+    name: 'Virtual Exhibitions Root Collection',
     description:
-      'Create the "Exhibitions" marker collection (child of the ISL project collection) that ISL exhibitions nest under',
+      'Create the "Virtual Exhibitions" marker collection (child of the ISL project collection) that ISL exhibitions nest under',
     importerClass: ExhibitionsRootCollectionImporter,
     dependencies: ['project', 'language'],
   },

--- a/scripts/importer/src/importers/phase-01/exhibitions-root-collection-importer.ts
+++ b/scripts/importer/src/importers/phase-01/exhibitions-root-collection-importer.ts
@@ -1,8 +1,8 @@
 /**
  * Exhibitions Root Collection Importer
  *
- * Creates a single "Exhibitions" marker collection as a child of the Islamic
- * Art (ISL) project collection. This mirrors ArtintroRootCollectionImporter:
+ * Creates a single "Virtual Exhibitions" marker collection as a child of the
+ * Islamic Art (ISL) project collection. This mirrors ArtintroRootCollectionImporter:
  * `type='exhibition'` (and even the `mwnf3:exhibitions:{id}` backward_compatibility
  * key) is not project-scoped — the mwnf3 legacy schema shares its exhibitions
  * table across multiple projects (ISL, BAR, SH, ...), so neither field alone
@@ -50,7 +50,7 @@ export class ExhibitionsRootCollectionImporter extends BaseImporter {
       const backwardCompat = `${MWNF3_SCHEMA}:exhibitions:root`;
 
       if (await this.entityExistsAsync(backwardCompat, 'collection')) {
-        this.logInfo('Exhibitions root collection already exists, skipping');
+        this.logInfo('Virtual Exhibitions root collection already exists, skipping');
         result.skipped++;
         this.showSkipped();
         return result;
@@ -77,7 +77,7 @@ export class ExhibitionsRootCollectionImporter extends BaseImporter {
         'exhibitions_root_collection',
         { internal_name: internalName, backward_compatibility: backwardCompat },
         'foundation',
-        'Exhibitions root collection'
+        'Virtual Exhibitions root collection'
       );
 
       if (this.isDryRun || this.isSampleOnlyMode) {
@@ -112,18 +112,18 @@ export class ExhibitionsRootCollectionImporter extends BaseImporter {
         language_id: defaultLanguageId,
         context_id: contextId,
         backward_compatibility: translationBackwardCompat,
-        title: 'Exhibitions',
+        title: 'Virtual Exhibitions',
         description:
           'Curated virtual exhibitions exploring themes, monuments, and objects from the Islamic art collection.',
       });
 
-      this.logInfo(`Created Exhibitions root collection: ${collectionId}`);
+      this.logInfo(`Created Virtual Exhibitions root collection: ${collectionId}`);
       result.imported++;
       this.showProgress();
     } catch (error) {
       result.success = false;
       const message = error instanceof Error ? error.message : String(error);
-      result.errors.push(`Error creating Exhibitions root collection: ${message}`);
+      result.errors.push(`Error creating Virtual Exhibitions root collection: ${message}`);
       this.logError('ExhibitionsRootCollectionImporter', message);
       this.showError();
     }

--- a/scripts/importer/src/importers/phase-01/mwnf3-exhibition-importer.ts
+++ b/scripts/importer/src/importers/phase-01/mwnf3-exhibition-importer.ts
@@ -3,8 +3,8 @@
  *
  * Imports the mwnf3 exhibition hierarchy as nested Collections:
  * - exhibitions (27, across ISL/BAR/SH/...) → Collection (type='exhibition').
- *   ISL exhibitions (18) nest under the "Exhibitions" marker collection
- *   created by ExhibitionsRootCollectionImporter (child of the ISL project
+ *   ISL exhibitions (18) nest under the "Virtual Exhibitions" marker
+ *   collection created by ExhibitionsRootCollectionImporter (child of the ISL project
  *   collection), since neither type='exhibition' nor the
  *   mwnf3:exhibitions:{id} key are project-scoped. Every other project's
  *   exhibitions keep nesting directly under their own project collection.
@@ -91,8 +91,8 @@ export class Mwnf3ExhibitionImporter extends BaseImporter {
             continue;
           }
 
-          // Resolve parent: for ISL, nest under the "Exhibitions" marker
-          // collection (created by ExhibitionsRootCollectionImporter) so ISL
+          // Resolve parent: for ISL, nest under the "Virtual Exhibitions"
+          // marker collection (created by ExhibitionsRootCollectionImporter) so ISL
           // exhibitions can be identified unambiguously by parent_id —
           // neither type='exhibition' nor the mwnf3:exhibitions:{id}
           // backward_compatibility key are project-scoped (the legacy schema
@@ -108,7 +108,7 @@ export class Mwnf3ExhibitionImporter extends BaseImporter {
             'collection'
           );
           if (!parentCollectionId) {
-            const label = isIsl ? 'Exhibitions root collection' : 'Project collection';
+            const label = isIsl ? 'Virtual Exhibitions root collection' : 'Project collection';
             result.errors.push(
               `Exhibition ${legacy.exhibition_id}: ${label} not found (${parentBackwardCompat})`
             );

--- a/scripts/viewer/src/composables/useInventoryData.js
+++ b/scripts/viewer/src/composables/useInventoryData.js
@@ -137,8 +137,8 @@ function artIntroThemeById(id) {
 
 // ── Exhibitions ────────────────────────────────────────────────────────────
 //
-// Imported as generic Collections, nested under a dedicated "Exhibitions"
-// marker collection (backward_compatibility "mwnf3:exhibitions:root", a
+// Imported as generic Collections, nested under a dedicated "Virtual
+// Exhibitions" marker collection (backward_compatibility "mwnf3:exhibitions:root", a
 // child of the Islamic Art project collection) — needed because neither
 // type='exhibition' nor the mwnf3:exhibitions:{id} backward_compatibility
 // key are project-scoped in the legacy schema (shared with Baroque Art,


### PR DESCRIPTION
- **Importer**: renamed the marker collection's title to "Virtual Exhibitions" in [exhibitions-root-collection-importer.ts](scripts/importer/src/importers/phase-01/exhibitions-root-collection-importer.ts), plus consistent updates to the doc comments and log messages in `mwnf3-exhibition-importer.ts` and the CLI pipeline entry name in `cli/import.ts`. Left `internal_name`/`backward_compatibility`/the `key:` pipeline identifier unchanged — those are stable pipeline keys, not display text.
- **Exporter**: confirmed no change needed — it's fully data-driven (reads `title` from `collection_translations` at export time, no hardcoded strings).
- **Database**: ran the SQL update against the **local docker DB only** (port 3316) — confirmed the row changed from "Exhibitions" → "Virtual Exhibitions". OVH was left untouched, since `ship` hasn't run yet.
- Typecheck and lint both clean.