### PR TITLE
fix(importer,exporter,viewer): islamicart legacy-parity backlog - Epics 10,11,12,13

### DIFF
--- a/scripts/exporter/src/exporters/item-exporter.ts
+++ b/scripts/exporter/src/exporters/item-exporter.ts
@@ -23,6 +23,7 @@ interface ItemRow {
 interface ItemTranslationRow {
   item_id: string
   language_id: string
+  context_id: string
   name: string
   alternate_name: string | null
   description: string | null
@@ -139,11 +140,33 @@ export class ItemExporter extends BaseExporter {
     const contextIds = this.context.contextIds
     const contextPh = this.placeholders(contextIds.length)
 
+    // Each item's "own" context — resolved via its project's context_id.
+    // An item can have item_translations rows in more than one context (e.g. a
+    // monument cross-cataloged under both ISL and EPM projects gets one row
+    // per context, by design — contexts are additive, not overlapping
+    // duplicates). Used below to know which row is the item's primary
+    // translation vs. a secondary one (see short_description handling).
+    const itemProjectIds = [...new Set(items.map(i => i.project_id).filter((p): p is string => !!p))]
+    const itemOwnContext = new Map<string, string>()
+    if (itemProjectIds.length > 0) {
+      const projectRows = await this.db.query<{ id: string; context_id: string | null }>(
+        `SELECT id, context_id FROM projects WHERE id IN (${this.placeholders(itemProjectIds.length)})`,
+        itemProjectIds
+      )
+      const projectContextMap = new Map(
+        projectRows.filter(p => p.context_id).map(p => [p.id, p.context_id as string])
+      )
+      for (const item of items) {
+        const ctx = item.project_id ? projectContextMap.get(item.project_id) : undefined
+        if (ctx) itemOwnContext.set(item.id, ctx)
+      }
+    }
+
     // ── 1. Content translations (name, description, …) ──────────────────────
     // Filter by context_id so that explore-context translations (which may have
     // extra=null) do not overwrite the canonical project translations.
     const translations = await this.db.query<ItemTranslationRow>(
-      `SELECT it.item_id, it.language_id,
+      `SELECT it.item_id, it.language_id, it.context_id,
               it.name, it.alternate_name, it.description,
               it.type, it.holder, it.owner, it.initial_owner, it.dates,
               it.location, it.dimensions, it.place_of_production,
@@ -264,35 +287,58 @@ export class ItemExporter extends BaseExporter {
     // ── Build maps ───────────────────────────────────────────────────────────
 
     // item_id -> lang_code -> translation fields
-    const translationMap = new Map<string, Record<string, Record<string, unknown>>>()
+    // Group rows by item_id+language first: an item can have more than one
+    // context row for the same language (own project context + e.g. EPM).
+    // These are combined, not merged with overwrite — the own-context row
+    // supplies every field, and a second context's row (when present)
+    // contributes only its description, as `short_description` (by
+    // convention: the primary/own context holds the long description, a
+    // secondary context like EPM holds the short one). See Epic 11 in the
+    // islamicart parity backlog / memory `project_context_semantics`.
+    const translationsByItemLang = new Map<string, ItemTranslationRow[]>()
     for (const t of translations) {
-      if (!translationMap.has(t.item_id)) translationMap.set(t.item_id, {})
       const code = langCodeMap.get(t.language_id)
       if (!code) continue
+      const key = `${t.item_id} ${code}`
+      if (!translationsByItemLang.has(key)) translationsByItemLang.set(key, [])
+      translationsByItemLang.get(key)!.push(t)
+    }
+
+    const translationMap = new Map<string, Record<string, Record<string, unknown>>>()
+    for (const [key, rows] of translationsByItemLang) {
+      const sep = key.indexOf(' ')
+      const itemId = key.slice(0, sep)
+      const code = key.slice(sep + 1)
+
+      const ownContext = itemOwnContext.get(itemId)
+      const ownRow = (ownContext ? rows.find(r => r.context_id === ownContext) : undefined) ?? rows[0]!
+      const otherRow = rows.find(r => r !== ownRow)
 
       // Fields without a dedicated column live in item_translations.extra JSON.
       // Each key is only ever set by the importer for the item type it applies
       // to (history/patrons/architects: monuments; workshop/scriber/binding_desc/
       // catalogue_holding_link/linkcatalogs: objects), so no type gating is needed here.
-      const extra = t.extra ? (parseJson(t.extra) as Record<string, string> | null) : null
+      const extra = ownRow.extra ? (parseJson(ownRow.extra) as Record<string, string> | null) : null
 
-      translationMap.get(t.item_id)![code] = {
-        name: t.name,
-        alternate_name: t.alternate_name,
-        description: t.description,
-        type: t.type,
-        holder: t.holder,
-        owner: t.owner,
-        initial_owner: t.initial_owner,
-        dates: t.dates,
-        location: t.location,
-        dimensions: t.dimensions,
-        place_of_production: t.place_of_production,
-        method_for_datation: t.method_for_datation,
-        method_for_provenance: t.method_for_provenance,
-        provenance: t.provenance,
-        obtention: t.obtention,
-        bibliography: t.bibliography,
+      if (!translationMap.has(itemId)) translationMap.set(itemId, {})
+      translationMap.get(itemId)![code] = {
+        name: ownRow.name,
+        alternate_name: ownRow.alternate_name,
+        description: ownRow.description,
+        short_description: otherRow?.description ?? null,
+        type: ownRow.type,
+        holder: ownRow.holder,
+        owner: ownRow.owner,
+        initial_owner: ownRow.initial_owner,
+        dates: ownRow.dates,
+        location: ownRow.location,
+        dimensions: ownRow.dimensions,
+        place_of_production: ownRow.place_of_production,
+        method_for_datation: ownRow.method_for_datation,
+        method_for_provenance: ownRow.method_for_provenance,
+        provenance: ownRow.provenance,
+        obtention: ownRow.obtention,
+        bibliography: ownRow.bibliography,
         history: extra?.history ?? null,
         patrons: extra?.patrons ?? null,
         architects: extra?.architects ?? null,
@@ -301,10 +347,10 @@ export class ItemExporter extends BaseExporter {
         binding_desc: extra?.binding_desc ?? null,
         catalogue_holding_link: extra?.catalogue_holding_link ?? null,
         linkcatalogs: extra?.linkcatalogs ?? null,
-        author: t.author_name,
-        copy_editor: t.copy_editor_name,
-        translator: t.translator_name,
-        translation_copy_editor: t.translation_copy_editor_name,
+        author: ownRow.author_name,
+        copy_editor: ownRow.copy_editor_name,
+        translator: ownRow.translator_name,
+        translation_copy_editor: ownRow.translation_copy_editor_name,
       }
     }
 

--- a/scripts/importer/src/importers/phase-02/monument-picture-importer.ts
+++ b/scripts/importer/src/importers/phase-02/monument-picture-importer.ts
@@ -137,16 +137,27 @@ export class MonumentPictureImporter extends BaseImporter {
   }
 
   private getPictureBackwardCompatibility(group: PictureGroup): string {
+    // `type` ('' for the default photo, 'plan' for site plans, etc.) is only
+    // appended when non-empty, so the identity of default-type pictures is
+    // unchanged (existing resolvers like thg-theme-item-resolver.ts and
+    // already-imported rows keep matching). Without this, a typed picture
+    // (e.g. type='plan') sharing the same image_number as the default photo
+    // would collide with it and be silently skipped as a duplicate — see
+    // Epic 10 in the islamicart parity backlog.
+    const pkValues: (string | number)[] = [
+      group.project_id,
+      group.country,
+      group.institution_id,
+      group.number,
+      group.image_number,
+    ];
+    if (group.type && group.type.trim() !== '') {
+      pkValues.push(group.type);
+    }
     return formatBackwardCompatibility({
       schema: 'mwnf3',
       table: 'monuments_pictures',
-      pkValues: [
-        group.project_id,
-        group.country,
-        group.institution_id,
-        group.number,
-        group.image_number,
-      ],
+      pkValues,
     });
   }
 

--- a/scripts/importer/src/importers/phase-02/object-picture-importer.ts
+++ b/scripts/importer/src/importers/phase-02/object-picture-importer.ts
@@ -137,16 +137,25 @@ export class ObjectPictureImporter extends BaseImporter {
   }
 
   private getPictureBackwardCompatibility(group: PictureGroup): string {
+    // `type` is only appended when non-empty, so the identity of default-type
+    // pictures is unchanged (matches MonumentPictureImporter's fix — see
+    // Epic 10 in the islamicart parity backlog). Without this, a typed
+    // picture sharing the same image_number as the default photo would
+    // collide with it and be silently skipped as a duplicate.
+    const pkValues: (string | number)[] = [
+      group.project_id,
+      group.country,
+      group.museum_id,
+      group.number,
+      group.image_number,
+    ];
+    if (group.type && group.type.trim() !== '') {
+      pkValues.push(group.type);
+    }
     return formatBackwardCompatibility({
       schema: 'mwnf3',
       table: 'objects_pictures',
-      pkValues: [
-        group.project_id,
-        group.country,
-        group.museum_id,
-        group.number,
-        group.image_number,
-      ],
+      pkValues,
     });
   }
 

--- a/scripts/importer/tests/unit/monument-picture-importer.test.ts
+++ b/scripts/importer/tests/unit/monument-picture-importer.test.ts
@@ -265,6 +265,36 @@ describe('MonumentPictureImporter', () => {
     expect(sql).not.toContain('AND type');
   });
 
+  it('imports a typed picture (e.g. type=plan) separately from a default picture sharing the same image_number', async () => {
+    // Regression test for Epic 10 (islamicart parity backlog): a plan-type
+    // picture at image_number=1 must not collide with the default (type='')
+    // picture at image_number=1 and be silently skipped as a duplicate.
+    const rowPlan = {
+      ...rowWithCaption,
+      type: 'plan',
+      path: 'bar/hr/mon11/30/plans/1.jpg',
+      caption: 'Floor plan',
+    };
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM mwnf3.monuments_pictures')) return [rowWithCaption, rowPlan];
+      if (sql.includes('FROM mwnf3.monuments')) return [{ name: 'Hellenbach Manor' }];
+      return [];
+    });
+    const importer = new MonumentPictureImporter(context);
+    const result = await importer.import();
+
+    expect(result.imported).toBe(2);
+    expect(result.skipped).toBe(0);
+    expect(writeItemMock).toHaveBeenCalledTimes(2);
+
+    const backwardCompats = writeItemMock.mock.calls.map(
+      (args) => (args[0] as { backward_compatibility: string }).backward_compatibility
+    );
+    expect(new Set(backwardCompats).size).toBe(2);
+    expect(backwardCompats).toContain('mwnf3:monuments_pictures:BAR:hr:Mon11:30:1');
+    expect(backwardCompats).toContain('mwnf3:monuments_pictures:BAR:hr:Mon11:30:1:plan');
+  });
+
   it('returns success=false when the main query throws', async () => {
     queryMock.mockRejectedValue(new Error('DB connection lost'));
     const importer = new MonumentPictureImporter(context);

--- a/scripts/viewer/src/composables/useInventoryData.js
+++ b/scripts/viewer/src/composables/useInventoryData.js
@@ -191,6 +191,71 @@ function exhibitionThemeById(exhibitionId, themeId) {
   return exhibitionThemes(exhibitionId).find(t => t.id === themeId) ?? null
 }
 
+// ── Item cross-links: Artistic Introduction pages / Exhibitions that
+// feature a given item ───────────────────────────────────────────────────
+//
+// No separate export is needed for this: collections.json already lists
+// each collection's items[] (used to render Artistic Introduction pages and
+// Exhibition theme/page grids), so "which collections reference this item"
+// is just a client-side reverse lookup over the same data. See Epic 12 in
+// the islamicart parity backlog.
+
+function collectionsContainingItem(itemId) {
+  return collections.value.filter(c => c.items?.some(it => it.id === itemId))
+}
+
+function artIntroLinksForItem(itemId) {
+  const root = artIntroRoot.value
+  if (!root) return []
+  const links = []
+  const seen = new Set()
+  for (const page of collectionsContainingItem(itemId)) {
+    // Items are attached to a theme's page; the page's parent is the theme.
+    const theme = collections.value.find(c => c.id === page.parent_id)
+    if (!theme || theme.parent_id !== root.id || seen.has(theme.id)) continue
+    seen.add(theme.id)
+    links.push({
+      themeId: theme.id,
+      label: enCollectionTranslations.value[theme.id]?.title ?? theme.internal_name,
+    })
+  }
+  return links
+}
+
+function exhibitionLinksForItem(itemId) {
+  const marker = collections.value.find(c => c.backward_compatibility === EXHIBITIONS_MARKER_BC)
+  if (!marker) return []
+  const links = []
+  const seen = new Set()
+  for (const c of collectionsContainingItem(itemId)) {
+    // Either attached directly to the exhibition itself (an "introduction"
+    // item — see the Exhibitions section comment above), or to a page
+    // nested under a theme nested under the exhibition.
+    let exhibition = null
+    let themeId = null
+    if (c.parent_id === marker.id) {
+      exhibition = c
+    } else {
+      const theme = collections.value.find(t => t.id === c.parent_id)
+      const ex = theme && collections.value.find(e => e.id === theme.parent_id)
+      if (ex && ex.parent_id === marker.id) {
+        exhibition = ex
+        themeId = theme.id
+      }
+    }
+    if (!exhibition) continue
+    const key = `${exhibition.id}:${themeId ?? ''}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    links.push({
+      exhibitionId: exhibition.id,
+      themeId,
+      label: enCollectionTranslations.value[exhibition.id]?.title ?? exhibition.internal_name,
+    })
+  }
+  return links
+}
+
 // ── Markdown helpers ───────────────────────────────────────────────────────
 
 // Full block markdown → HTML (for prose sections)
@@ -254,6 +319,8 @@ export function useInventoryData() {
     exhibitionById,
     exhibitionThemes,
     exhibitionThemeById,
+    artIntroLinksForItem,
+    exhibitionLinksForItem,
     md,
     mdInline,
     mdStrip,

--- a/scripts/viewer/src/views/Dynasties.vue
+++ b/scripts/viewer/src/views/Dynasties.vue
@@ -1,8 +1,32 @@
 <script setup>
 import { computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { useInventoryData } from '../composables/useInventoryData.js'
 
-const { dynasties, items, dynastyLabel, enDynastyTranslations } = useInventoryData()
+const router = useRouter()
+const { dynasties, items, dynastyLabel, enDynastyTranslations, md } = useInventoryData()
+
+// Legacy intro copy from https://islamicart.museumwnf.org/dynasties/ — not
+// backed by any database table (confirmed: dynasty-importer.ts only imports
+// dynasty records/texts, no landing-page content), so it's hardcoded here
+// per product decision. English only for now — no source text was available
+// to hardcode for other languages. See Epic 13 in the islamicart parity backlog.
+const introHeading = 'What do we intend by ‘Islamic Dynasties’?'
+const introBody = `After the first four caliphs, the ‘Rightly Guided’, who had established the Rashidun, the first Islamic Caliphate, the Islamic world was reigned by families of great local influence who carried out an ambitious military, social and cultural programme, often with impact far beyond their geographic area of origin. Many visionary rulers shaped Islamic lands through almost thirteen centuries and left a legacy that continues inspiring in all fields: religion, arts, culture, social life and also policies.
+
+Similar to the terminology used for the succession of ruling families in other civilisations, also Islamic histography refers to those families as '**Dynasties**'. Some ruled in specific regions, others over the entire Islamic empire.
+
+In this section of the Discover Islamic Art website **we introduce the Islamic dynasties who had ruled, from the Umayyad Caliphate until the end of the Ottoman empire**. Initially focus was given on the Mediterranean region but we started to expand also to other parts of the Islamic world.
+
+You will be able to read the profile of the selected Dynasty and view related content in the MWNF database. This will include Objects, Monuments, and, if available, also an Artistic Introduction to the specific stylistic characteristics of the selected Dynasty and/or an Exhibition presenting the cultural and historical background.
+
+All texts have been compiled by local experts of the country concerned; names of authors can be found on the page itself or on the general Discover Islamic Art credits page.
+
+All texts are available in Arabic and English, and most also in French and Spanish.`
+
+function goToDynasty(id) {
+  if (id) router.push(`/dynasty/${encodeURIComponent(id)}`)
+}
 
 // Only list dynasties actually linked to items in the collection, sorted
 // chronologically (from_ad), mirroring the "Period / Dynasty" ordering
@@ -34,11 +58,20 @@ function dateRangeLabel(d) {
     <h1 class="section-heading">Islamic Dynasties</h1>
 
     <div class="content-box">
-      <p class="intro-text">
-        Browse the dynasties and ruling periods of the Islamic world. Select a
-        dynasty below to read its history and see the objects and monuments
-        linked to it.
-      </p>
+      <h2 class="intro-heading">{{ introHeading }}</h2>
+      <div class="intro-text" v-html="md(introBody)"></div>
+
+      <div class="dynasty-quicknav">
+        <label for="dynasty-quicknav-select" class="quicknav-label">Jump to a dynasty:</label>
+        <select
+          id="dynasty-quicknav-select"
+          class="quicknav-select"
+          @change="goToDynasty($event.target.value)"
+        >
+          <option value="">Select a dynasty…</option>
+          <option v-for="d in dynastyList" :key="d.id" :value="d.id">{{ d.name }}</option>
+        </select>
+      </div>
 
       <p class="result-count">
         {{ dynastyList.length }} dynast{{ dynastyList.length !== 1 ? 'ies' : 'y' }}
@@ -67,12 +100,48 @@ function dateRangeLabel(d) {
 </template>
 
 <style scoped>
+.intro-heading {
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--heading);
+  margin-bottom: 10px;
+  font-family: 'Roboto', sans-serif;
+}
+
 .intro-text {
   font-size: 13px;
   line-height: 1.65;
   color: var(--muted);
   margin-bottom: 16px;
   font-family: 'Roboto', sans-serif;
+}
+.intro-text :deep(p) { margin: 0 0 .75em; }
+.intro-text :deep(p:last-child) { margin-bottom: 0; }
+.intro-text :deep(strong) { font-weight: 600; color: var(--text); }
+
+.dynasty-quicknav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+.quicknav-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--heading);
+  font-family: 'Roboto', sans-serif;
+  white-space: nowrap;
+}
+.quicknav-select {
+  font-size: 13px;
+  font-family: 'Roboto', sans-serif;
+  color: var(--text);
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  flex: 1;
+  max-width: 320px;
 }
 
 .result-count {

--- a/scripts/viewer/src/views/ItemDetail.vue
+++ b/scripts/viewer/src/views/ItemDetail.vue
@@ -13,6 +13,7 @@ const {
   loadLangTranslations,
   itemById,
   itemLabel, countryLabel, partnerLabel,
+  artIntroLinksForItem, exhibitionLinksForItem,
   md, mdInline,
 } = useInventoryData()
 
@@ -282,6 +283,21 @@ const contentSections = computed(() => {
   return sections
 })
 
+// ── Short description — legacy's collapsible "view short description"
+// toggle (pc_view_sdesc), shown below the main Description when the item
+// also has a translation in a secondary context (e.g. EPM) whose
+// description is the shorter summary. See Epic 11 in the islamicart
+// parity backlog. ──
+
+const showShortDescription = ref(false)
+
+const shortDescription = computed(() => {
+  if (!item.value) return null
+  return t(item.value).short_description ?? null
+})
+
+watch(() => item.value?.id, () => { showShortDescription.value = false })
+
 // ── Monument "Special Features" — sub-details already imported as child
 // items (type='detail', parent_id = this monument), just never surfaced ──
 
@@ -341,6 +357,26 @@ const relatedMedia = computed(() => {
   if (!all.length) return []
   const inLang = all.filter(m => m.language === activeLang.value)
   return inLang.length ? inLang : all
+})
+
+// ── "Artistic Introduction" & "On display in" (Exhibitions) — which
+// Artistic-Introduction pages / Virtual Exhibitions feature this item,
+// derived client-side from collections.json (see Epic 12 in the islamicart
+// parity backlog; distinct from the THG cross-links below). ──
+
+const artIntroLinks = computed(() => {
+  if (!item.value) return []
+  return artIntroLinksForItem(item.value.id)
+})
+
+const onDisplayInLinks = computed(() => {
+  if (!item.value) return []
+  return exhibitionLinksForItem(item.value.id).map(l => ({
+    label: l.label,
+    to: l.themeId
+      ? { path: `/exhibitions/${encodeURIComponent(l.exhibitionId)}/theme/${encodeURIComponent(l.themeId)}` }
+      : { path: `/exhibitions/${encodeURIComponent(l.exhibitionId)}/introduction` },
+  }))
 })
 
 // ── THG (Thematic Gallery) cross-links — a separate legacy project's
@@ -413,14 +449,27 @@ function back() {
       </table>
 
       <!-- Content sections (markdown) -->
-      <section
-        v-for="section in contentSections"
-        :key="section.heading"
-        class="content-section"
-      >
-        <h2 class="content-section-heading">{{ section.heading }}</h2>
-        <div v-html="mdGloss(section.value)" class="prose" :dir="contentDir" />
-      </section>
+      <template v-for="section in contentSections" :key="section.heading">
+        <section class="content-section">
+          <h2 class="content-section-heading">{{ section.heading }}</h2>
+          <div v-html="mdGloss(section.value)" class="prose" :dir="contentDir" />
+        </section>
+
+        <!-- Short description toggle (legacy: pc_view_sdesc), directly below Description -->
+        <section
+          v-if="section.heading === 'Description' && shortDescription"
+          class="content-section short-description"
+        >
+          <button
+            type="button"
+            class="short-description-toggle"
+            @click="showShortDescription = !showShortDescription"
+          >
+            {{ showShortDescription ? 'Hide short description' : 'View short description' }}
+          </button>
+          <div v-if="showShortDescription" v-html="mdGloss(shortDescription)" class="prose" :dir="contentDir" />
+        </section>
+      </template>
 
       <!-- Special Features (monument sub-details) -->
       <div v-if="monumentDetails.length" class="special-features">
@@ -482,6 +531,26 @@ function back() {
           <p v-if="d.history" class="dynasty-history">{{ d.history }}</p>
           <p v-if="d.area" class="dynasty-area">Area: {{ d.area }}</p>
         </div>
+      </div>
+
+      <!-- Artistic Introduction -->
+      <div v-if="artIntroLinks.length" class="art-intro-links">
+        <h2 class="sub-section-title">Artistic Introduction</h2>
+        <ul class="gallery-list">
+          <li v-for="l in artIntroLinks" :key="l.themeId">
+            <router-link :to="`/artistic-introduction/${encodeURIComponent(l.themeId)}`" v-html="mdInline(l.label)" />
+          </li>
+        </ul>
+      </div>
+
+      <!-- On display in (Virtual Exhibitions) -->
+      <div v-if="onDisplayInLinks.length" class="on-display-in">
+        <h2 class="sub-section-title">On display in</h2>
+        <ul class="gallery-list">
+          <li v-for="l in onDisplayInLinks" :key="l.to.path">
+            <router-link :to="l.to" v-html="mdInline(l.label)" />
+          </li>
+        </ul>
       </div>
 
       <!-- Galleries (THG cross-links) -->
@@ -634,6 +703,24 @@ function back() {
   letter-spacing: 0.07em;
   color: var(--heading);
   margin-bottom: 10px;
+  font-family: 'Roboto', sans-serif;
+}
+.content-section.short-description {
+  border-top: none;
+  padding-top: 0;
+  margin-top: -8px;
+}
+.short-description-toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-bottom: 8px;
+  font-size: 13px;
+  font-style: italic;
+  font-weight: 500;
+  color: var(--link);
+  text-decoration: underline;
+  cursor: pointer;
   font-family: 'Roboto', sans-serif;
 }
 


### PR DESCRIPTION
## Summary
Implements the remaining islamicart legacy-parity gaps found in the second comparison pass against https://islamicart.museumwnf.org (see the branch's commits for full per-epic detail; local backlog notes in `tmp/islamicart-parity-audit-2026-07-06.md`, gitignored):

- **Epic 10** (importer bug): a monument/object picture with a legacy `type` (e.g. `plan`) sharing an `image_number` with the default photo collided identities and was silently dropped as a duplicate - e.g. the Amman Citadel monument's 7th image (a site plan) never made it into the export. Fixed by only including `type` in the identity when non-empty.
- **Epic 11** (exporter bug): items cross-catalogued under both ISL and EPM legacy projects get two `item_translations` rows per language by design (ISL = long description, EPM = short) - the exporter combined them with last-write-wins instead of explicitly combining, so the long description was sometimes dropped entirely. Now exports both as `description` + `short_description`; the viewer renders the short one as a collapsible "View short description" toggle, matching legacy.
- **Epic 12** (viewer gap): "Artistic Introduction" and "On display in" (Virtual Exhibition) item cross-links were entirely missing from the item detail page (only THG gallery links existed). No exporter change needed - `collections.json` already lists each collection's items, so this is a client-side reverse lookup.
- **Epic 13** (viewer gap): the Dynasties landing page showed a generic placeholder instead of legacy's full intro text (not backed by any DB table, hardcoded per product decision), and had no quick-nav select to jump straight to a dynasty (existing list kept as-is).

Epic 14 (Virtual Exhibition map image) is intentionally excluded from this PR per direction.

## Test plan
- [x] Importer: full test suite (385/385) passes, `tsc --noEmit` clean
- [x] Exporter: `tsc --noEmit` clean (package has no test runner configured)
- [x] Viewer: `vite build` clean; browser-verified against the live installed `@metanull/islamicart-data` package:
  - Dynasties page: intro text renders with markdown formatting, quick-nav select navigates to the correct dynasty detail page, existing list unchanged
  - Item detail (Amman Citadel monument): "On display in" links render with correct, distinct exhibition/theme routes; "Related Video" already works (confirms Epic 3's earlier fix is live)
  - No console errors
- [ ] `short_description` toggle and the Epic 10 "plan" image fix were verified by code review + type-checking only - the currently-installed data package predates these two fixes, and there was no safe way to inject realistic test data without modifying `node_modules` (declined) or running the importer against the **production** database (declined - `scripts/importer/.env`/`scripts/exporter/.env` are both configured against the live production DB, not a local/staging one). Recommend re-running the import/export pipeline in a safe environment to confirm end-to-end before merging.

Generated with Claude Code
