### PR TITLE
feat(import-tool): use glossary:bulk-resync for append/clean too

### DIFF
--- a/scripts/import-tool/README.md
+++ b/scripts/import-tool/README.md
@@ -86,7 +86,7 @@ destroys `local-mysql-data`/`local-images-data`/`local-app-vendor`.
 | Command | Touches remote server? | What it does |
 |---|---|---|
 | `backup-permissions` | Yes (read + write snapshot) | Snapshots users (incl. MFA), roles, permissions, and API tokens to an encrypted file on the remote host, plus a timestamped local copy. Read-only against application data. |
-| `append` | Yes | Imports legacy data directly into the remote database (over the SSH tunnel), pushes new images via rsync, and resyncs the glossary on the remote host. No wipe. |
+| `append` | Yes | Imports legacy data directly into the remote database (over the SSH tunnel), pushes new images via rsync, and runs `glossary:bulk-resync` on the remote host (synchronous, no queue). No wipe. |
 | `clean` | Yes, **destructive** | `db:wipe` → `migrate` → `db:seed` → `permission:sync` → restore/recreate users → the same pipeline as `append`. Requires `CONFIRM_WIPE=yes-really-wipe-production`. See "Auth restore" below for the users/roles step. |
 | `stage` | No | Imports legacy data + syncs images into local `local-mysql` / `local-images-data`. No auth/seeders — this container is never meant to be logged into. |
 | `local-glossary-sync` | No | Computes glossary term ↔ item/collection/timeline-event links against `local-mysql`, in-container, via `glossary:bulk-resync` (one combined pattern per language, one pass per translation — a couple of minutes, vs. over a day for `glossary:resync`'s one-job-per-spelling approach). Run after `stage`, before `ship`. |

--- a/scripts/import-tool/entrypoint.sh
+++ b/scripts/import-tool/entrypoint.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 # Entrypoint for the inventory-app legacy import tool container.
 #
 # Modes (first arg or $IMPORT_MODE, default "append"):
-#   append              import -> image-sync -> glossary-resync (idempotent,
-#                       safe to re-run any time, adds only what's missing)
+#   append              import -> image-sync -> glossary bulk resync
+#                       (idempotent, safe to re-run any time, adds only
+#                       what's missing)
 #   backup-permissions  snapshot users/MFA/roles/permissions to a fixed OVH
 #                       path + a redundant local copy. No import, no writes
 #                       to application data.
@@ -284,11 +285,11 @@ run_image_sync_local_only() {
 
 run_glossary_resync() {
   if [ "$DRY_RUN" = "1" ]; then
-    log "DRY_RUN=1 — skipping glossary:resync"
+    log "DRY_RUN=1 — skipping glossary:bulk-resync"
     return 0
   fi
-  log "Queuing glossary resync (inventory-queue.service consumes it; not waiting for drain)"
-  ssh_run "php artisan glossary:resync --remove-existing --force"
+  log "Running glossary bulk resync on the remote host (synchronous, no queue involved)"
+  ssh_run "php artisan glossary:bulk-resync"
 }
 
 # ------------------------------------------------------------------------------
@@ -309,7 +310,7 @@ do_import_pipeline() {
   close_tunnel
 
   [ "$rc_a" -eq 0 ] || die "image-sync/rsync branch failed (exit $rc_a)"
-  [ "$rc_b" -eq 0 ] || die "glossary:resync branch failed (exit $rc_b)"
+  [ "$rc_b" -eq 0 ] || die "glossary bulk-resync branch failed (exit $rc_b)"
 }
 
 # True if a snapshot file already exists on the OVH host. Checked with a


### PR DESCRIPTION
## Summary
`run_glossary_resync()` now runs `php artisan glossary:bulk-resync` via SSH instead of `glossary:resync --remove-existing --force`, for `append`/`clean` too (the `stage`/`ship` path already switched in #1428).

This drops the dependency on OVH's `inventory-queue.service` entirely, for every mode: the bulk command runs synchronously (no queue involved), so by the time the SSH call returns, the glossary links are already fully up to date - no more "not waiting for drain" caveat anywhere in the pipeline.

## Test plan
- [x] `bash -n entrypoint.sh` - syntax valid
- [x] `docker compose config` validates
- [x] Builds on #1428's already-tested `glossary:bulk-resync` command (11 passing tests, verified against the full dataset)

Generated with Claude Code