### PR TITLE
fix(ci): retry SSH auth check and clarify timeout vs auth errors in Deploy to OVH

### DIFF
--- a/.github/workflows/deploy-ovh.yml
+++ b/.github/workflows/deploy-ovh.yml
@@ -95,8 +95,31 @@ jobs:
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_USER: ${{ secrets.VPS_SSH_USER }}
         run: |
-          ssh -i ~/.ssh/deploy_key -o ConnectTimeout=10 -o BatchMode=yes "${VPS_USER}@${VPS_HOST}" whoami || \
-            { echo "::error::SSH auth failed — check VPS_SSH_KEY and VPS_SSH_USER secrets"; exit 1; }
+          max_attempts=3
+          attempt=1
+          while [[ $attempt -le $max_attempts ]]; do
+            ssh_output=$(ssh -i ~/.ssh/deploy_key -o ConnectTimeout=10 -o BatchMode=yes "${VPS_USER}@${VPS_HOST}" whoami 2>&1)
+            ssh_exit=$?
+            if [[ $ssh_exit -eq 0 ]]; then
+              echo "SSH authentication succeeded as: ${ssh_output}"
+              exit 0
+            fi
+
+            if echo "$ssh_output" | grep -qi "permission denied\|authentication failed"; then
+              echo "::error::SSH auth rejected — check VPS_SSH_KEY and VPS_SSH_USER secrets"
+              echo "$ssh_output"
+              exit 1
+            fi
+
+            echo "Attempt ${attempt}/${max_attempts} failed (transient network issue?): ${ssh_output}"
+            if [[ $attempt -lt $max_attempts ]]; then
+              sleep $((attempt * 5))
+            fi
+            attempt=$((attempt + 1))
+          done
+
+          echo "::error::SSH connection failed after ${max_attempts} attempts (network/timeout, not an auth rejection) — ${ssh_output}"
+          exit 1
 
       - name: Upload release to VPS
         env:


### PR DESCRIPTION
## Summary
- Investigated a Deploy to OVH failure ([run 28826911985](https://github.com/metanull/inventory-app/actions/runs/28826911985)) where "Verify SSH authentication" failed with "Connection timed out" — a plain TCP-level network blip, not a rejected key. The TCP probe (`nc -z`) succeeded instantly right before it.
- The step retried and immediately succeeded, and no code/secret changed in between, confirming it was transient network flakiness, not a regression.
- The old error message ("SSH auth failed — check VPS_SSH_KEY and VPS_SSH_USER secrets") fires on any non-zero `ssh` exit, so a transient timeout looked identical to a real credential/key problem.

## Changes
- `Verify SSH authentication` now retries up to 3 times with backoff (5s/10s) on transient failures.
- It fails fast (no retry) on an actual `Permission denied` rejection, since retrying won't fix a bad key/user.
- Error messages now distinguish "auth rejected" from "connection failed after N attempts (network/timeout, not an auth rejection)".

## Test plan
- [ ] Merge and confirm `Deploy to OVH` triggers via the `workflow_run` (Build) event and completes successfully
- [ ] No behavior change on the happy path (first attempt succeeds immediately, same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)