### PR TITLE
docs(importer): point post-import glossary resync at glossary:bulk-resync

### DIFF
--- a/app/Console/Commands/GlossaryBulkResync.php
+++ b/app/Console/Commands/GlossaryBulkResync.php
@@ -19,6 +19,15 @@ class GlossaryBulkResync extends Command
      * the time, because the per-language pattern is checked once per
      * translation instead of once per spelling per translation.
      *
+     * No --remove-existing flag: every translation's link set is fully
+     * recomputed via sync() on each run, so stale links are always dropped,
+     * not just newly-matching ones added. glossary:resync needs the flag as an
+     * opt-in wipe because its per-spelling jobs only reconcile spellings that
+     * still exist; this command doesn't have an equivalent gap to opt out of —
+     * spelling deletion also detaches its links transactionally (see
+     * GlossarySpelling::delete()) and cascades at the DB level, so there is
+     * never a stale link left for a "remove existing" step to find.
+     *
      * Runs synchronously (no queue) — it's already a single pass per
      * translation, there's nothing left to usefully parallelize via jobs.
      *

--- a/scripts/importer/README.md
+++ b/scripts/importer/README.md
@@ -219,7 +219,7 @@ The importer is designed to run as part of a complete database initialization:
 3. **Seed and sync permissions** - Run `php artisan db:seed --class=MinimalDatabaseSeeder --force` and `php artisan permissions:sync`
 4. **Restore auth snapshot** - Restore users after migrations and permission sync (`php artisan auth:restore auth-snapshots/pre-import.json.enc --force`)
 5. **Run the importer** - `import`, then `image-sync`
-6. **Glossary resync** - Re-link glossary spellings to imported translations (required post-import step)
+6. **Glossary resync** - Re-link glossary spellings to imported translations via `php artisan glossary:bulk-resync` (required post-import step)
 7. **Done** - Database is ready with both reference and legacy data
 
 [`import-tool`](../import-tool/README.md) automates steps 1–6 end to end
@@ -238,16 +238,16 @@ After the importer finishes, glossary-to-translation links must be rebuilt. The 
 ```bash
 # From the inventory-app root directory:
 
-# 1. Queue glossary resync jobs (removes stale links first)
-php artisan glossary:resync --remove-existing --force
-
-# 2. Process the queued jobs
-php artisan queue:work --queue=glossary
+php artisan glossary:bulk-resync
 ```
 
-The `glossary:resync` command scans all ItemTranslation, CollectionTranslation, and TimelineEventTranslation records for glossary spelling matches and creates pivot links. This is a **required post-import step** — without it, glossary terms will not be highlighted in translation content.
+`glossary:bulk-resync` scans all ItemTranslation, CollectionTranslation, and TimelineEventTranslation records for glossary spelling matches and creates pivot links, one combined regex pattern per language checked once per translation. This is a **required post-import step** — without it, glossary terms will not be highlighted in translation content. It runs synchronously (no queue, no `queue:work` step needed) and finishes in minutes even on the full dataset.
 
-> **Note:** The queue worker will process jobs until the queue is empty. For large imports, this may take several minutes. You can monitor progress in the Laravel log or run `queue:work --verbose`.
+Every run fully recomputes each translation's spelling links from the current glossary and current translation text, so stale links (spellings that no longer match, or that have since been deleted) are always dropped — there's no separate "remove existing first" flag to remember, unlike the older `glossary:resync` command below.
+
+Add `--dry-run` to report match counts without writing any links, and `--chunk=<n>` to change how many translations are processed per chunk (default 200).
+
+There is also an older, per-spelling command, `glossary:resync --remove-existing --force` followed by `php artisan queue:work --queue=glossary`, which dispatches one queued job per glossary spelling and re-scans every translation of that spelling's language for each one — O(spellings × translations), which takes hours on the full dataset. It still exists for the reactive single-spelling case (editing one glossary entry in the admin panel dispatches just its own job), but `glossary:bulk-resync` is what to run after a bulk import.
 
 ### Running the importer
 


### PR DESCRIPTION
## Summary
- `scripts/importer/README.md` still exclusively documented the old `glossary:resync --remove-existing --force` + `queue:work` pair as the post-import step. Updates it to `glossary:bulk-resync`, which the rest of the pipeline (import-tool's `append`/`clean`/`local-glossary-sync`) already switched to for being ~250x faster on the full dataset.
- Investigated whether `glossary:bulk-resync` needs its own `--remove-existing` flag to match `glossary:resync`. It doesn't: every run fully recomputes each translation's spelling links via `sync()`, so stale/removed links are always dropped automatically (and spelling deletion already detaches its links transactionally + via DB cascade, so there's never a dangling link for a flag to clean up). Documented this explicitly in both the command's docblock and the README so the omission doesn't look like a gap.
- Kept `glossary:resync` documented as the reactive, per-spelling command (still used by the admin-panel single-edit flow), just no longer presented as the post-import step.

## Test plan
- [x] `php artisan test tests/Console/GlossaryBulkResyncTest.php` — 11 passed (docblock-only code change, no behavior change)
- [x] `vendor/bin/phpstan analyse app/Console/Commands/GlossaryBulkResync.php` — no errors

Generated with Claude Code