### PR TITLE
feat(exporter,viewer): support EPM (Explore Islamic Art Collections) alongside ISL

### DIFF
--- a/scripts/exporter/src/exporters/partner-exporter.ts
+++ b/scripts/exporter/src/exporters/partner-exporter.ts
@@ -63,6 +63,7 @@ interface PartnerLogoRow {
 interface PartnerLevelRow {
   partner_id: string
   level: string | null
+  project_id: string
 }
 
 interface GroupMembershipRow {
@@ -155,9 +156,11 @@ export class PartnerExporter extends BaseExporter {
         partnerIds
       ),
       // Legacy tier (partner / associated_partner / minor_contributor), scoped to the
-      // collections that represent the exported projects themselves.
+      // collections that represent the exported projects themselves. Also carries
+      // which project each attachment belongs to, so a partner curated under more
+      // than one exported project (e.g. ISL and EPM both list it) reports all of them.
       this.db.query<PartnerLevelRow>(
-        `SELECT cp.partner_id, cp.level
+        `SELECT cp.partner_id, cp.level, proj.id AS project_id
          FROM collection_partner cp
          JOIN collections c ON c.id = cp.collection_id
          JOIN projects proj ON proj.context_id = c.context_id
@@ -168,6 +171,11 @@ export class PartnerExporter extends BaseExporter {
         [...this.projectIds, ...partnerIds]
       ),
     ])
+
+    // project UUID -> legacy project key (e.g. 'ISL', 'EPM'), for project_ids below
+    const projectKeyById = new Map(
+      this.projectIds.map((id, i) => [id, this.context.projectKeys[i]])
+    )
 
     // Per-context hierarchy: partner-hierarchy-importer.ts / institution-hierarchy-importer.ts
     // give each tier-1 partner_museums/partner_institutions row its own "group" collection
@@ -269,11 +277,21 @@ export class PartnerExporter extends BaseExporter {
 
     // partner_id -> most prominent level across the exported projects
     const levelMap = new Map<string, string>()
+    // partner_id -> legacy project keys this partner is curated under (e.g. ['ISL'], or
+    // ['ISL', 'EPM'] if listed in both) — lets the viewer split Partners by project the
+    // same way legacy keeps separate pages per project (pm_partner_list.php vs
+    // pm_partner_list_eiac.php).
+    const projectIdsMap = new Map<string, Set<string>>()
     for (const row of levels) {
       if (!row.level) continue
       const current = levelMap.get(row.partner_id)
       if (!current || (LEVEL_RANK[row.level] ?? 99) < (LEVEL_RANK[current] ?? 99)) {
         levelMap.set(row.partner_id, row.level)
+      }
+      const key = projectKeyById.get(row.project_id)
+      if (key) {
+        if (!projectIdsMap.has(row.partner_id)) projectIdsMap.set(row.partner_id, new Set())
+        projectIdsMap.get(row.partner_id)!.add(key)
       }
     }
 
@@ -301,6 +319,7 @@ export class PartnerExporter extends BaseExporter {
       map_zoom: p.map_zoom,
       monument_item_id: p.monument_item_id,
       level: levelMap.get(p.id) ?? null,
+      project_ids: [...(projectIdsMap.get(p.id) ?? [])],
       parent_id: parentMap.get(p.id) ?? null,
       contact_person_1: contactMap.get(p.id)?.contact_person_1 ?? null,
       contact_person_2: contactMap.get(p.id)?.contact_person_2 ?? null,

--- a/scripts/viewer/src/composables/useInventoryData.js
+++ b/scripts/viewer/src/composables/useInventoryData.js
@@ -22,6 +22,19 @@ const defaultLang = (manifestData.languages ?? []).includes('en')
   ? 'en'
   : ((manifestData.languages ?? [])[0] ?? 'en')
 
+// Legacy project key (e.g. 'ISL', 'EPM') by project UUID — manifest.json's
+// projectIds/projectKeys are parallel arrays, one exported project per index.
+const projectKeyById = new Map(
+  (manifestData.projectIds ?? []).map((id, i) => [id, manifestData.projectKeys?.[i]])
+)
+
+// 'ISL' ("Discover Islamic Art") is always the default/primary project; any other
+// exported project (e.g. 'EPM', "Explore Islamic Art Collections") is opt-in —
+// mirrors legacy's database.php "Include Explore Islamic Art Collections" checkbox.
+function itemProjectKey(item) {
+  return projectKeyById.get(item.project_id) ?? null
+}
+
 const enItemTranslations = ref({})
 const enCountryTranslations = ref({})
 const enDynastyTranslations = ref({})
@@ -232,6 +245,7 @@ export function useInventoryData() {
     countryLabel,
     dynastyLabel,
     partnerLabel,
+    itemProjectKey,
     itemById,
     artIntroRoot,
     artIntroThemes,

--- a/scripts/viewer/src/views/Database.vue
+++ b/scripts/viewer/src/views/Database.vue
@@ -24,6 +24,7 @@ const cond2    = ref('AND')
 const cond3    = ref('AND')
 const dateFrom = ref('')
 const dateTo   = ref('')
+const includeEpm = ref(false)
 
 function search() {
   const q = {}
@@ -32,11 +33,14 @@ function search() {
   if (keyword3.value) { q.keyword3 = keyword3.value; q.field3 = field3.value; q.cond3 = cond3.value }
   if (dateFrom.value) q.date_from = dateFrom.value
   if (dateTo.value)   q.date_to   = dateTo.value
+  if (includeEpm.value) q.epm = '1'
   router.push({ path: '/database/results', query: q })
 }
 
 function showAll() {
-  router.push({ path: '/database/results', query: {} })
+  const q = {}
+  if (includeEpm.value) q.epm = '1'
+  router.push({ path: '/database/results', query: q })
 }
 </script>
 
@@ -96,6 +100,19 @@ function showAll() {
 
           <tr><td colspan="2"><hr class="form-divider" /></td></tr>
 
+          <!-- Collection scope -->
+          <tr>
+            <th></th>
+            <td>
+              <label class="epm-toggle">
+                <input type="checkbox" v-model="includeEpm" />
+                Include Explore Islamic Art Collections
+              </label>
+            </td>
+          </tr>
+
+          <tr><td colspan="2"><hr class="form-divider" /></td></tr>
+
           <!-- Date range -->
           <tr>
             <th>Date (from year)</th>
@@ -146,5 +163,14 @@ function showAll() {
   border: none;
   border-top: 1px solid var(--border);
   margin: 8px 0;
+}
+.epm-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-family: 'Roboto', sans-serif;
+  color: var(--text);
+  cursor: pointer;
 }
 </style>

--- a/scripts/viewer/src/views/DatabaseResults.vue
+++ b/scripts/viewer/src/views/DatabaseResults.vue
@@ -8,7 +8,7 @@ const router = useRouter()
 const {
   items, dynasties,
   itemLabel, countryLabel, dynastyLabel,
-  enItemTranslations, mdInline,
+  enItemTranslations, mdInline, itemProjectKey,
 } = useInventoryData()
 
 const PAGE_SIZE = 20
@@ -27,6 +27,7 @@ function parseQuery(q) {
     cond3:    q.cond3    ?? 'AND',
     dateFrom: q.date_from ?? '',
     dateTo:   q.date_to   ?? '',
+    includeEpm: q.epm === '1',
     page:     parseInt(q.page ?? '1', 10) || 1,
     // refine row
     keyword4: q.keyword4 ?? '',
@@ -162,7 +163,13 @@ function itemMatches(item, s) {
 
 const filteredItems = computed(() => {
   const s = search.value
-  return items.value.filter(item => itemMatches(item, s))
+  return items.value.filter(item => {
+    // 'ISL' (Discover Islamic Art) is always searched; other projects (e.g. 'EPM',
+    // Explore Islamic Art Collections) are opt-in via the "Include..." checkbox.
+    const key = itemProjectKey(item)
+    if (key && key !== 'ISL' && !s.includeEpm) return false
+    return itemMatches(item, s)
+  })
 })
 
 const totalPages = computed(() => Math.max(1, Math.ceil(filteredItems.value.length / PAGE_SIZE)))
@@ -191,6 +198,7 @@ const searchSummary = computed(() => {
   if (s.keyword4) parts.push(`${s.cond4} ${fieldLabel(s.field4)}: "${s.keyword4}"`)
   if (s.dateFrom) parts.push(`from ${s.dateFrom}`)
   if (s.dateTo)   parts.push(`to ${s.dateTo}`)
+  if (s.includeEpm) parts.push('+ Explore Islamic Art Collections')
   return parts
 })
 </script>

--- a/scripts/viewer/src/views/PartnersEntrance.vue
+++ b/scripts/viewer/src/views/PartnersEntrance.vue
@@ -3,8 +3,8 @@ import { useRouter } from 'vue-router'
 
 const router = useRouter()
 
-function browse(type) {
-  router.push({ path: '/partners/results', query: { type } })
+function browse(type, project) {
+  router.push({ path: '/partners/results', query: { type, project } })
 }
 </script>
 
@@ -25,13 +25,37 @@ function browse(type) {
           <tr>
             <th><label>Partner Museums</label></th>
             <td>
-              <button class="btn" @click="browse('museum')">Browse Museums →</button>
+              <button class="btn" @click="browse('museum', 'ISL')">Browse Museums →</button>
             </td>
           </tr>
           <tr>
             <th><label>Partner Institutions</label></th>
             <td>
-              <button class="btn" @click="browse('institution')">Browse Institutions →</button>
+              <button class="btn" @click="browse('institution', 'ISL')">Browse Institutions →</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="content-box">
+      <p class="intro-text">
+        Explore Islamic Art Collections brings together further museums and institutions
+        beyond the core Discover Islamic Art network.
+      </p>
+
+      <table class="form-table filter-table">
+        <tbody>
+          <tr>
+            <th><label>Partner Museums</label></th>
+            <td>
+              <button class="btn" @click="browse('museum', 'EPM')">Browse Museums →</button>
+            </td>
+          </tr>
+          <tr>
+            <th><label>Partner Institutions</label></th>
+            <td>
+              <button class="btn" @click="browse('institution', 'EPM')">Browse Institutions →</button>
             </td>
           </tr>
         </tbody>

--- a/scripts/viewer/src/views/PartnersResults.vue
+++ b/scripts/viewer/src/views/PartnersResults.vue
@@ -11,12 +11,18 @@ const otherType = computed(() => (filterType.value === 'museum' ? 'institution' 
 const typeLabel = computed(() => (filterType.value === 'museum' ? 'Museums' : 'Institutions'))
 const otherTypeLabel = computed(() => (otherType.value === 'museum' ? 'Partner Museums' : 'Partner Institutions'))
 
+// 'ISL' (Discover Islamic Art, pm_partner_list.php) and 'EPM' (Explore Islamic Art
+// Collections, pm_partner_list_eiac.php) are two entirely separate curated lists in
+// legacy — never merged into one, unlike Permanent Collection/Database.
+const project = computed(() => (route.query.project === 'EPM' ? 'EPM' : 'ISL'))
+const projectLabel = computed(() => (project.value === 'EPM' ? 'Explore Islamic Art Collections' : 'Discover Islamic Art'))
+
 // Associated tiers are nested under the main "Partners" list per country,
 // mirroring the legacy pm_partner_list.php accordion (level is only present
 // once the exporter's partner-hierarchy join has been re-published; a
 // partner without a level is treated as a main partner).
 const groupedByCountry = computed(() => {
-  const byType = partners.value.filter(p => p.type === filterType.value)
+  const byType = partners.value.filter(p => p.type === filterType.value && p.project_ids?.includes(project.value))
 
   const countries = new Map()
   for (const p of byType) {
@@ -55,12 +61,13 @@ function partnerLink(partner) {
 
     <h1 class="section-heading">
       Partner {{ typeLabel }}
+      <span class="heading-project"> — {{ projectLabel }}</span>
     </h1>
 
     <div class="content-box">
       <p class="result-count">
         {{ totalCount }} partner{{ totalCount !== 1 ? 's' : '' }} found —
-        <RouterLink :to="{ path: '/partners/results', query: { type: otherType } }">
+        <RouterLink :to="{ path: '/partners/results', query: { type: otherType, project } }">
           view {{ otherTypeLabel }} instead
         </RouterLink>
       </p>
@@ -94,6 +101,8 @@ function partnerLink(partner) {
 </template>
 
 <style scoped>
+.heading-project { font-weight: normal; font-size: 14px; color: var(--muted); }
+
 .result-count {
   font-family: 'Roboto', sans-serif;
   font-size: 12px;


### PR DESCRIPTION
## Summary
Legacy islamicart.museumwnf.org merges two legacy projects everywhere on the public site: `ISL` (Discover Islamic Art) and `EPM` (Explore Islamic Art Collections) - `pc_entrance.php`, `pclist_all.php`, and `database_results.php` all explicitly query `project_id='ISL' OR project_id='EPM'`. The exporter has only ever been run with `ISL` alone, so EPM's ~1,222 objects across 18 countries (15 entirely absent from ISL, e.g. Austria) were missing from the published data package - even though EPM was already fully imported into `inventory-app`'s database.

- `partner-exporter.ts`: adds `project_ids` per partner (which curated project(s) it's listed under). Legacy keeps ISL and EPM partners as two entirely separate lists (`pm_partner_list.php` vs `pm_partner_list_eiac.php`), unlike Permanent Collection/Database which merge the two projects.
- `Database.vue` / `DatabaseResults.vue`: adds an "Include Explore Islamic Art Collections" checkbox (default off, ISL only), mirroring legacy's own checkbox on `database.php`.
- `PartnersEntrance.vue` / `PartnersResults.vue`: split into two sections/sets (Discover Islamic Art / Explore Islamic Art Collections), matching legacy's separate pages.
- Permanent Collection needed no code changes - it already renders the full `items`/`partners` lists with no project filtering, so it automatically merges ISL+EPM once the export includes both, matching legacy's unconditional merge.

Requires re-exporting with both project keys (`ISL EPM`) to have any visible effect on the live site.

## Test plan
- [x] `npm run type-check` clean in `scripts/exporter`
- [x] `npm run build` clean in `scripts/viewer`
- [x] Verified locally against a real `ISL EPM` export: `items.json` 1221 -> 2443 (exact +1222 EPM objects), `partners.json` 48 -> 76 (28 new EPM-only partners, 0 overlap)
- [x] Verified in-browser (temporarily swapped data package): the exact reported missing item ("Ancient South Arabian inscription", Austria) is absent by default and found with the checkbox enabled; Partners correctly splits into "46 found - Discover Islamic Art" vs "28 found - Explore Islamic Art Collections" (Austria's 4 museums, including Kunsthistorisches Museum, appear under the EPM set)

Generated with Claude Code