### PR TITLE
fix(exporter,viewer): islamicart legacy-parity backlog - Epics 1,2,4,5,6,7,9

### DIFF
--- a/scripts/exporter/src/exporters/dynasty-exporter.ts
+++ b/scripts/exporter/src/exporters/dynasty-exporter.ts
@@ -21,6 +21,13 @@ interface DynastyTranslationRow {
   date_description_ad: string | null
 }
 
+interface DynastyImageRow {
+  dynasty_id: string
+  item_id: string
+  path: string
+  display_order: number | null
+}
+
 export class DynastyExporter extends BaseExporter {
   getName(): string {
     return 'Dynasties'
@@ -80,6 +87,25 @@ export class DynastyExporter extends BaseExporter {
       }
     }
 
+    // A representative image per dynasty — the first (by display_order) image
+    // belonging to any item linked to the dynasty via item_dynasty, mirroring
+    // the legacy dynasties micro-site's own selection logic.
+    const dynastyImages = await this.db.query<DynastyImageRow>(
+      `SELECT idyn.dynasty_id, pic.parent_id AS item_id, ii.path, pic.display_order
+       FROM item_dynasty idyn
+       JOIN items pic ON pic.parent_id = idyn.item_id AND pic.type = 'picture'
+       JOIN item_images ii ON ii.item_id = pic.id
+       WHERE idyn.dynasty_id IN (${this.placeholders(dynastyIds.length)})
+       ORDER BY idyn.dynasty_id, pic.display_order`,
+      dynastyIds
+    )
+
+    // dynasty_id -> first image URL (first row per dynasty, already ordered above)
+    const imageMap = new Map<string, string>()
+    for (const row of dynastyImages) {
+      if (!imageMap.has(row.dynasty_id)) imageMap.set(row.dynasty_id, this.imageUrl(row.path))
+    }
+
     // Write one translations/dynasties.{lang}.json per language (null fields omitted)
     const byLang = new Map<string, Record<string, unknown>>()
     for (const [dynastyId, langMap] of translationMap) {
@@ -96,6 +122,7 @@ export class DynastyExporter extends BaseExporter {
       to_ah: d.to_ah,
       from_ad: d.from_ad,
       to_ad: d.to_ad,
+      image: imageMap.get(d.id) ?? null,
     }))
 
     await this.writeJson('dynasties.json', output)

--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -83,6 +83,11 @@ interface ItemGlossaryRow {
   glossary_id: string
 }
 
+interface ItemArtistRow {
+  item_id: string
+  name: string
+}
+
 export class ItemExporter extends BaseExporter {
   getName(): string {
     return 'Items'
@@ -171,8 +176,8 @@ export class ItemExporter extends BaseExporter {
       )
     }
 
-    // ── 3. Dynasty, tag, glossary, and item-item links ──────────────────────
-    const [dynastyLinks, tagLinks, glossaryLinks, itemItemLinks] = await Promise.all([
+    // ── 3. Dynasty, tag, glossary, artist, and item-item links ──────────────
+    const [dynastyLinks, tagLinks, glossaryLinks, artistLinks, itemItemLinks] = await Promise.all([
       this.db.query<ItemDynastyRow>(
         `SELECT item_id, dynasty_id FROM item_dynasty WHERE item_id IN (${itemPh})`,
         itemIds
@@ -194,6 +199,16 @@ export class ItemExporter extends BaseExporter {
          WHERE it3.item_id IN (${itemPh})`,
         itemIds
       ),
+      // Object artists (legacy `artist_` text, parsed into structured Artist
+      // entities by the importer). Language-independent — `artists.name` has
+      // no language column — so this is a top-level item field, not per-translation.
+      this.db.query<ItemArtistRow>(
+        `SELECT ai.item_id, a.name
+         FROM artist_item ai
+         JOIN artists a ON a.id = ai.artist_id
+         WHERE ai.item_id IN (${itemPh})`,
+        itemIds
+      ),
       // Outgoing links only (source_id IN items). The legacy data model stores
       // directed links; fetching both directions and reversing doubles the list.
       // Justification texts are joined per link per language.
@@ -209,9 +224,6 @@ export class ItemExporter extends BaseExporter {
 
     // ── Build maps ───────────────────────────────────────────────────────────
 
-    // item_id -> type (needed to conditionally surface monument-specific extra fields)
-    const itemTypeMap = new Map<string, string>(items.map(i => [i.id, i.type]))
-
     // item_id -> lang_code -> translation fields
     const translationMap = new Map<string, Record<string, Record<string, unknown>>>()
     for (const t of translations) {
@@ -219,15 +231,11 @@ export class ItemExporter extends BaseExporter {
       const code = langCodeMap.get(t.language_id)
       if (!code) continue
 
-      // For monuments, surface history and patrons stored in item_translations.extra.
-      // These fields are distinct from objects' obtention and initial_owner.
-      let history: string | null = null
-      let patrons: string | null = null
-      if (itemTypeMap.get(t.item_id) === 'monument' && t.extra) {
-        const extra = parseJson(t.extra) as Record<string, string> | null
-        history = extra?.history ?? null
-        patrons = extra?.patrons ?? null
-      }
+      // Fields without a dedicated column live in item_translations.extra JSON.
+      // Each key is only ever set by the importer for the item type it applies
+      // to (history/patrons/architects: monuments; workshop/scriber/binding_desc/
+      // catalogue_holding_link/linkcatalogs: objects), so no type gating is needed here.
+      const extra = t.extra ? (parseJson(t.extra) as Record<string, string> | null) : null
 
       translationMap.get(t.item_id)![code] = {
         name: t.name,
@@ -246,8 +254,14 @@ export class ItemExporter extends BaseExporter {
         provenance: t.provenance,
         obtention: t.obtention,
         bibliography: t.bibliography,
-        history,
-        patrons,
+        history: extra?.history ?? null,
+        patrons: extra?.patrons ?? null,
+        architects: extra?.architects ?? null,
+        workshop: extra?.workshop ?? null,
+        scriber: extra?.scriber ?? null,
+        binding_desc: extra?.binding_desc ?? null,
+        catalogue_holding_link: extra?.catalogue_holding_link ?? null,
+        linkcatalogs: extra?.linkcatalogs ?? null,
         author: t.author_name,
         copy_editor: t.copy_editor_name,
         translator: t.translator_name,
@@ -330,6 +344,13 @@ export class ItemExporter extends BaseExporter {
       glossaryMap.get(link.item_id)!.push(link.glossary_id)
     }
 
+    // item_id -> artist_names[]
+    const artistMap = new Map<string, string[]>()
+    for (const link of artistLinks) {
+      if (!artistMap.has(link.item_id)) artistMap.set(link.item_id, [])
+      artistMap.get(link.item_id)!.push(link.name)
+    }
+
     // item_id -> related item entries (outgoing links only; only targets present in this export)
     // source_id -> target_id -> lang_code -> justification text
     const itemIdSet = new Set(itemIds)
@@ -373,6 +394,7 @@ export class ItemExporter extends BaseExporter {
       })),
       tags: tagMap.get(item.id) ?? [],
       glossary_ids: glossaryMap.get(item.id) ?? [],
+      artist_names: artistMap.get(item.id) ?? [],
       languages: Object.keys(translationMap.get(item.id) ?? {}).sort(),
     }))
 

--- a/scripts/viewer/package-lock.json
+++ b/scripts/viewer/package-lock.json
@@ -105,9 +105,9 @@
       "license": "MIT"
     },
     "node_modules/@metanull/islamicart-data": {
-      "version": "1.0.19",
-      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.19/bb4e1989ac8aeab28dea69b85b8f633cdff56311",
-      "integrity": "sha512-vnqVgw6z7G/jRRynQ8zdqREpUSba74NLaf5DlZzQ+0kQkT6wwDkfXUcqp6NAJjDi0H8Lat04KR7/Qv1925Y/4g==",
+      "version": "1.0.21",
+      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.21/01bfbcbae70abc5a67248d87d6718b5fec5ade2a",
+      "integrity": "sha512-dyYjwf1d3+TMP0wcAJX6QErJ8+15N55oEeJzI9jfvzykqaoFkowLi0I4KWAepj482fMbAwE9EI7ZNgbTOi3kHg==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=16.0.0",

--- a/scripts/viewer/src/App.vue
+++ b/scripts/viewer/src/App.vue
@@ -320,4 +320,14 @@ select:focus, input:focus { outline: 1px solid var(--gold-dark); }
   color: var(--muted);
 }
 .back-link:hover { color: var(--nav-active); }
+
+.timeline-link {
+  display: inline-block;
+  margin-bottom: 12px;
+  margin-left: 16px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 13px;
+  color: var(--muted);
+}
+.timeline-link:hover { color: var(--nav-active); }
 </style>

--- a/scripts/viewer/src/views/Database.vue
+++ b/scripts/viewer/src/views/Database.vue
@@ -1,18 +1,28 @@
 <script setup>
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
+import { useInventoryData } from '../composables/useInventoryData.js'
 
 const router = useRouter()
+const { availableLangs } = useInventoryData()
 
+// Matches legacy database.php's 9 field options exactly, in order.
 const FIELD_OPTIONS = [
-  { value: 'keyword',   label: 'Name / Keyword' },
-  { value: 'location',  label: 'Location' },
+  { value: 'keyword',    label: 'Keyword(s)' },
+  { value: 'name',       label: 'Name' },
+  { value: 'location',   label: 'Location' },
   { value: 'provenance', label: 'Provenance' },
-  { value: 'dynasty',   label: 'Period / Dynasty' },
-  { value: 'patron',    label: 'Patron / Initial Owner' },
-  { value: 'artist',    label: 'Architect / Artist / Master' },
-  { value: 'material',  label: 'Material / Technique' },
+  { value: 'dynasty',    label: 'Period / Dynasty' },
+  { value: 'patron',     label: 'Patron / Initial Owner' },
+  { value: 'artist',     label: 'Architect / Artist / Master' },
+  { value: 'material',   label: 'Material / Technique' },
+  { value: 'other',      label: 'Other' },
 ]
+
+// Legacy's fixed century-boundary date dropdowns (database.php:88-124).
+// "From" runs 501-2001 (16 values), "to" runs 600-2000 (15 values) — not symmetric.
+const DATE_FROM_OPTIONS = Array.from({ length: 16 }, (_, i) => 501 + i * 100)
+const DATE_TO_OPTIONS   = Array.from({ length: 15 }, (_, i) => 600 + i * 100)
 
 const keyword1 = ref('')
 const field1   = ref('keyword')
@@ -24,6 +34,7 @@ const cond2    = ref('AND')
 const cond3    = ref('AND')
 const dateFrom = ref('')
 const dateTo   = ref('')
+const searchLanguage = ref('')
 const includeEpm = ref(false)
 
 function search() {
@@ -31,8 +42,11 @@ function search() {
   if (keyword1.value) { q.keyword1 = keyword1.value; q.field1 = field1.value }
   if (keyword2.value) { q.keyword2 = keyword2.value; q.field2 = field2.value; q.cond2 = cond2.value }
   if (keyword3.value) { q.keyword3 = keyword3.value; q.field3 = field3.value; q.cond3 = cond3.value }
+  // Date range and search language are applied once, globally, to the whole
+  // query — unlike field1/field2/field3, which are genuinely per-row.
   if (dateFrom.value) q.date_from = dateFrom.value
   if (dateTo.value)   q.date_to   = dateTo.value
+  if (searchLanguage.value) q.lang = searchLanguage.value
   if (includeEpm.value) q.epm = '1'
   router.push({ path: '/database/results', query: q })
 }
@@ -52,7 +66,7 @@ function showAll() {
       <p class="intro-text">
         Search the collection by one or more keywords. Select the field to search in and
         enter a keyword for each row. Leave a row blank to ignore it.
-        Optionally restrict results to a date range.
+        Optionally restrict results to a date range and/or a search language.
       </p>
 
       <table class="form-table db-form">
@@ -117,13 +131,30 @@ function showAll() {
           <tr>
             <th>Date (from year)</th>
             <td>
-              <input type="number" v-model="dateFrom" placeholder="e.g. 800" style="width:120px" />
+              <select v-model="dateFrom" style="width:120px">
+                <option value="">—</option>
+                <option v-for="y in DATE_FROM_OPTIONS" :key="y" :value="y">{{ y }}</option>
+              </select>
             </td>
           </tr>
           <tr>
             <th>Date (to year)</th>
             <td>
-              <input type="number" v-model="dateTo" placeholder="e.g. 1400" style="width:120px" />
+              <select v-model="dateTo" style="width:120px">
+                <option value="">—</option>
+                <option v-for="y in DATE_TO_OPTIONS" :key="y" :value="y">{{ y }}</option>
+              </select>
+            </td>
+          </tr>
+
+          <!-- Search language -->
+          <tr>
+            <th>Search language</th>
+            <td>
+              <select v-model="searchLanguage" style="width:120px">
+                <option value="">Any</option>
+                <option v-for="lang in availableLangs" :key="lang" :value="lang">{{ lang.toUpperCase() }}</option>
+              </select>
             </td>
           </tr>
 

--- a/scripts/viewer/src/views/DatabaseResults.vue
+++ b/scripts/viewer/src/views/DatabaseResults.vue
@@ -101,7 +101,8 @@ function matchField(item, field, keyword) {
     case 'patron':
       return (tr.patrons ?? tr.initial_owner ?? '').toLowerCase().includes(kw)
     case 'artist':
-      return (tr.initial_owner ?? '').toLowerCase().includes(kw)
+      return (item.artist_names ?? []).join(' ').toLowerCase().includes(kw) ||
+             (tr.architects ?? '').toLowerCase().includes(kw)
     case 'material':
       return (tr.type ?? '').toLowerCase().includes(kw)
     default:

--- a/scripts/viewer/src/views/DatabaseResults.vue
+++ b/scripts/viewer/src/views/DatabaseResults.vue
@@ -9,6 +9,7 @@ const {
   items, dynasties,
   itemLabel, countryLabel, dynastyLabel,
   enItemTranslations, mdInline, itemProjectKey,
+  translationsCache, loadLangTranslations,
 } = useInventoryData()
 
 const PAGE_SIZE = 20
@@ -25,8 +26,11 @@ function parseQuery(q) {
     keyword3: q.keyword3 ?? '',
     field3:   q.field3   ?? 'keyword',
     cond3:    q.cond3    ?? 'AND',
+    // Date range and search language apply once, globally, to the whole
+    // query — unlike field1/field2/field3, which are genuinely per-row.
     dateFrom: q.date_from ?? '',
     dateTo:   q.date_to   ?? '',
+    lang:     q.lang      ?? '',
     includeEpm: q.epm === '1',
     page:     parseInt(q.page ?? '1', 10) || 1,
     // refine row
@@ -44,6 +48,16 @@ watch(() => route.query, q => {
   currentPage.value = search.value.page
 })
 
+watch(() => search.value.lang, lang => {
+  if (lang) loadLangTranslations(lang)
+}, { immediate: true })
+
+// Translations to search against for the currently-selected search language
+// (falls back to English when no language is chosen).
+function translationsFor(lang) {
+  return lang ? (translationsCache.value[lang] ?? {}) : enItemTranslations.value
+}
+
 // ── Refine row ────────────────────────────────────────────────────────
 
 const refineKeyword = ref('')
@@ -52,13 +66,15 @@ const refineCond    = ref('AND')
 const showRefine    = ref(false)
 
 const FIELD_OPTIONS = [
-  { value: 'keyword',   label: 'Name / Keyword' },
-  { value: 'location',  label: 'Location' },
+  { value: 'keyword',    label: 'Keyword(s)' },
+  { value: 'name',       label: 'Name' },
+  { value: 'location',   label: 'Location' },
   { value: 'provenance', label: 'Provenance' },
-  { value: 'dynasty',   label: 'Period / Dynasty' },
-  { value: 'patron',    label: 'Patron / Initial Owner' },
-  { value: 'artist',    label: 'Architect / Artist / Master' },
-  { value: 'material',  label: 'Material / Technique' },
+  { value: 'dynasty',    label: 'Period / Dynasty' },
+  { value: 'patron',     label: 'Patron / Initial Owner' },
+  { value: 'artist',     label: 'Architect / Artist / Master' },
+  { value: 'material',   label: 'Material / Technique' },
+  { value: 'other',      label: 'Other' },
 ]
 
 function fieldLabel(val) {
@@ -80,16 +96,21 @@ function applyRefine() {
 
 // ── Keyword matching ─────────────────────────────────────────────────
 
-function matchField(item, field, keyword) {
+function matchField(item, field, keyword, tr) {
   if (!keyword) return true
   const kw = keyword.toLowerCase().trim()
   if (!kw) return true
-  const tr = enItemTranslations.value[item.id] ?? {}
 
   switch (field) {
     case 'keyword':
+      // General full-text search, legacy's "Keyword(s)" option.
       return (tr.name ?? item.internal_name ?? '').toLowerCase().includes(kw) ||
-             (tr.alternate_name ?? '').toLowerCase().includes(kw)
+             (tr.alternate_name ?? '').toLowerCase().includes(kw) ||
+             (tr.description ?? '').toLowerCase().includes(kw) ||
+             item.tags.some(tag => tag.toLowerCase().includes(kw))
+    case 'name':
+      // Legacy's distinct "Name" option — the name field specifically.
+      return (tr.name ?? item.internal_name ?? '').toLowerCase().includes(kw)
     case 'location':
       return (tr.location ?? '').toLowerCase().includes(kw)
     case 'provenance':
@@ -105,6 +126,14 @@ function matchField(item, field, keyword) {
              (tr.architects ?? '').toLowerCase().includes(kw)
     case 'material':
       return (tr.type ?? '').toLowerCase().includes(kw)
+    case 'other':
+      // Catch-all across descriptive fields not covered by the other 8
+      // categories (see Open Product Question 5 in the parity backlog).
+      return [
+        tr.description, tr.method_for_datation, tr.method_for_provenance,
+        tr.obtention, tr.bibliography, tr.workshop, tr.scriber,
+        tr.binding_desc, tr.history,
+      ].filter(Boolean).join(' ').toLowerCase().includes(kw)
     default:
       return (tr.name ?? item.internal_name ?? '').toLowerCase().includes(kw)
   }
@@ -135,6 +164,9 @@ function itemMatches(item, s) {
 
   if (noSearch) return true
 
+  // Search language applies once, globally, to the whole query.
+  const tr = translationsFor(s.lang)[item.id] ?? {}
+
   // Keyword rows combined
   let result = null
 
@@ -145,16 +177,16 @@ function itemMatches(item, s) {
   }
 
   if (s.keyword1) {
-    result = combine(result, matchField(item, s.field1, s.keyword1), 'AND')
+    result = combine(result, matchField(item, s.field1, s.keyword1, tr), 'AND')
   }
   if (s.keyword2) {
-    result = combine(result, matchField(item, s.field2, s.keyword2), s.cond2)
+    result = combine(result, matchField(item, s.field2, s.keyword2, tr), s.cond2)
   }
   if (s.keyword3) {
-    result = combine(result, matchField(item, s.field3, s.keyword3), s.cond3)
+    result = combine(result, matchField(item, s.field3, s.keyword3, tr), s.cond3)
   }
   if (s.keyword4) {
-    result = combine(result, matchField(item, s.field4, s.keyword4), s.cond4)
+    result = combine(result, matchField(item, s.field4, s.keyword4, tr), s.cond4)
   }
 
   return result === null ? true : result
@@ -199,6 +231,7 @@ const searchSummary = computed(() => {
   if (s.keyword4) parts.push(`${s.cond4} ${fieldLabel(s.field4)}: "${s.keyword4}"`)
   if (s.dateFrom) parts.push(`from ${s.dateFrom}`)
   if (s.dateTo)   parts.push(`to ${s.dateTo}`)
+  if (s.lang)     parts.push(`language: ${s.lang.toUpperCase()}`)
   if (s.includeEpm) parts.push('+ Explore Islamic Art Collections')
   return parts
 })

--- a/scripts/viewer/src/views/DynastyDetail.vue
+++ b/scripts/viewer/src/views/DynastyDetail.vue
@@ -9,6 +9,8 @@ const {
   dynasties, items,
   availableLangs, defaultLang,
   md, mdInline,
+  enCollectionTranslations,
+  artIntroThemes, exhibitions, exhibitionThemes,
 } = useInventoryData()
 
 const dynasty = computed(() => dynasties.value.find(d => d.id === decodeURIComponent(route.params.id)) ?? null)
@@ -32,6 +34,123 @@ onMounted(() => loadDynastyLangTranslations(activeLang.value))
 watch(activeLang, lang => loadDynastyLangTranslations(lang))
 
 const t = computed(() => dynastyTranslationsCache.value[activeLang.value]?.[dynasty.value?.id] ?? {})
+
+// ── Glossary term hyperlinking in dynasty history ───────────────────────
+//
+// Items link only the glossary terms actually used in their own text
+// (item.glossary_ids, resolved at export time via item_translation_spelling).
+// Dynasties have no such precomputed link — there's no dynasty_translation_spelling
+// table — so instead of a dynasty-specific 60-row schema/importer change,
+// scan the full (small, ~600-term) glossary set against this dynasty's own
+// history text client-side. Mirrors ItemDetail.vue's glossify/modal pattern.
+
+const glossaryTranslationsCache = ref({})
+
+async function loadGlossaryTranslations(lang) {
+  if (glossaryTranslationsCache.value[lang]) return
+  try {
+    const m = await import(`@inventory-data/translations/glossary.${lang}.json`)
+    glossaryTranslationsCache.value = { ...glossaryTranslationsCache.value, [lang]: m.default }
+  } catch {
+    glossaryTranslationsCache.value = { ...glossaryTranslationsCache.value, [lang]: {} }
+  }
+}
+
+onMounted(() => loadGlossaryTranslations(activeLang.value))
+watch(activeLang, lang => loadGlossaryTranslations(lang))
+
+// spelling (lowercased) -> { gid, spelling, definition }, longest spelling first
+// so multi-word phrases match before any single word they contain.
+const glossaryEntries = computed(() => {
+  const byGid = glossaryTranslationsCache.value[activeLang.value] ?? {}
+  const entries = []
+  for (const [gid, entry] of Object.entries(byGid)) {
+    if (!entry?.spellings?.length) continue
+    for (const spelling of entry.spellings) {
+      entries.push({ gid, spelling, definition: entry.definition ?? '' })
+    }
+  }
+  return entries.sort((a, b) => b.spelling.length - a.spelling.length)
+})
+
+const glossaryRegex = computed(() => {
+  const entries = glossaryEntries.value
+  if (!entries.length) return null
+  const escaped = entries.map(e => e.spelling.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  return new RegExp(`\\b(${escaped.join('|')})\\b`, 'gi')
+})
+
+const spellingToEntry = computed(() => {
+  const m = new Map()
+  for (const e of glossaryEntries.value) m.set(e.spelling.toLowerCase(), e)
+  return m
+})
+
+function glossify(text) {
+  if (!text || !glossaryRegex.value) return text
+  return text.replace(glossaryRegex.value, match => {
+    const entry = spellingToEntry.value.get(match.toLowerCase())
+    if (!entry) return match
+    return `<span class="gloss-term" data-gid="${entry.gid}">${match}</span>`
+  })
+}
+
+function mdGloss(text) {
+  return md(glossify(text))
+}
+
+const activeGlossaryTerm = ref(null)
+
+function onDetailClick(event) {
+  const el = event.target?.closest?.('.gloss-term')
+  if (!el) return
+  event.preventDefault()
+  const entry = glossaryEntries.value.find(e => e.gid === el.dataset.gid)
+  activeGlossaryTerm.value = {
+    spelling: el.textContent,
+    definition: entry?.definition ?? '',
+  }
+}
+
+function closeGlossaryModal() {
+  activeGlossaryTerm.value = null
+}
+
+// ── Artistic Introduction & Exhibitions cross-links ─────────────────────
+//
+// Both features now exist natively in this viewer — compute overlap
+// client-side from already-exported collections.json + items.json (an
+// item belongs to a collection when it appears in that collection's own
+// `items[]` array).
+
+function collectionHasAnyItem(collection, idSet) {
+  return (collection.items ?? []).some(entry => idSet.has(entry.id))
+}
+
+function collectionLabel(collection) {
+  return enCollectionTranslations.value[collection.id]?.title ?? collection.internal_name ?? collection.id
+}
+
+const relatedItemIds = computed(() => new Set(relatedItems.value.map(i => i.id)))
+
+const relatedArtIntroThemes = computed(() => {
+  const ids = relatedItemIds.value
+  if (!ids.size) return []
+  return artIntroThemes.value
+    .filter(theme => theme.pages.some(page => collectionHasAnyItem(page, ids)))
+    .map(theme => ({ id: theme.id, label: collectionLabel(theme) }))
+})
+
+const relatedExhibitions = computed(() => {
+  const ids = relatedItemIds.value
+  if (!ids.size) return []
+  return exhibitions.value
+    .filter(exh =>
+      collectionHasAnyItem(exh, ids) ||
+      exhibitionThemes(exh.id).some(theme => theme.pages.some(page => collectionHasAnyItem(page, ids)))
+    )
+    .map(exh => ({ id: exh.id, label: collectionLabel(exh) }))
+})
 
 // ── Key facts ──────────────────────────────────────────────────────────
 
@@ -91,8 +210,13 @@ function back() {
       </select>
     </div>
 
-    <div class="detail content-box">
+    <div class="detail content-box" @click="onDetailClick">
       <h1 class="detail-title" v-html="mdInline(t.name ?? dynasty.id)" />
+
+      <!-- Representative image -->
+      <figure v-if="dynasty.image" class="dynasty-image">
+        <img :src="dynasty.image" :alt="t.name ?? ''" loading="lazy" />
+      </figure>
 
       <!-- View objects / monuments -->
       <div v-if="relatedItems.length || timelineLink" class="view-items-row">
@@ -102,6 +226,22 @@ function back() {
         <RouterLink v-if="timelineLink" :to="timelineLink" class="homepage-link">
           View on Timeline →
         </RouterLink>
+      </div>
+
+      <!-- Artistic Introduction / Exhibitions cross-links -->
+      <div v-if="relatedArtIntroThemes.length || relatedExhibitions.length" class="cross-links-row">
+        <RouterLink
+          v-for="theme in relatedArtIntroThemes"
+          :key="'ai-' + theme.id"
+          :to="`/artistic-introduction/${encodeURIComponent(theme.id)}`"
+          class="homepage-link"
+        >{{ theme.label }} (Artistic Introduction) →</RouterLink>
+        <RouterLink
+          v-for="exh in relatedExhibitions"
+          :key="'exh-' + exh.id"
+          :to="`/exhibitions/${encodeURIComponent(exh.id)}`"
+          class="homepage-link"
+        >{{ exh.label }} (Exhibition) →</RouterLink>
       </div>
 
       <!-- Key facts table -->
@@ -117,7 +257,7 @@ function back() {
       <!-- History -->
       <section v-if="t.history" class="content-section">
         <h2 class="content-section-heading">History</h2>
-        <div v-html="md(t.history)" class="prose" />
+        <div v-html="mdGloss(t.history)" class="prose" />
       </section>
 
       <!-- Related items -->
@@ -145,6 +285,16 @@ function back() {
         <RouterLink v-if="relatedItems.length > 12" :to="relatedItemsLink()" class="see-all-link">
           See all {{ relatedItems.length }} objects &amp; monuments →
         </RouterLink>
+      </div>
+    </div>
+
+    <!-- Glossary term modal, mirrors ItemDetail.vue's -->
+    <div v-if="activeGlossaryTerm" class="gloss-modal-overlay" @click.self="closeGlossaryModal">
+      <div class="gloss-modal">
+        <button class="gloss-modal-close" @click="closeGlossaryModal" aria-label="Close">✕</button>
+        <h2 class="gloss-modal-heading">Glossary &amp; Spelling</h2>
+        <h3 class="gloss-modal-term">{{ activeGlossaryTerm.spelling }}</h3>
+        <p class="gloss-modal-definition">{{ activeGlossaryTerm.definition }}</p>
       </div>
     </div>
   </div>
@@ -175,16 +325,97 @@ function back() {
   font-family: 'Roboto', sans-serif;
 }
 
+.dynasty-image { margin-bottom: 20px; }
+.dynasty-image img {
+  width: 100%;
+  max-width: 360px;
+  height: auto;
+  border: 1px solid var(--border);
+  display: block;
+}
+
 .view-items-row {
   display: flex;
   align-items: center;
   gap: 16px;
   margin-bottom: 20px;
 }
+.cross-links-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 16px;
+  margin-bottom: 20px;
+}
 .homepage-link {
   font-size: 13px;
   font-weight: 500;
   color: var(--nav-active);
+  font-family: 'Roboto', sans-serif;
+}
+
+/* Glossary term links, injected as raw HTML into v-html content */
+.detail :deep(.gloss-term) {
+  color: var(--heading);
+  text-decoration: underline dotted;
+  text-decoration-color: var(--gold-dark);
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.detail :deep(.gloss-term:hover) {
+  color: var(--gold-dark);
+  text-decoration-style: solid;
+}
+
+/* Glossary modal */
+.gloss-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 40px 16px;
+  z-index: 1000;
+}
+.gloss-modal {
+  position: relative;
+  background: var(--section-bg, #fff);
+  border-top: 4px solid var(--gold-dark);
+  max-width: 480px;
+  width: 100%;
+  padding: 28px 24px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
+}
+.gloss-modal-close {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  background: none;
+  border: none;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--muted);
+}
+.gloss-modal-heading {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-bottom: 12px;
+  font-family: 'Roboto', sans-serif;
+}
+.gloss-modal-term {
+  font-size: 20px;
+  color: var(--heading);
+  margin-bottom: 10px;
+  font-family: 'Roboto', sans-serif;
+}
+.gloss-modal-definition {
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--text);
   font-family: 'Roboto', sans-serif;
 }
 

--- a/scripts/viewer/src/views/ItemDetail.vue
+++ b/scripts/viewer/src/views/ItemDetail.vue
@@ -230,18 +230,24 @@ const keyFacts = computed(() => {
     if (tr.alternate_name)  facts.push({ label: 'Also known as',    value: tr.alternate_name })
     if (tr.location)        facts.push({ label: 'Location',         value: tr.location })
     if (tr.dates)           facts.push({ label: 'Date of Monument', value: tr.dates })
+    if (tr.architects)      facts.push({ label: 'Architects',       value: tr.architects })
     if (dynastyNames)       facts.push({ label: 'Period / Dynasty', value: dynastyNames })
     const patronValue = tr.patrons ?? tr.initial_owner
     if (patronValue)        facts.push({ label: 'Patron(s)',        value: patronValue })
   } else {
+    if (tr.alternate_name)      facts.push({ label: 'Also known as',              value: tr.alternate_name })
     if (tr.location)            facts.push({ label: 'Location',                  value: tr.location })
     if (tr.holder)              facts.push({ label: 'Holding Museum',             value: tr.holder })
     if (tr.dates)               facts.push({ label: 'Date of Object',             value: tr.dates })
+    if (it.artist_names?.length) facts.push({ label: 'Artist',                    value: it.artist_names.join(', ') })
+    if (tr.scriber)             facts.push({ label: 'Scribe',                     value: tr.scriber })
     if (it.owner_reference)     facts.push({ label: 'Museum Inventory Number',    value: it.owner_reference })
     if (tr.type)                facts.push({ label: 'Material(s) / Technique(s)', value: tr.type })
     if (tr.dimensions)          facts.push({ label: 'Dimensions',                 value: tr.dimensions })
     if (dynastyNames)           facts.push({ label: 'Period / Dynasty',           value: dynastyNames })
     if (tr.provenance)          facts.push({ label: 'Provenance',                 value: tr.provenance })
+    if (tr.workshop)            facts.push({ label: 'Workshop',                   value: tr.workshop })
+    if (tr.binding_desc)        facts.push({ label: 'Binding',                    value: tr.binding_desc })
     if (tr.owner)               facts.push({ label: 'Owner',                      value: tr.owner })
     if (tr.initial_owner)       facts.push({ label: 'Initial Owner',              value: tr.initial_owner })
     if (tr.place_of_production) facts.push({ label: 'Place of Production',        value: tr.place_of_production })
@@ -270,6 +276,7 @@ const contentSections = computed(() => {
     if (tr.obtention)             sections.push({ heading: 'How Object was obtained',              value: tr.obtention })
     if (tr.method_for_provenance) sections.push({ heading: 'How provenance was established',       value: tr.method_for_provenance })
     if (tr.bibliography)          sections.push({ heading: 'Selected bibliography',                value: tr.bibliography })
+    if (tr.catalogue_holding_link) sections.push({ heading: 'Catalogue', value: `[${tr.catalogue_holding_link}](${tr.catalogue_holding_link})` })
   }
 
   return sections

--- a/scripts/viewer/src/views/ItemDetail.vue
+++ b/scripts/viewer/src/views/ItemDetail.vue
@@ -282,6 +282,16 @@ const contentSections = computed(() => {
   return sections
 })
 
+// ── Monument "Special Features" — sub-details already imported as child
+// items (type='detail', parent_id = this monument), just never surfaced ──
+
+const monumentDetails = computed(() => {
+  if (!item.value) return []
+  return items.value
+    .filter(i => i.parent_id === item.value.id && i.type === 'detail')
+    .sort((a, b) => (a.display_order ?? 9999) - (b.display_order ?? 9999))
+})
+
 // ── Credits ───────────────────────────────────────────────────────────
 
 const credits = computed(() => {
@@ -293,6 +303,34 @@ const credits = computed(() => {
   if (tr.translator)               c.push({ label: 'Translation by',             value: tr.translator })
   if (tr.translation_copy_editor)  c.push({ label: 'Translation copyedited by',  value: tr.translation_copy_editor })
   return c
+})
+
+// ── Citation — mirrors legacy's auto-generated citation blurb + permalink ─
+
+const citation = computed(() => {
+  if (!item.value) return ''
+  const tr = t(item.value)
+  const name = labelText(item.value)
+  if (!name) return ''
+  const year = new Date().getFullYear()
+  const permalink = `${window.location.origin}${window.location.pathname}#/item/${encodeURIComponent(item.value.id)}`
+  const author = tr.author ? `${tr.author} ` : ''
+  return `${author}"${name}" in Discover Islamic Art, ${year}. ${permalink}`
+})
+
+// ── "View on Timeline" — country + date-range proximity link. Legacy never
+// stores a direct item↔HCR-event link either; it computes this live by
+// country/date overlap, same as this link's target route already does. ──
+
+const timelineLink = computed(() => {
+  if (!item.value?.country_id) return null
+  const begin = item.value.start_date
+  const end = item.value.end_date
+  if (begin == null && end == null) return null
+  const query = { country: item.value.country_id }
+  if (begin != null) query.begin = String(begin)
+  if (end != null) query.end = String(end)
+  return { path: '/timeline/results', query }
 })
 
 // ── Navigation ─────────────────────────────────────────────────────────
@@ -315,6 +353,7 @@ function back() {
   <div v-else class="detail-wrap">
     <!-- Breadcrumb / back -->
     <a class="back-link" href="#" @click.prevent="back">← Back to results</a>
+    <router-link v-if="timelineLink" :to="timelineLink" class="timeline-link">View on Timeline →</router-link>
 
     <!-- Language selector for item content — only languages this item actually has -->
     <div v-if="itemLangs.length > 1" class="lang-selector">
@@ -362,6 +401,23 @@ function back() {
         <div v-html="mdGloss(section.value)" class="prose" :dir="contentDir" />
       </section>
 
+      <!-- Special Features (monument sub-details) -->
+      <div v-if="monumentDetails.length" class="special-features">
+        <h2 class="sub-section-title">Special Features</h2>
+        <div v-for="d in monumentDetails" :key="d.id" class="special-feature" :dir="contentDir">
+          <h3 class="special-feature-name" v-html="mdInline(t(d).name ?? d.internal_name ?? d.id)" />
+          <p v-if="t(d).location" class="special-feature-meta">{{ t(d).location }}</p>
+          <p v-if="t(d).dates" class="special-feature-meta">{{ t(d).dates }}</p>
+          <p v-if="d.artist_names?.length" class="special-feature-meta">{{ d.artist_names.join(', ') }}</p>
+          <div v-if="t(d).description" v-html="mdGloss(t(d).description)" class="prose" />
+          <div v-if="d.images?.length" class="images">
+            <figure v-for="(img, i) in d.images" :key="i">
+              <img :src="img.url" :alt="img.captions?.[activeLang] ?? ''" loading="lazy" class="detail-img" />
+            </figure>
+          </div>
+        </div>
+      </div>
+
       <!-- Credits -->
       <div v-if="credits.length" class="credits">
         <h2 class="credits-heading">Credits</h2>
@@ -374,6 +430,12 @@ function back() {
         <p v-if="item.mwnf_reference" class="mwnf-ref">
           MWNF Working Number: <strong>{{ item.mwnf_reference }}</strong>
         </p>
+      </div>
+
+      <!-- Citation -->
+      <div v-if="citation" class="citation">
+        <h2 class="credits-heading">Citation</h2>
+        <p class="citation-text">{{ citation }}</p>
       </div>
 
       <!-- Dynasty cards -->
@@ -571,6 +633,16 @@ function back() {
 .credits-list dt { font-weight: 500; color: var(--muted); }
 .credits-list dd { color: var(--text); }
 .mwnf-ref { font-size: 11px; color: var(--muted); font-family: 'Roboto', sans-serif; }
+
+/* Citation */
+.citation { margin-top: 16px; }
+.citation-text { font-size: 12px; line-height: 1.6; color: var(--muted); font-family: 'Roboto', sans-serif; }
+
+/* Special Features (monument sub-details) */
+.special-features { margin-top: 20px; border-top: 1px solid var(--border); padding-top: 16px; }
+.special-feature { margin-bottom: 16px; }
+.special-feature-name { font-size: 15px; font-weight: 500; color: var(--heading); margin-bottom: 4px; font-family: 'Roboto', sans-serif; }
+.special-feature-meta { font-size: 12px; color: var(--muted); margin: 0 0 4px; font-family: 'Roboto', sans-serif; }
 
 /* Dynasty cards */
 .sub-section-title {

--- a/scripts/viewer/src/views/PartnersEntrance.vue
+++ b/scripts/viewer/src/views/PartnersEntrance.vue
@@ -29,7 +29,7 @@ function browse(type, project) {
             </td>
           </tr>
           <tr>
-            <th><label>Partner Institutions</label></th>
+            <th><label>Other Partners</label></th>
             <td>
               <button class="btn" @click="browse('institution', 'ISL')">Browse Institutions →</button>
             </td>
@@ -53,7 +53,7 @@ function browse(type, project) {
             </td>
           </tr>
           <tr>
-            <th><label>Partner Institutions</label></th>
+            <th><label>Other Partners</label></th>
             <td>
               <button class="btn" @click="browse('institution', 'EPM')">Browse Institutions →</button>
             </td>

--- a/scripts/viewer/src/views/PcEntrance.vue
+++ b/scripts/viewer/src/views/PcEntrance.vue
@@ -46,6 +46,7 @@ const selectedDynasty = ref('')
 const selectedPartner = ref('')
 const beginDate = ref('')
 const endDate = ref('')
+const includeEpm = ref(false)
 
 function search() {
   const q = {}
@@ -54,6 +55,7 @@ function search() {
   if (filterType.value === 'partner' && selectedPartner.value)   q.partner = selectedPartner.value
   if (filterType.value === 'begin'   && beginDate.value)         q.begin   = beginDate.value
   if (filterType.value === 'end'     && endDate.value)           q.end     = endDate.value
+  if (includeEpm.value) q.epm = '1'
   router.push({ path: '/permanent-collection/results', query: q })
 }
 </script>
@@ -139,6 +141,17 @@ function search() {
             </td>
           </tr>
 
+          <!-- Collection scope -->
+          <tr>
+            <th></th>
+            <td>
+              <label class="epm-toggle">
+                <input type="checkbox" v-model="includeEpm" />
+                Include Explore Islamic Art Collections
+              </label>
+            </td>
+          </tr>
+
           <!-- Submit -->
           <tr>
             <th></th>
@@ -183,5 +196,15 @@ function search() {
 select:disabled, input:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.epm-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-family: 'Roboto', sans-serif;
+  color: var(--text);
+  cursor: pointer;
 }
 </style>

--- a/scripts/viewer/src/views/PcList.vue
+++ b/scripts/viewer/src/views/PcList.vue
@@ -8,7 +8,7 @@ const router = useRouter()
 const {
   items, countries, partners, dynasties,
   countryLabel, dynastyLabel, partnerLabel,
-  itemLabel, enItemTranslations, mdInline,
+  itemLabel, enItemTranslations, mdInline, itemProjectKey,
 } = useInventoryData()
 
 const PAGE_SIZE = 20
@@ -20,10 +20,11 @@ const filterDynasty = ref(route.query.dynasty ?? '')
 const filterPartner = ref(route.query.partner ?? '')
 const filterBegin   = ref(route.query.begin   ?? '')
 const filterEnd     = ref(route.query.end     ?? '')
+const includeEpm    = ref(route.query.epm === '1')
 const currentPage   = ref(parseInt(route.query.page ?? '1', 10) || 1)
 
 watch(
-  [filterCountry, filterDynasty, filterPartner, filterBegin, filterEnd],
+  [filterCountry, filterDynasty, filterPartner, filterBegin, filterEnd, includeEpm],
   () => { currentPage.value = 1 }
 )
 
@@ -35,6 +36,7 @@ watch(
     filterPartner.value = q.partner ?? ''
     filterBegin.value   = q.begin   ?? ''
     filterEnd.value     = q.end     ?? ''
+    includeEpm.value    = q.epm === '1'
     currentPage.value   = parseInt(q.page ?? '1', 10) || 1
   }
 )
@@ -46,6 +48,7 @@ function applyFilters() {
   if (filterPartner.value) q.partner = filterPartner.value
   if (filterBegin.value)   q.begin   = filterBegin.value
   if (filterEnd.value)     q.end     = filterEnd.value
+  if (includeEpm.value)    q.epm     = '1'
   router.push({ path: '/permanent-collection/results', query: q })
 }
 
@@ -55,6 +58,7 @@ function resetFilters() {
   filterPartner.value = ''
   filterBegin.value   = ''
   filterEnd.value     = ''
+  includeEpm.value    = false
   applyFilters()
 }
 
@@ -89,6 +93,13 @@ const availablePartners = computed(() => {
 const filteredItems = computed(() => {
   let result = items.value
 
+  // 'ISL' (Discover Islamic Art) is always browsed; other projects (e.g. 'EPM',
+  // Explore Islamic Art Collections) are opt-in, matching the Database feature.
+  result = result.filter(item => {
+    const key = itemProjectKey(item)
+    return !key || key === 'ISL' || includeEpm.value
+  })
+
   if (filterCountry.value) {
     result = result.filter(item => item.country_id === filterCountry.value)
   }
@@ -119,7 +130,23 @@ const filteredItems = computed(() => {
     }
   }
 
-  return result
+  // Legacy orders results chronologically by start date (undated items last).
+  return [...result].sort((a, b) => {
+    const ad = a.start_date ?? Infinity
+    const bd = b.start_date ?? Infinity
+    return ad - bd
+  })
+})
+
+// "[N objects, M monuments]" split, matching legacy's result-count phrasing.
+const resultCounts = computed(() => {
+  let objects = 0
+  let monuments = 0
+  for (const item of filteredItems.value) {
+    if (item.type === 'monument') monuments++
+    else objects++
+  }
+  return { objects, monuments }
 })
 
 const totalPages = computed(() => Math.max(1, Math.ceil(filteredItems.value.length / PAGE_SIZE)))
@@ -194,6 +221,13 @@ const activeFilterLabel = computed(() => {
         <input type="number" v-model="filterEnd" placeholder="e.g. 1400" style="width:100px" />
       </div>
 
+      <div class="filter-row">
+        <label class="epm-toggle">
+          <input type="checkbox" v-model="includeEpm" />
+          Include Explore Islamic Art Collections
+        </label>
+      </div>
+
       <div class="filter-actions">
         <button class="btn" @click="applyFilters">Apply</button>
         <button class="btn btn-secondary" style="margin-left:8px" @click="resetFilters">Reset</button>
@@ -203,7 +237,8 @@ const activeFilterLabel = computed(() => {
     <!-- Results -->
     <div class="content-box">
       <p class="result-count">
-        {{ filteredItems.length }} item{{ filteredItems.length !== 1 ? 's' : '' }} found
+        {{ resultCounts.objects }} object{{ resultCounts.objects !== 1 ? 's' : '' }},
+        {{ resultCounts.monuments }} monument{{ resultCounts.monuments !== 1 ? 's' : '' }}
       </p>
 
       <ul v-if="pagedItems.length" class="item-list">
@@ -222,6 +257,8 @@ const activeFilterLabel = computed(() => {
             <div class="item-list-meta">
               <span v-if="item.country_id">{{ countryLabel(item.country_id) }}</span>
               <span v-if="enItemTranslations[item.id]?.dates">{{ enItemTranslations[item.id].dates }}</span>
+              <span v-if="item.dynasty_ids.length">{{ item.dynasty_ids.map(dynastyLabel).join(', ') }}</span>
+              <span v-if="item.partner_id && partners.some(p => p.id === item.partner_id)">{{ partnerLabel(item.partner_id) }}</span>
               <span v-if="item.type" class="item-type-badge">{{ item.type }}</span>
             </div>
           </div>
@@ -258,6 +295,7 @@ const activeFilterLabel = computed(() => {
 .filter-label { font-family: 'Roboto', sans-serif; font-size: 12px; font-weight: bold; color: var(--muted); }
 .filter-row { display: flex; align-items: center; gap: 6px; font-family: 'Roboto', sans-serif; font-size: 12px; color: var(--muted); }
 .filter-actions { margin-left: auto; }
+.epm-toggle { display: flex; align-items: center; gap: 8px; cursor: pointer; }
 
 .result-count {
   font-family: 'Roboto', sans-serif;

--- a/scripts/viewer/src/views/TimelineEntrance.vue
+++ b/scripts/viewer/src/views/TimelineEntrance.vue
@@ -48,7 +48,7 @@ function search() {
   }
 
   const q = {}
-  if (selectedCountry.value) q.country = selectedCountry.value
+  if (selectedCountry.value && selectedCountry.value !== 'all') q.country = selectedCountry.value
   if (selectedBegin.value) q.begin = selectedBegin.value
   if (selectedEnd.value) q.end = selectedEnd.value
   router.push({ path: '/timeline/results', query: q })
@@ -71,7 +71,8 @@ function search() {
             <th><label for="tl-country">Country</label></th>
             <td>
               <select id="tl-country" v-model="selectedCountry" style="width:280px">
-                <option value="">— All Countries —</option>
+                <option value="" disabled>Select a Country</option>
+                <option value="all">— All Countries —</option>
                 <option v-for="c in availableCountries" :key="c.id" :value="c.id">{{ c.name }}</option>
               </select>
             </td>


### PR DESCRIPTION
## Summary

Implements 7 epics from a full legacy-vs-viewer parity audit of the islamicart port (https://islamicart.museumwnf.org vs the new Vue3 viewer), one commit per epic:

- **Epic 1** - export item fields the importer already captures but the exporter dropped (Artist, Architects, Workshop, Scribe, Binding, Catalogue Link), and fix "Also known as" being shown only for monuments.
- **Epic 2** - render item-detail features whose data was already fully imported but never surfaced: monument "Special Features" sub-details, an auto-generated Citation blurb + permalink, and a "View on Timeline" proximity link.
- **Epic 4** - restore Database search form parity: split the merged Name/Keyword field option and restore "Other", replace freeform date inputs with legacy's century-boundary dropdowns, add a searchlanguage filter.
- **Epic 5** - Permanent Collection results: add dynasty/holding-museum info to result cards, chronological sort, object/monument count split, and - the one new bug this surfaced - an "Include Explore Islamic Art Collections" opt-in gate (PcList.vue had none at all, so it silently mixed in EPM items, and so did Timeline's "view items" link that forwards into it).
- **Epic 6** - rename "Partner Institutions" to "Other Partners" to match legacy exactly. (Story 6.2, a Partner Contact "fax" field, turned out to need an importer change - documented and deferred, not implemented here.)
- **Epic 7** - dynasty representative image, cross-links from a dynasty to related Artistic Introduction themes/Exhibitions (computed client-side, since both features now exist natively in this viewer), and glossary-term linking in dynasty history text.
- **Epic 9** - add the "Select a Country" placeholder to the Timeline entrance dropdown.

Backlog source: tmp/islamicart-parity-audit-2026-07-06.md (gitignored, local only - trimmed down to what's still outstanding: Epic 3 research spikes, Epic 8 importer bug, and the deferred Story 6.2).

## Test plan

- [x] scripts/exporter: npm run type-check and npm run lint:check clean after every exporter change.
- [x] scripts/viewer: npm run build clean after every change.
- [x] Manually verified each epic in a local preview against the live data package (@metanull/islamicart-data@1.0.21, bumped from a stale 1.0.19): Database search (field split, date dropdowns, per-language matching - confirmed a French-language search for "bowl" returns 0 while English returns 57), Permanent Collection EPM toggle (849->2071 objects when included), Dynasty cross-links and glossary modal (found real Artistic Introduction/Exhibition overlaps and a glossary term on a live dynasty), Timeline country placeholder (forces a choice, "All Countries" now has its own sentinel value so downstream query-building is unaffected).
- [ ] New exporter fields (artist_names, workshop/scriber/binding_desc/catalogue_holding_link/architects on items, image on dynasties) need a fresh partner-exporter/item-exporter/dynasty-exporter run + package republish before they're visible in production - verified only against currently-shipped data for regressions, not the new fields' actual output (no live DB access in this environment).

Generated with Claude Code