### PR TITLE
fix(importer): keep first occurrence when an artintro page image repeats

### DIFF
--- a/scripts/importer/src/importers/phase-01/mwnf3-exhibition-item-importer.ts
+++ b/scripts/importer/src/importers/phase-01/mwnf3-exhibition-item-importer.ts
@@ -388,6 +388,16 @@ export class Mwnf3ExhibitionItemImporter extends BaseImporter {
     // Pre-load EAV placement metadata for artintro page images
     const artintroImageEavMap = await this.loadArtintroImageEav();
 
+    // `collection_item` has one row per (collection_id, item_id) — when the
+    // same item appears more than once on a page (distinct `n` grid slots,
+    // e.g. several photos of the same monument), only one row can survive.
+    // Legacy always treats the *first* occurrence (n=1) as the default/
+    // featured item shown on page load, and this query is already ordered by
+    // `n` ascending, so keep the first occurrence per (collection, item) and
+    // skip the rest — otherwise writeCollectionItem's "ON DUPLICATE KEY
+    // UPDATE" lets whichever occurrence is processed *last* silently win.
+    const seenCollectionItems = new Set<string>();
+
     for (const img of images) {
       try {
         const collectionBackwardCompat = `${MWNF3_SCHEMA}:artintro_pages:${img.page_id}`;
@@ -433,6 +443,14 @@ export class Mwnf3ExhibitionItemImporter extends BaseImporter {
           this.showSkipped();
           continue;
         }
+
+        const dedupeKey = `${collectionId}:${itemId}`;
+        if (seenCollectionItems.has(dedupeKey)) {
+          result.skipped++;
+          this.showSkipped();
+          continue;
+        }
+        seenCollectionItems.add(dedupeKey);
 
         if (this.isDryRun || this.isSampleOnlyMode) {
           result.imported++;

--- a/scripts/importer/tests/unit/mwnf3-exhibition-item-importer.test.ts
+++ b/scripts/importer/tests/unit/mwnf3-exhibition-item-importer.test.ts
@@ -552,3 +552,53 @@ describe('Mwnf3ExhibitionItemImporter — story #1223: artintro page image EAV f
     expect(extra.picture).toBe('images/artintro.jpg');
   });
 });
+
+// ===========================================================================
+// Tests: artintro page image dedup — same item repeated across `n` slots
+// ===========================================================================
+
+describe('Mwnf3ExhibitionItemImporter — artintro page image dedup (first occurrence wins)', () => {
+  let tracker: UnifiedTracker;
+  let writeCollectionItemMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tracker = new UnifiedTracker();
+    tracker.set(ARTINTRO_PAGE_COLLECTION_BC, 'artintro-page-uuid', 'collection');
+    tracker.set(ITEM_BC, 'item-uuid', 'item');
+    writeCollectionItemMock = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it('keeps the first (lowest n) occurrence when the same item repeats on a page, instead of the last', async () => {
+    // Same page, same resolved item, three distinct grid slots — mirrors the
+    // legacy Umayyad Mosque case (n=1, n=5, n=9 on one page). The query is
+    // already ordered by `n` ascending, matching production behavior.
+    const firstOccurrence = { ...ARTINTRO_IMAGE_ROW, image_id: 42, n: 1, picture: 'images/first.jpg' };
+    const secondOccurrence = { ...ARTINTRO_IMAGE_ROW, image_id: 43, n: 5, picture: 'images/second.jpg' };
+    const thirdOccurrence = { ...ARTINTRO_IMAGE_ROW, image_id: 44, n: 9, picture: 'images/third.jpg' };
+
+    const ctx = makeContext(
+      makeArtintroImageQueryMock([firstOccurrence, secondOccurrence, thirdOccurrence], []),
+      tracker,
+      writeCollectionItemMock
+    );
+
+    const importer = new Mwnf3ExhibitionItemImporter(ctx);
+    const result = await importer.import();
+
+    // Only the first occurrence should ever reach writeCollectionItem — not
+    // three separate INSERT...ON DUPLICATE KEY UPDATE calls that would let
+    // the last one silently overwrite it.
+    expect(writeCollectionItemMock).toHaveBeenCalledTimes(1);
+    const call = writeCollectionItemMock.mock.calls[0][0] as {
+      display_order: number | null;
+      extra: Record<string, unknown>;
+    };
+    expect(call.display_order).toBe(1);
+    expect(call.extra.n).toBe(1);
+    expect(call.extra.picture).toBe('images/first.jpg');
+
+    // The two skipped duplicates are still accounted for in the import stats.
+    expect(result.skipped).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Epic 8 of the islamicart legacy-parity backlog (`tmp/islamicart-parity-audit-2026-07-06.md`, local/gitignored).

- `mwnf3-exhibition-item-importer.ts`'s `importArtintroPageImages` writes one `collection_item` pivot row per legacy image row, upserting on `(collection_id, item_id)`. When the same item appears more than once on an Artistic Introduction page (distinct `n` grid slots, e.g. several photos of the same monument), the last-processed occurrence silently overwrote the earlier ones - but legacy always treats the *first* occurrence (`n=1`) as the default/featured item shown on page load.
- Confirmed concretely before this fix: the Umayyad Mosque item on theme 1/page 1 (the legacy default) exported with `display_order=9` instead of 1; item `M;ISL;es;1;29` on page 9 exported collapsed to `display_order=3` instead of 1.
- Fix: track seen `(collection_id, item_id)` pairs (query is already ordered by `n` ascending) and skip subsequent occurrences instead of re-writing over the first one.

## Test plan

- [x] Added a regression test reproducing the Umayyad-Mosque-shaped case (same item at n=1, n=5, n=9 on one page) - asserts `writeCollectionItem` is called exactly once, with the first occurrence's `display_order` and picture, and the two duplicates counted as skipped.
- [x] `npm run test` (scripts/importer): 384/384 passing across 56 files.
- [x] `npm run type-check` and `npm run lint:check` (scripts/importer): clean.

Generated with Claude Code