### PR TITLE
chore(viewer): bump islamicart-data to 1.0.25

### DIFF
--- a/scripts/viewer/package-lock.json
+++ b/scripts/viewer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "inventory-viewer",
       "version": "1.0.0",
       "dependencies": {
-        "@metanull/islamicart-data": "^1.0.22",
+        "@metanull/islamicart-data": "^1.0.25",
         "marked": "^18.0.5",
         "vue": "^3.5.39",
         "vue-router": "^4.6.4"
@@ -105,9 +105,9 @@
       "license": "MIT"
     },
     "node_modules/@metanull/islamicart-data": {
-      "version": "1.0.22",
-      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.22/8f09c3b5b136df18e6b7ce7ad8b6ad7d59bd8780",
-      "integrity": "sha512-piAPOsGoM+7H5wlCWHEgymulIjOiAiXUJUObI66UigBEjA4qwS/EGPxf/gcWfMrwireBaZ3RskkCcapcWtNdcw==",
+      "version": "1.0.25",
+      "resolved": "https://npm.pkg.github.com/download/@metanull/islamicart-data/1.0.25/c26135b603a004cf7adfc5ae90a8c0e95971e020",
+      "integrity": "sha512-0S167rLc5EETPuqg6A8Uho7Gt0ZQ4JvU9tvVWxxw0Bpw1azlRRgv1rjpTwjGmDCzSAJ+RTigO1UObHm4ON/+xw==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=16.0.0",

--- a/scripts/viewer/package.json
+++ b/scripts/viewer/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@metanull/islamicart-data": "^1.0.22",
+    "@metanull/islamicart-data": "^1.0.25",
     "marked": "^18.0.5",
     "vue": "^3.5.39",
     "vue-router": "^4.6.4"


### PR DESCRIPTION
## Summary
- Bumps the viewer's `@metanull/islamicart-data` dependency from `^1.0.24` to `^1.0.25`, the package version published from PR #1435 (islamicart legacy-parity Epics 10-13).
- Verified against the newly-installed 1.0.25 package with real production data: the Amman Citadel item (`44db66ac-94d1-513a-affd-eaec477e9022`) now shows its full/long description plus a working "View short description" toggle (Epic 11), and "On display in" exhibition links resolve to the correct theme pages (Epic 12, confirmed unaffected/still working).
- Epic 10's "plan" image fix is importer-side only; it will not show up in exported data until a full re-import is run against the legacy source (out of scope here - this PR only republishes already-available data with the exporter/viewer-side fixes applied).

## Test plan
- [x] `npm install` in `scripts/viewer`, confirms `@metanull/islamicart-data@1.0.25` installed
- [x] `npm run build` clean
- [x] Browser-verified item detail page (full description + short-description toggle, On display in links) and no console errors

Generated with Claude Code
