### PR TITLE
feat(exporter,viewer): item media (video) and THG gallery cross-links

### DIFF
--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -88,6 +88,21 @@ interface ItemArtistRow {
   name: string
 }
 
+interface ItemMediaRow {
+  item_id: string
+  language_id: string | null
+  type: string
+  title: string
+  description: string | null
+  url: string
+}
+
+interface ItemThgGalleryRow {
+  item_id: string
+  name: string | null
+  internal_name: string
+}
+
 export class ItemExporter extends BaseExporter {
   getName(): string {
     return 'Items'
@@ -176,8 +191,8 @@ export class ItemExporter extends BaseExporter {
       )
     }
 
-    // ── 3. Dynasty, tag, glossary, artist, and item-item links ──────────────
-    const [dynastyLinks, tagLinks, glossaryLinks, artistLinks, itemItemLinks] = await Promise.all([
+    // ── 3. Dynasty, tag, glossary, artist, THG gallery, media, and item-item links ──
+    const [dynastyLinks, tagLinks, glossaryLinks, artistLinks, thgGalleryLinks, mediaRows, itemItemLinks] = await Promise.all([
       this.db.query<ItemDynastyRow>(
         `SELECT item_id, dynasty_id FROM item_dynasty WHERE item_id IN (${itemPh})`,
         itemIds
@@ -207,6 +222,30 @@ export class ItemExporter extends BaseExporter {
          FROM artist_item ai
          JOIN artists a ON a.id = ai.artist_id
          WHERE ai.item_id IN (${itemPh})`,
+        itemIds
+      ),
+      // THG (Thematic Gallery) cross-references — a separate legacy project's
+      // galleries that also feature this item, already linked via
+      // ThgGalleryMwnf3{Object,Monument}Importer (phase-10) attaching the item
+      // to the gallery's own `collection_item` row. THG's own collection tree
+      // is intentionally never exported (out of scope, separate site) — this
+      // is a lightweight, scoped-by-prefix lookup, not a full THG export.
+      this.db.query<ItemThgGalleryRow>(
+        `SELECT ci.item_id, ct.title AS name, c.internal_name
+         FROM collection_item ci
+         JOIN collections c ON c.id = ci.collection_id
+         LEFT JOIN collection_translations ct ON ct.collection_id = c.id AND ct.language_id = 'eng'
+         WHERE ci.item_id IN (${itemPh})
+           AND c.backward_compatibility LIKE 'mwnf3\\_thematic\\_gallery:thg\\_gallery:%'`,
+        itemIds
+      ),
+      // Audio/video media attached to items (item_media table) — legacy
+      // objects_video/monuments_video, already imported via ItemMediaImporter.
+      this.db.query<ItemMediaRow>(
+        `SELECT item_id, language_id, type, title, description, url
+         FROM item_media
+         WHERE item_id IN (${itemPh})
+         ORDER BY item_id, display_order`,
         itemIds
       ),
       // Outgoing links only (source_id IN items). The legacy data model stores
@@ -351,6 +390,26 @@ export class ItemExporter extends BaseExporter {
       artistMap.get(link.item_id)!.push(link.name)
     }
 
+    // item_id -> thg_galleries[]
+    const thgGalleryMap = new Map<string, { name: string }[]>()
+    for (const row of thgGalleryLinks) {
+      if (!thgGalleryMap.has(row.item_id)) thgGalleryMap.set(row.item_id, [])
+      thgGalleryMap.get(row.item_id)!.push({ name: row.name ?? row.internal_name })
+    }
+
+    // item_id -> media[] (audio/video)
+    const mediaMap = new Map<string, MediaEntry[]>()
+    for (const m of mediaRows) {
+      if (!mediaMap.has(m.item_id)) mediaMap.set(m.item_id, [])
+      mediaMap.get(m.item_id)!.push({
+        type: m.type,
+        title: m.title,
+        description: m.description,
+        url: m.url,
+        language: m.language_id ? (langCodeMap.get(m.language_id) ?? null) : null,
+      })
+    }
+
     // item_id -> related item entries (outgoing links only; only targets present in this export)
     // source_id -> target_id -> lang_code -> justification text
     const itemIdSet = new Set(itemIds)
@@ -395,6 +454,8 @@ export class ItemExporter extends BaseExporter {
       tags: tagMap.get(item.id) ?? [],
       glossary_ids: glossaryMap.get(item.id) ?? [],
       artist_names: artistMap.get(item.id) ?? [],
+      thg_galleries: thgGalleryMap.get(item.id) ?? [],
+      media: mediaMap.get(item.id) ?? [],
       languages: Object.keys(translationMap.get(item.id) ?? {}).sort(),
     }))
 
@@ -411,6 +472,14 @@ interface ImageEntry {
   captions: Record<string, string>
   photographer: string | null
   copyright: string | null
+}
+
+interface MediaEntry {
+  type: string
+  title: string
+  description: string | null
+  url: string
+  language: string | null
 }
 
 /**

--- a/scripts/viewer/package-lock.json
+++ b/scripts/viewer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "inventory-viewer",
       "version": "1.0.0",
       "dependencies": {
-        "@metanull/islamicart-data": "^1.0.18",
+        "@metanull/islamicart-data": "^1.0.22",
         "marked": "^18.0.5",
         "vue": "^3.5.39",
         "vue-router": "^4.6.4"
@@ -105,9 +105,9 @@
       "license": "MIT"
     },
     "node_modules/@metanull/islamicart-data": {
-      "version": "1.0.21",
-      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.21/01bfbcbae70abc5a67248d87d6718b5fec5ade2a",
-      "integrity": "sha512-dyYjwf1d3+TMP0wcAJX6QErJ8+15N55oEeJzI9jfvzykqaoFkowLi0I4KWAepj482fMbAwE9EI7ZNgbTOi3kHg==",
+      "version": "1.0.22",
+      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.22/8f09c3b5b136df18e6b7ce7ad8b6ad7d59bd8780",
+      "integrity": "sha512-piAPOsGoM+7H5wlCWHEgymulIjOiAiXUJUObI66UigBEjA4qwS/EGPxf/gcWfMrwireBaZ3RskkCcapcWtNdcw==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=16.0.0",

--- a/scripts/viewer/package.json
+++ b/scripts/viewer/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@metanull/islamicart-data": "^1.0.18",
+    "@metanull/islamicart-data": "^1.0.22",
     "marked": "^18.0.5",
     "vue": "^3.5.39",
     "vue-router": "^4.6.4"

--- a/scripts/viewer/src/views/ItemDetail.vue
+++ b/scripts/viewer/src/views/ItemDetail.vue
@@ -333,6 +333,27 @@ const timelineLink = computed(() => {
   return { path: '/timeline/results', query }
 })
 
+// ── Related video/audio (item_media) — prefer the active content language,
+// fall back to any language the item actually has media in ────────────
+
+const relatedMedia = computed(() => {
+  const all = item.value?.media ?? []
+  if (!all.length) return []
+  const inLang = all.filter(m => m.language === activeLang.value)
+  return inLang.length ? inLang : all
+})
+
+// ── THG (Thematic Gallery) cross-links — a separate legacy project's
+// galleries also featuring this item. THG is due for a rewrite, so these
+// are placeholder same-page anchors, not real external URLs, for now. ──
+
+const thgGalleryLinks = computed(() => {
+  return (item.value?.thg_galleries ?? []).map(g => ({
+    name: g.name,
+    href: `#ThematicGallery-${g.name}`,
+  }))
+})
+
 // ── Navigation ─────────────────────────────────────────────────────────
 
 function back() {
@@ -418,6 +439,15 @@ function back() {
         </div>
       </div>
 
+      <!-- Related Video -->
+      <div v-if="relatedMedia.length" class="related-media">
+        <h2 class="sub-section-title">Related Video</h2>
+        <div v-for="(m, i) in relatedMedia" :key="i" class="media-entry">
+          <a :href="m.url" target="_blank" rel="noopener" class="media-title">{{ m.title }}</a>
+          <p v-if="m.description" class="media-description">{{ m.description }}</p>
+        </div>
+      </div>
+
       <!-- Credits -->
       <div v-if="credits.length" class="credits">
         <h2 class="credits-heading">Credits</h2>
@@ -452,6 +482,16 @@ function back() {
           <p v-if="d.history" class="dynasty-history">{{ d.history }}</p>
           <p v-if="d.area" class="dynasty-area">Area: {{ d.area }}</p>
         </div>
+      </div>
+
+      <!-- Galleries (THG cross-links) -->
+      <div v-if="thgGalleryLinks.length" class="galleries">
+        <h2 class="sub-section-title">Galleries</h2>
+        <ul class="gallery-list">
+          <li v-for="g in thgGalleryLinks" :key="g.name">
+            <a :href="g.href">{{ g.name }}</a>
+          </li>
+        </ul>
       </div>
 
       <!-- Related items -->
@@ -643,6 +683,17 @@ function back() {
 .special-feature { margin-bottom: 16px; }
 .special-feature-name { font-size: 15px; font-weight: 500; color: var(--heading); margin-bottom: 4px; font-family: 'Roboto', sans-serif; }
 .special-feature-meta { font-size: 12px; color: var(--muted); margin: 0 0 4px; font-family: 'Roboto', sans-serif; }
+
+/* Related Video */
+.related-media { margin-top: 20px; border-top: 1px solid var(--border); padding-top: 16px; }
+.media-entry { margin-bottom: 10px; }
+.media-title { font-size: 13px; font-weight: 500; color: var(--nav-active); font-family: 'Roboto', sans-serif; }
+.media-description { font-size: 12px; color: var(--muted); margin: 2px 0 0; font-family: 'Roboto', sans-serif; }
+
+/* Galleries (THG cross-links) */
+.galleries { margin-top: 20px; border-top: 1px solid var(--border); padding-top: 16px; }
+.gallery-list { list-style: none; font-size: 13px; font-family: 'Roboto', sans-serif; }
+.gallery-list a { color: var(--nav-active); }
 
 /* Dynasty cards */
 .sub-section-title {


### PR DESCRIPTION
## Summary

Follow-up to the Epic 3 research pass (tmp/islamicart-epic3-research-2026-07-06.md, gitignored/local), implementing two findings that turned out to need only exporter+viewer work -- corrected after review, no importer changes:

- **Item media (video)**: already fully imported via ItemMediaImporter (phase-08) into a dedicated item_media table / ItemMedia model -- 5 rows for ISL today (confirmed live). item-exporter.ts now reads it into a `media[]` field per item; ItemDetail.vue renders a "Related Video" section.
- **THG (Thematic Gallery) cross-links**: 908 ISL items are already attached to 48 THG gallery collections via collection_item (from phase-10 importers) -- invisible until now purely because collection-exporter.ts correctly never exports THG's own out-of-scope collection tree. item-exporter.ts adds a lightweight `thg_galleries[]` field via a query scoped to the THG backward_compatibility prefix, without exporting THG's collections. ItemDetail.vue renders a "Galleries" section.
  - Per direction: gallery links use a placeholder `#ThematicGallery-{name}` anchor rather than the real legacy per-gallery-family URLs (confirmed not captured by any importer, and not worth capturing since THG is due for a rewrite).

## Test plan

- [x] scripts/exporter: npm run type-check and npm run lint:check clean.
- [x] scripts/viewer: npm run build clean.
- [x] Local (unpublished) test export against the live DB: 2130 of 2443 ISL+EPM items get a populated thg_galleries field, 17 get a populated media field -- spot-checked real values (gallery names like "Paintings"/"Water in Islam", a real YouTube video title+URL).
- [x] Verified in local preview: no console errors against the currently-installed (older-shape) package -- new fields are optional-chained throughout.

Generated with Claude Code