### PR TITLE
fix(exporter,importer): resolve legacy-vs-viewer gaps found in islamicart audit

### DIFF
--- a/scripts/exporter/src/exporters/dynasty-exporter.ts
+++ b/scripts/exporter/src/exporters/dynasty-exporter.ts
@@ -29,18 +29,19 @@ export class DynastyExporter extends BaseExporter {
   async export(): Promise<ExportResult> {
     this.logger.info('Exporting dynasties.json...')
 
-    const ph = this.placeholders(this.projectIds.length)
-
-    // Only dynasties linked (via item_dynasty pivot) to non-picture items in the given projects
+    // The `dynasties` table has no project/context column of its own — legacy's
+    // mwnf3.dynasties is imported wholesale (dynasty-importer.ts has no project filter),
+    // and today it holds only ISL's 60 rows, so exporting the full table reproduces
+    // legacy's dynasty list exactly. Scoping via item_dynasty instead (as this used to)
+    // silently dropped the ~17 dynasties legacy lists that no cataloged item happens to
+    // reference — legacy shows all defined dynasties regardless of item usage.
+    // If a second project's dynasties are ever imported into this same table, this will
+    // need real project scoping (a column on `dynasties`, mirroring the still-open
+    // cross-project scoping problem in glossary-exporter.ts) rather than exporting everything.
     const dynasties = await this.db.query<DynastyRow>(
-      `SELECT DISTINCT d.id, d.backward_compatibility, d.from_ah, d.to_ah, d.from_ad, d.to_ad
-       FROM dynasties d
-       JOIN item_dynasty id2 ON d.id = id2.dynasty_id
-       JOIN items i ON id2.item_id = i.id
-       WHERE i.project_id IN (${ph})
-         AND i.type IN ('object', 'monument', 'detail')
-       ORDER BY d.from_ad`,
-      this.projectIds
+      `SELECT id, backward_compatibility, from_ah, to_ah, from_ad, to_ad
+       FROM dynasties
+       ORDER BY from_ad`
     )
 
     if (dynasties.length === 0) {

--- a/scripts/exporter/src/exporters/glossary-exporter.ts
+++ b/scripts/exporter/src/exporters/glossary-exporter.ts
@@ -27,8 +27,57 @@ export class GlossaryExporter extends BaseExporter {
   async export(): Promise<ExportResult> {
     this.logger.info('Exporting glossary.json...')
 
+    // `glossaries` has no project/context column — it's a single table shared across every
+    // imported project's legacy glossary variants. Scope to entries actually referenced (via
+    // a spelling) from this project's items, collection text, or timeline event text; without
+    // this every project's export would ship every other project's glossary too.
+    const ph = this.placeholders(this.projectIds.length)
+    const usedIds = await this.db.query<{ id: string }>(
+      `SELECT DISTINCT gs.glossary_id AS id
+       FROM glossary_spellings gs
+       JOIN item_translation_spelling its ON its.spelling_id = gs.id
+       JOIN item_translations it ON it.id = its.item_translation_id
+       JOIN items i ON i.id = it.item_id
+       WHERE i.project_id IN (${ph})
+         AND i.type IN ('object', 'monument', 'detail')
+
+       UNION
+
+       SELECT DISTINCT gs.glossary_id AS id
+       FROM glossary_spellings gs
+       JOIN collection_translation_spelling cts ON cts.spelling_id = gs.id
+       JOIN collection_translations ct ON ct.id = cts.collection_translation_id
+       JOIN collections c ON c.id = ct.collection_id
+       WHERE c.context_id IN (SELECT p.context_id FROM projects p WHERE p.id IN (${ph}))
+
+       UNION
+
+       SELECT DISTINCT gs.glossary_id AS id
+       FROM glossary_spellings gs
+       JOIN timeline_event_translation_spelling tets ON tets.spelling_id = gs.id
+       JOIN timeline_event_translations tet ON tet.id = tets.timeline_event_translation_id
+       JOIN timeline_events te ON te.id = tet.timeline_event_id
+       JOIN timelines t ON t.id = te.timeline_id
+       WHERE t.collection_id IN (
+         SELECT c.id FROM collections c
+         WHERE c.context_id IN (SELECT p.context_id FROM projects p WHERE p.id IN (${ph}))
+       )
+       ${this.context.projectKeys.includes('ISL') ? 'OR t.collection_id IS NULL' : ''}`,
+      [...this.projectIds, ...this.projectIds, ...this.projectIds]
+    )
+
+    if (usedIds.length === 0) {
+      await this.writeJson('glossary.json', [])
+      this.logger.warning('glossary.json (0 entries used by this project)')
+      return { file: 'glossary.json', count: 0 }
+    }
+
+    const usedPh = this.placeholders(usedIds.length)
     const entries = await this.db.query<GlossaryRow>(
-      `SELECT id, internal_name, backward_compatibility FROM glossaries ORDER BY internal_name`
+      `SELECT id, internal_name, backward_compatibility FROM glossaries
+       WHERE id IN (${usedPh})
+       ORDER BY internal_name`,
+      usedIds.map(r => r.id)
     )
 
     if (entries.length === 0) {

--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -78,6 +78,11 @@ interface ItemTagRow {
   tag: string
 }
 
+interface ItemGlossaryRow {
+  item_id: string
+  glossary_id: string
+}
+
 export class ItemExporter extends BaseExporter {
   getName(): string {
     return 'Items'
@@ -166,8 +171,8 @@ export class ItemExporter extends BaseExporter {
       )
     }
 
-    // ── 3. Dynasty, tag, and item-item links ────────────────────────────────
-    const [dynastyLinks, tagLinks, itemItemLinks] = await Promise.all([
+    // ── 3. Dynasty, tag, glossary, and item-item links ──────────────────────
+    const [dynastyLinks, tagLinks, glossaryLinks, itemItemLinks] = await Promise.all([
       this.db.query<ItemDynastyRow>(
         `SELECT item_id, dynasty_id FROM item_dynasty WHERE item_id IN (${itemPh})`,
         itemIds
@@ -177,6 +182,16 @@ export class ItemExporter extends BaseExporter {
          FROM item_tag it2
          JOIN tags t ON t.id = it2.tag_id
          WHERE it2.item_id IN (${itemPh})`,
+        itemIds
+      ),
+      // Glossary terms used anywhere in this item's translations (any language),
+      // via item_translations -> item_translation_spelling -> glossary_spellings.
+      this.db.query<ItemGlossaryRow>(
+        `SELECT DISTINCT it3.item_id, gs.glossary_id
+         FROM item_translation_spelling its
+         JOIN item_translations it3 ON it3.id = its.item_translation_id
+         JOIN glossary_spellings gs ON gs.id = its.spelling_id
+         WHERE it3.item_id IN (${itemPh})`,
         itemIds
       ),
       // Outgoing links only (source_id IN items). The legacy data model stores
@@ -308,6 +323,13 @@ export class ItemExporter extends BaseExporter {
       tagMap.get(link.item_id)!.push(link.tag)
     }
 
+    // item_id -> glossary_ids[]
+    const glossaryMap = new Map<string, string[]>()
+    for (const link of glossaryLinks) {
+      if (!glossaryMap.has(link.item_id)) glossaryMap.set(link.item_id, [])
+      glossaryMap.get(link.item_id)!.push(link.glossary_id)
+    }
+
     // item_id -> related item entries (outgoing links only; only targets present in this export)
     // source_id -> target_id -> lang_code -> justification text
     const itemIdSet = new Set(itemIds)
@@ -350,6 +372,7 @@ export class ItemExporter extends BaseExporter {
         justifications: justificationMap.get(item.id)?.get(targetId) ?? {},
       })),
       tags: tagMap.get(item.id) ?? [],
+      glossary_ids: glossaryMap.get(item.id) ?? [],
     }))
 
     await this.writeJson('items.json', output)

--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -65,6 +65,12 @@ interface PartnerLevelRow {
   level: string | null
 }
 
+interface GroupMembershipRow {
+  collection_id: string
+  partner_id: string
+  level: string | null
+}
+
 // Legacy tiers, most to least prominent. A partner attached at multiple
 // levels across the exported projects is reported at its most prominent tier.
 const LEVEL_RANK: Record<string, number> = {
@@ -90,6 +96,13 @@ export class PartnerExporter extends BaseExporter {
     // a Ministry of Culture recorded as the monument's owner), not an actual listed project
     // partner — legacy's Partners page only ever shows the curated hierarchy, never every
     // institution that happens to own an item.
+    //
+    // `level IS NOT NULL` is what actually enforces that narrowing: monument/object import
+    // also attaches every item's owning partner to collection_partner (same collection_type
+    //='project') for ownership tracking, but leaves `level` null since that generic
+    // attachment was never curated onto the legacy Partners page. Only the dedicated
+    // hierarchy importers (partner-hierarchy-importer.ts / institution-hierarchy-importer.ts)
+    // set a level, so requiring one here excludes the generic item-owner rows.
     const partners = await this.db.query<PartnerRow>(
       `SELECT DISTINCT p.id, p.type, p.internal_name, p.backward_compatibility,
               p.country_id, p.latitude, p.longitude, p.map_zoom, p.monument_item_id
@@ -101,6 +114,7 @@ export class PartnerExporter extends BaseExporter {
          JOIN projects proj ON proj.context_id = c.context_id
          WHERE cp.collection_type = 'project'
            AND cp.visible = true
+           AND cp.level IS NOT NULL
            AND cp.partner_id = p.id
            AND proj.id IN (${ph})
        )
@@ -154,6 +168,26 @@ export class PartnerExporter extends BaseExporter {
         [...this.projectIds, ...partnerIds]
       ),
     ])
+
+    // Per-context hierarchy: partner-hierarchy-importer.ts / institution-hierarchy-importer.ts
+    // give each tier-1 partner_museums/partner_institutions row its own "group" collection
+    // (collection_type='collection', internal_name 'partner_group:...') and attach that
+    // partner plus every associated/further-associated museum or institution legacy links
+    // to it via `associated_museums.partner_id` to that same collection. The member with
+    // level='partner' in a group is that group's owner (the legacy top-level partner); every
+    // other member's parent_id is that owner's id. A partner can own or belong to at most one
+    // group per project (mirrors legacy: one partner_museums/partner_institutions row per
+    // museum/institution per project).
+    const groupMemberships = await this.db.query<GroupMembershipRow>(
+      `SELECT cp.collection_id, cp.partner_id, cp.level
+       FROM collection_partner cp
+       JOIN collections c ON c.id = cp.collection_id
+       WHERE cp.collection_type = 'collection'
+         AND c.internal_name LIKE 'partner_group:%'
+         AND c.context_id IN (SELECT p.context_id FROM projects p WHERE p.id IN (${ph}))
+         AND cp.partner_id IN (${partnerPh})`,
+      [...this.projectIds, ...partnerIds]
+    )
 
     // partner_id -> lang_code -> fields
     const translationMap = new Map<string, Record<string, Record<string, string | null>>>()
@@ -243,6 +277,20 @@ export class PartnerExporter extends BaseExporter {
       }
     }
 
+    // collection_id -> owner partner_id (the member with level='partner')
+    const groupOwnerMap = new Map<string, string>()
+    for (const row of groupMemberships) {
+      if (row.level === 'partner') groupOwnerMap.set(row.collection_id, row.partner_id)
+    }
+    // partner_id -> parent partner_id (the owner of the group(s) this partner belongs to,
+    // excluding the group(s) it owns itself)
+    const parentMap = new Map<string, string>()
+    for (const row of groupMemberships) {
+      if (row.level === 'partner') continue
+      const owner = groupOwnerMap.get(row.collection_id)
+      if (owner && owner !== row.partner_id) parentMap.set(row.partner_id, owner)
+    }
+
     const output = partners.map(p => ({
       id: p.id,
       type: p.type,
@@ -253,6 +301,7 @@ export class PartnerExporter extends BaseExporter {
       map_zoom: p.map_zoom,
       monument_item_id: p.monument_item_id,
       level: levelMap.get(p.id) ?? null,
+      parent_id: parentMap.get(p.id) ?? null,
       contact_person_1: contactMap.get(p.id)?.contact_person_1 ?? null,
       contact_person_2: contactMap.get(p.id)?.contact_person_2 ?? null,
       additional_urls: contactMap.get(p.id)?.urls ?? [],

--- a/scripts/import-tool/README.md
+++ b/scripts/import-tool/README.md
@@ -27,7 +27,8 @@ build` once beforehand) to be sure you're running current code.
 | `backup-permissions` | Snapshots users (incl. MFA columns), role assignments, direct permission assignments, and API tokens to an encrypted JSON on the OVH host, plus a redundant timestamped copy pulled back locally. No import, no writes to application data. |
 | `clean` | `db:wipe` → `migrate` → `db:seed` → `permission:sync` → restore users → the full `append` pipeline. **Destructive.** Requires `CONFIRM_WIPE=yes-really-wipe-production` or it refuses to run. Restores from a snapshot at `AUTH_SNAPSHOT_REMOTE` if one exists (run `backup-permissions` first to create it — `clean` does not take a fresh snapshot itself); if none exists **and** both `ADMIN_EMAIL`/`REGULAR_USER_EMAIL` are set, falls back to recreating just those two accounts instead. If neither applies, aborts before anything beyond the wipe itself is lost. |
 | `stage` | `import` → `image-sync`, writing straight to a local, persistent MySQL (`local-mysql`) instead of through the OVH tunnel. **No SSH, no OVH contact at all.** Builds a fully-populated local copy of the legacy import — DB rows in `local-mysql`, image files in the `local-images-data` volume — at local-network speed. Safe to run at any time, including while a real `append`/`clean` run is in progress against OVH (they hit the same legacy source DB, which comfortably handles concurrent readers). See "Local staging" below. |
-| `ship` | Ships an already-built `stage` copy to OVH: rebuilds the app layer on OVH exactly like `clean` (`db:wipe` → `migrate` → `db:seed` → `permission:sync` → restore/recreate users), then copies local-mysql's **content tables only** to OVH and loads them there (against OVH's own local MySQL, not through the tunnel), and pushes the already-staged images. **Destructive**, same `CONFIRM_WIPE` requirement as `clean`. See "Shipping a staged build to a server" below. |
+| `local-glossary-sync` (compose service, not an entrypoint mode) | Runs `glossary:resync` and drains its queue **inline, in this container**, against `local-mysql` — no OVH contact, no dependency on OVH's `inventory-queue.service`. Run this after `stage` and before `ship`, so the item/collection/timeline-event ↔ glossary link rows are already real data in `local-mysql` by the time `ship` dumps it. Invoke directly: `docker compose -f scripts/import-tool/docker-compose.yml run --build --rm local-glossary-sync`. |
+| `ship` | Ships an already-built `stage` (+ `local-glossary-sync`) copy to OVH: rebuilds the app layer on OVH exactly like `clean` (`db:wipe` → `migrate` → `db:seed` → `permission:sync` → restore/recreate users), then copies local-mysql's **content tables only** to OVH and loads them there (against OVH's own local MySQL, not through the tunnel), and pushes the already-staged images. Does **not** resync the glossary itself — that already happened locally. **Destructive**, same `CONFIRM_WIPE` requirement as `clean`. See "Shipping a staged build to a server" below. |
 
 ## Build
 
@@ -213,10 +214,13 @@ what's missing instead of redoing everything. Concretely:
   `docker compose -f scripts/import-tool/docker-compose.yml run --build --rm stage`.
   Already-imported rows and already-copied images are detected and skipped;
   only what's new or was missing gets added.
-- **`glossary:resync`:** there's nothing to "continue" locally — `stage`
-  never touches it (it's an OVH-only side effect, consumed by
-  `inventory-queue.service` running on OVH). It happens automatically as
-  part of `ship`, once you're ready to send the build to OVH.
+- **`glossary:resync`:** `stage` itself never touches it — run the
+  `local-glossary-sync` compose service separately once `stage` has finished,
+  and again any time you rerun `stage` and pick up new/changed text. It runs
+  entirely against `local-mysql` in-container (dispatch + drain the `glossary`
+  queue synchronously, no OVH contact, no dependency on OVH's
+  `inventory-queue.service`), so by the time you `ship`, the link rows are
+  already sitting in `local-mysql` as plain data and travel with the dump.
 - **You actually want to rebuild from nothing** (e.g. to verify a truly
   clean import from scratch): `docker compose -f scripts/import-tool/docker-compose.yml down -v`
   destroys `local-mysql-data`/`local-images-data`/`local-app-vendor`, then
@@ -226,10 +230,12 @@ what's missing instead of redoing everything. Concretely:
 ## Shipping a staged build to a server
 
 Once `stage` has produced a fully-populated `local-mysql` + `local-images-data`,
+run `local-glossary-sync` once against it (see the mode table above), then
 `ship` sends that build to OVH instead of running `append`/`clean` against it
 directly over the tunnel:
 
 ```powershell
+docker compose -f scripts/import-tool/docker-compose.yml run --build --rm local-glossary-sync
 $env:CONFIRM_WIPE='yes-really-wipe-production'
 docker compose -f scripts/import-tool/docker-compose.yml run --build --rm ship
 ```
@@ -264,7 +270,15 @@ What it actually does, in order:
    just collide with it.
 3. **Pushes the already-staged images** from `local-images-data` — no
    re-running image-sync, they're already there.
-4. **Resyncs the glossary** on OVH, same as `append`/`clean`.
+
+That's it — unlike `append`/`clean`, `ship` does **not** resync the glossary
+itself. `local-glossary-sync` already computed
+`item_translation_spelling`/`collection_translation_spelling`/
+`timeline_event_translation_spelling` as plain rows in `local-mysql` before
+you ran `ship`, and those tables aren't in `SHIP_EXCLUDED_TABLES`, so step 2's
+dump already carries them. Skip `local-glossary-sync` and OVH will simply load
+whatever was (or wasn't) there from the last time you ran it — it does not
+error, it just ships stale or missing links.
 
 **Why load the dump on OVH itself, not through the tunnel?** That's the
 entire reason `stage`/`ship` exist: avoid thousands of small round-trips over

--- a/scripts/import-tool/docker-compose.yml
+++ b/scripts/import-tool/docker-compose.yml
@@ -150,11 +150,55 @@ services:
       local-migrate:
         condition: service_completed_successfully
 
+  # Runs the glossary spelling <-> translation sync against local-mysql, once
+  # `stage` has populated it — dispatches glossary:resync's jobs onto the
+  # 'glossary' queue and drains them inline in the same container run, so
+  # item_translation_spelling/collection_translation_spelling/
+  # timeline_event_translation_spelling are already fully populated as plain
+  # data rows by the time `ship` dumps local-mysql. This replaces relying on
+  # OVH's inventory-queue.service after the fact (see do_ship in entrypoint.sh
+  # and README.md): ship's dump/load has nothing left to trigger remotely.
+  # Uses QUEUE_CONNECTION=database (not the reactive Eloquent-event path —
+  # the importer writes translations via raw SQL, which never fires
+  # GlossarySpelling's `saved` event) so the jobs land in local-mysql's own
+  # `jobs` table, then `queue:work --stop-when-empty` processes them
+  # synchronously before this container exits.
+  local-glossary-sync:
+    build:
+      context: ../..
+      dockerfile: .docker/Dockerfile.dev
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        [ -f vendor/autoload.php ] || composer install --no-interaction --quiet
+        php artisan glossary:resync --remove-existing --force
+        php artisan queue:work --queue=glossary --stop-when-empty --tries=3
+    volumes:
+      - ../..:/var/www/app
+      - local-app-vendor:/var/www/app/vendor
+      - ../../.docker/php.dev.ini:/usr/local/etc/php/conf.d/99-app.ini:ro
+    environment:
+      APP_ENV: local
+      APP_DEBUG: "true"
+      DB_CONNECTION: mysql
+      DB_HOST: local-mysql
+      DB_PORT: "3306"
+      DB_DATABASE: inventory
+      DB_USERNAME: inventory
+      DB_PASSWORD: secret
+      QUEUE_CONNECTION: database
+    depends_on:
+      local-mysql:
+        condition: service_healthy
+
   # Ships an already-built `stage` copy to OVH. DESTRUCTIVE (same
   # CONFIRM_WIPE requirement as `clean`) — see entrypoint.sh's do_ship and
   # README.md "Shipping a staged build to a server". No LEGACY_IMAGES_HOST_PATH
   # mount: images come from the already-staged local-images-data volume, not
-  # the legacy image source.
+  # the legacy image source. Requires `local-glossary-sync` to have already
+  # been run against local-mysql — see that service's comment.
   ship:
     <<: *build
     command: ["ship"]

--- a/scripts/import-tool/entrypoint.sh
+++ b/scripts/import-tool/entrypoint.sh
@@ -38,7 +38,11 @@ set -euo pipefail
 #                       SHIP_EXCLUDED_TABLES below) to OVH and loading them
 #                       there against OVH's own local MySQL (not through the
 #                       tunnel — see load_staged_dump), then pushing the
-#                       already-staged images and resyncing the glossary.
+#                       already-staged images. Does NOT resync the glossary on
+#                       OVH — run the `local-glossary-sync` compose service
+#                       against local-mysql before `ship` instead, so the
+#                       item/collection/timeline_event <-> glossary link rows
+#                       are already part of the dump (see README.md).
 #                       DESTRUCTIVE — same CONFIRM_WIPE requirement
 #                       as `clean`. Requires a `stage` run to have already
 #                       populated local-mysql/local-images-data.
@@ -454,6 +458,14 @@ push_staged_images() {
 # `clean` does, and never reads any of that from local-mysql (which has none
 # of it — see do_stage). Only the CONTENT tables (the actual imported legacy
 # data) come from the local build.
+#
+# No glossary resync here, unlike do_import_pipeline: the `local-glossary-sync`
+# compose service (run against local-mysql, after `stage` and before `ship`)
+# already computed item_translation_spelling/collection_translation_spelling/
+# timeline_event_translation_spelling as plain data rows, so load_staged_dump's
+# dump already carries them — nothing left to trigger on OVH. Running
+# run_glossary_resync here too would just re-dispatch the exact same work onto
+# OVH's queue for inventory-queue.service to redo a second time.
 do_ship() {
   do_wipe_and_restore
 
@@ -463,7 +475,6 @@ do_ship() {
   load_staged_dump
 
   push_staged_images
-  run_glossary_resync
 }
 
 do_backup_permissions() {

--- a/scripts/importer/src/importers/phase-01/institution-hierarchy-importer.ts
+++ b/scripts/importer/src/importers/phase-01/institution-hierarchy-importer.ts
@@ -17,6 +17,15 @@
  * the country's generic administrative authority, e.g. a Ministry of
  * Culture, without being a listed project partner).
  *
+ * Beyond the flat per-project tier (still attached to the project's own
+ * collection, `collection_type='project'`, as before), each tier-1
+ * `partner_institutions` row also gets its own dedicated "group" collection
+ * (`collection_type='collection'`), and every associated institution legacy
+ * links to it via `associated_institutions.partner_id` is *also* attached to
+ * that same group collection — see partner-hierarchy-importer.ts's class
+ * comment for why this per-context grouping (rather than a global parent
+ * field on Partner) is the right shape.
+ *
  * Dependencies:
  * - ProjectImporter (creates collections from projects)
  * - PartnerImporter (creates partners from institutions)
@@ -93,13 +102,25 @@ export class InstitutionHierarchyImporter extends BaseImporter {
           row.country_id,
           'partner'
         );
-        if (imported) {
-          result.imported++;
-          this.showProgress();
-        } else {
+        if (!imported) {
           result.skipped++;
           this.showSkipped();
+          continue;
         }
+
+        // Best-effort: enriches the flat per-project attachment above but
+        // doesn't gate result.imported — see PartnerHierarchyImporter's
+        // importPartnerMuseums for the same reasoning.
+        await this.attachToGroupCollection(
+          row.project_id,
+          row.partner_id,
+          row.institution_id,
+          row.country_id,
+          'partner'
+        );
+
+        result.imported++;
+        this.showProgress();
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         const bc = `partner_institutions:${row.partner_id}`;
@@ -129,13 +150,25 @@ export class InstitutionHierarchyImporter extends BaseImporter {
           row.country_id,
           'associated_partner'
         );
-        if (imported) {
-          result.imported++;
-          this.showProgress();
-        } else {
+        if (!imported) {
           result.skipped++;
           this.showSkipped();
+          continue;
         }
+
+        // Best-effort — doesn't gate result.imported, see importPartnerInstitutions.
+        if (row.partner_id !== null) {
+          await this.attachToGroupCollection(
+            projectId,
+            row.partner_id,
+            row.institution_id,
+            row.country_id,
+            'associated_partner'
+          );
+        }
+
+        result.imported++;
+        this.showProgress();
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         const bc = `associated_institutions:${row.associated_id}`;
@@ -212,5 +245,105 @@ export class InstitutionHierarchyImporter extends BaseImporter {
     );
 
     return true;
+  }
+
+  /**
+   * Attaches a partner (identified by institutionId/countryId) to the
+   * dedicated per-context "group" collection for legacy top-level partner
+   * `topPartnerId` (a `partner_institutions.partner_id` — globally unique,
+   * one project per row), creating that group collection on first use.
+   */
+  private async attachToGroupCollection(
+    projectId: string,
+    topPartnerId: number | null,
+    institutionId: string,
+    countryId: string,
+    level: string
+  ): Promise<boolean> {
+    if (topPartnerId === null) {
+      return false;
+    }
+
+    const partnerBackwardCompat = formatBackwardCompatibility({
+      schema: 'mwnf3',
+      table: 'institutions',
+      pkValues: [institutionId, countryId],
+    });
+    const partnerId = await this.getEntityUuidAsync(partnerBackwardCompat, 'partner');
+    if (!partnerId) {
+      // Already warned about by attachInstitutionToProject for the same row.
+      return false;
+    }
+
+    if (this.isDryRun || this.isSampleOnlyMode) {
+      this.logInfo(
+        `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would attach partner ${institutionId}:${countryId} to group collection for institutions:${topPartnerId} with level=${level}`
+      );
+      return true;
+    }
+
+    const groupCollectionId = await this.getOrCreateGroupCollection(projectId, topPartnerId);
+    if (!groupCollectionId) {
+      return false;
+    }
+
+    await this.context.strategy.attachPartnerToCollectionWithLevel(
+      groupCollectionId,
+      partnerId,
+      'collection',
+      level
+    );
+
+    return true;
+  }
+
+  private async getOrCreateGroupCollection(
+    projectId: string,
+    topPartnerId: number
+  ): Promise<string | null> {
+    const groupBackwardCompat = formatBackwardCompatibility({
+      schema: 'mwnf3',
+      table: 'partner_institutions_group',
+      pkValues: [String(topPartnerId)],
+    });
+
+    const existingId = await this.getEntityUuidAsync(groupBackwardCompat, 'collection');
+    if (existingId) {
+      return existingId;
+    }
+
+    const projectBackwardCompat = formatBackwardCompatibility({
+      schema: 'mwnf3',
+      table: 'projects',
+      pkValues: [projectId],
+    });
+    const parentCollectionId = await this.getEntityUuidAsync(projectBackwardCompat, 'collection');
+    const contextId = await this.getEntityUuidAsync(projectBackwardCompat, 'context');
+    if (!parentCollectionId || !contextId) {
+      this.logWarning(
+        `Project collection/context not found for ${projectId}, skipping group collection for institutions:${topPartnerId}`
+      );
+      return null;
+    }
+
+    const defaultLanguageId = await this.getDefaultLanguageIdAsync();
+    const internalName = `partner_group:institutions:${topPartnerId}`;
+
+    const collectionId = await this.context.strategy.writeCollection({
+      internal_name: internalName,
+      backward_compatibility: groupBackwardCompat,
+      context_id: contextId,
+      language_id: defaultLanguageId,
+      parent_id: parentCollectionId,
+      type: 'collection',
+      latitude: null,
+      longitude: null,
+      map_zoom: null,
+      country_id: null,
+    });
+
+    this.registerEntity(collectionId, groupBackwardCompat, 'collection');
+
+    return collectionId;
   }
 }

--- a/scripts/importer/src/importers/phase-01/partner-hierarchy-importer.ts
+++ b/scripts/importer/src/importers/phase-01/partner-hierarchy-importer.ts
@@ -8,6 +8,23 @@
  *
  * These map to collection_partner.level in inventory-app.
  *
+ * Beyond the flat per-project tier (still attached to the project's own
+ * collection, `collection_type='project'`, as before — this is what
+ * partner-exporter.ts's curated-partner filter keys off), each tier-1
+ * `partner_museums` row also gets its own dedicated "group" collection
+ * (`collection_type='collection'`), and every associated/further-associated
+ * museum legacy links to it via `associated_museums.partner_id` /
+ * `further_associated_museums.partner_id` is *also* attached to that same
+ * group collection. This reproduces legacy's actual nesting — which specific
+ * associated museum belongs under which specific top-level museum — which the
+ * flat per-project tier alone cannot: two different top-level museums in the
+ * same country would otherwise have their associated museums indistinguishably
+ * merged into one country-wide bucket. Because the group collection is scoped
+ * to this project's context, the same museum can be a parent in one project
+ * and a mere sibling (or absent) in another — the hierarchy is per-context,
+ * not a global property of the partner itself, matching how legacy itself
+ * scopes `partner_museums`/`associated_museums` per `project_id`.
+ *
  * Dependencies:
  * - ProjectImporter (creates collections from projects)
  * - PartnerImporter (creates partners from museums)
@@ -54,13 +71,13 @@ export class PartnerHierarchyImporter extends BaseImporter {
       this.logInfo('Importing partner hierarchy levels...');
 
       // Import tier 1: partner_museums → level = 'partner'
-      await this.importTier(result, 'partner');
+      await this.importPartnerMuseums(result);
 
       // Import tier 2: associated_museums → level = 'associated_partner'
-      await this.importTier(result, 'associated_partner');
+      await this.importAssociatedMuseums(result);
 
       // Import tier 3: further_associated_museums → level = 'minor_contributor'
-      await this.importTier(result, 'minor_contributor');
+      await this.importFurtherAssociatedMuseums(result);
 
       this.showSummary(
         result.imported,
@@ -76,19 +93,6 @@ export class PartnerHierarchyImporter extends BaseImporter {
 
     result.success = result.errors.length === 0;
     return result;
-  }
-
-  private async importTier(
-    result: ImportResult,
-    level: 'partner' | 'associated_partner' | 'minor_contributor'
-  ): Promise<void> {
-    if (level === 'partner') {
-      await this.importPartnerMuseums(result);
-    } else if (level === 'associated_partner') {
-      await this.importAssociatedMuseums(result);
-    } else {
-      await this.importFurtherAssociatedMuseums(result);
-    }
   }
 
   private async importPartnerMuseums(result: ImportResult): Promise<void> {
@@ -108,13 +112,30 @@ export class PartnerHierarchyImporter extends BaseImporter {
           row.country_id,
           'partner'
         );
-        if (imported) {
-          result.imported++;
-          this.showProgress();
-        } else {
+        if (!imported) {
           result.skipped++;
           this.showSkipped();
+          continue;
         }
+
+        // Tier-1 museum owns a group collection for this project — create it
+        // now (before any tier-2/3 row can need it) and attach the museum
+        // itself as the group's 'partner'-level (owner) member. Best-effort:
+        // this enriches the flat per-project attachment above but doesn't
+        // gate it — a row whose group-collection step fails (e.g. project
+        // context not yet resolvable) still counts as imported, since the
+        // primary (legacy-equivalent) attachment above already succeeded.
+        await this.attachToGroupCollection(
+          row.project_id,
+          'museums',
+          row.partner_id,
+          row.museum_id,
+          row.country_id,
+          'partner'
+        );
+
+        result.imported++;
+        this.showProgress();
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         const bc = `partner_museums:${row.partner_id}`;
@@ -144,13 +165,28 @@ export class PartnerHierarchyImporter extends BaseImporter {
           row.country_id,
           'associated_partner'
         );
-        if (imported) {
-          result.imported++;
-          this.showProgress();
-        } else {
+        if (!imported) {
           result.skipped++;
           this.showSkipped();
+          continue;
         }
+
+        // Best-effort: nests under the parent's group collection if it has
+        // one (row.partner_id !== null and the parent's own tier-1 row
+        // resolved). Doesn't gate result.imported — see importPartnerMuseums.
+        if (row.partner_id !== null) {
+          await this.attachToGroupCollection(
+            projectId,
+            'museums',
+            row.partner_id,
+            row.museum_id,
+            row.country_id,
+            'associated_partner'
+          );
+        }
+
+        result.imported++;
+        this.showProgress();
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         const bc = `associated_museums:${row.associated_id}`;
@@ -195,13 +231,24 @@ export class PartnerHierarchyImporter extends BaseImporter {
           row.country_id,
           'minor_contributor'
         );
-        if (imported) {
-          result.imported++;
-          this.showProgress();
-        } else {
+        if (!imported) {
           result.skipped++;
           this.showSkipped();
+          continue;
         }
+
+        // Best-effort — doesn't gate result.imported, see importPartnerMuseums.
+        await this.attachToGroupCollection(
+          row.project_id,
+          'museums',
+          row.partner_id,
+          row.museum_id,
+          row.country_id,
+          'minor_contributor'
+        );
+
+        result.imported++;
+        this.showProgress();
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         const bc = `further_associated_museums:${row.fur_associated_id}`;
@@ -261,5 +308,109 @@ export class PartnerHierarchyImporter extends BaseImporter {
     );
 
     return true;
+  }
+
+  /**
+   * Attaches a partner (identified by museumId/countryId) to the dedicated
+   * per-context "group" collection for legacy top-level partner `topPartnerId`
+   * (a `partner_museums.partner_id` — globally unique, one project per row),
+   * creating that group collection on first use. `entityType` distinguishes
+   * museums from institutions in the backward_compatibility key so the two
+   * hierarchies never collide.
+   */
+  private async attachToGroupCollection(
+    projectId: string,
+    entityType: 'museums' | 'institutions',
+    topPartnerId: number,
+    museumId: string,
+    countryId: string,
+    level: string
+  ): Promise<boolean> {
+    const partnerBackwardCompat = formatBackwardCompatibility({
+      schema: 'mwnf3',
+      table: entityType,
+      pkValues: [museumId, countryId],
+    });
+    const partnerId = await this.getEntityUuidAsync(partnerBackwardCompat, 'partner');
+    if (!partnerId) {
+      // Already warned about by attachPartnerToProject for the same row.
+      return false;
+    }
+
+    if (this.isDryRun || this.isSampleOnlyMode) {
+      this.logInfo(
+        `[${this.isSampleOnlyMode ? 'SAMPLE' : 'DRY-RUN'}] Would attach partner ${museumId}:${countryId} to group collection for ${entityType}:${topPartnerId} with level=${level}`
+      );
+      return true;
+    }
+
+    const groupCollectionId = await this.getOrCreateGroupCollection(
+      projectId,
+      entityType,
+      topPartnerId
+    );
+    if (!groupCollectionId) {
+      return false;
+    }
+
+    await this.context.strategy.attachPartnerToCollectionWithLevel(
+      groupCollectionId,
+      partnerId,
+      'collection',
+      level
+    );
+
+    return true;
+  }
+
+  private async getOrCreateGroupCollection(
+    projectId: string,
+    entityType: 'museums' | 'institutions',
+    topPartnerId: number
+  ): Promise<string | null> {
+    const groupBackwardCompat = formatBackwardCompatibility({
+      schema: 'mwnf3',
+      table: `partner_${entityType}_group`,
+      pkValues: [String(topPartnerId)],
+    });
+
+    const existingId = await this.getEntityUuidAsync(groupBackwardCompat, 'collection');
+    if (existingId) {
+      return existingId;
+    }
+
+    const projectBackwardCompat = formatBackwardCompatibility({
+      schema: 'mwnf3',
+      table: 'projects',
+      pkValues: [projectId],
+    });
+    const parentCollectionId = await this.getEntityUuidAsync(projectBackwardCompat, 'collection');
+    const contextId = await this.getEntityUuidAsync(projectBackwardCompat, 'context');
+    if (!parentCollectionId || !contextId) {
+      this.logWarning(
+        `Project collection/context not found for ${projectId}, skipping group collection for ${entityType}:${topPartnerId}`
+      );
+      return null;
+    }
+
+    const defaultLanguageId = await this.getDefaultLanguageIdAsync();
+    const internalName = `partner_group:${entityType}:${topPartnerId}`;
+
+    const collectionId = await this.context.strategy.writeCollection({
+      internal_name: internalName,
+      backward_compatibility: groupBackwardCompat,
+      context_id: contextId,
+      language_id: defaultLanguageId,
+      parent_id: parentCollectionId,
+      type: 'collection',
+      latitude: null,
+      longitude: null,
+      map_zoom: null,
+      country_id: null,
+    });
+
+    this.registerEntity(collectionId, groupBackwardCompat, 'collection');
+
+    return collectionId;
   }
 }


### PR DESCRIPTION
## Summary
Fixes four data-pipeline gaps found while comparing the new islamicart viewer against legacy islamicart.museumwnf.org, page by page:

- **Partners - institution leak**: `partner-exporter.ts` now requires `collection_partner.level IS NOT NULL`, so generic item-owner institutions (e.g. "Ministry of Culture") no longer leak into the curated Partners list. Verified against the staged DB: 48 partners exported (46 museums + 2 institutions), exact match with legacy.
- **Partners - hierarchy**: each tier-1 `partner_museums`/`partner_institutions` row now gets its own per-context "group" `Collection` (reusing the existing `Collection`/`collection_partner` model, `collection_type='collection'` - no schema change), with associated/further-associated partners attached to it. `partner-exporter.ts` derives `parent_id` per partner from group ownership.
- **Dynasties**: `dynasty-exporter.ts` now exports every project dynasty directly instead of only ones linked to a cataloged item. Verified: 60 dynasties exported, exact match with legacy (was 43).
- **Glossary**: `glossary-exporter.ts` now scopes `glossary.json` to terms actually referenced by this project's items/collections/timeline-events instead of shipping every project's glossary. `item-exporter.ts` adds `glossary_ids` per item.
- **Import pipeline**: added a `local-glossary-sync` compose service that runs `glossary:resync` and drains its queue inline against `local-mysql`, so the glossary link rows are already part of the dump before `ship` - `ship` no longer relies on OVH's `inventory-queue.service` to resync asynchronously afterward.

## Test plan
- [x] `npm run type-check` clean in `scripts/exporter` and `scripts/importer`
- [x] Full importer unit test suite passes (383 tests, 56 files)
- [x] Verified against the live staged DB: `partners.json` (48), `dynasties.json` (60) exact-match legacy
- [x] New `PartnerHierarchyImporter`/`InstitutionHierarchyImporter` logic ran with 0 errors against the full multi-project staged legacy dataset
- [x] `local-glossary-sync` manually run against `local-mysql`, confirmed it populates `item_translation_spelling` etc. (slow - full run is multi-hour, not yet completed)
- [ ] Full re-`stage` + re-export end-to-end verification of `parent_id` in `partners.json` (pending stage completion)
- [ ] Viewer (`PartnersResults.vue`) not yet updated to consume `parent_id` - follow-up

Generated with Claude Code